### PR TITLE
Check for possible undefined options parameter

### DIFF
--- a/src/print.js
+++ b/src/print.js
@@ -3,8 +3,8 @@ var visit = require('./visit');
 
 function print(ast, _options) {
   var options = {};
-  options.highlight = _options ? _options.highlight || highlight : highlight;
-  options.biblio = _options && _options.biblio ? buildBiblio(_options.biblio) : {};
+  options.highlight = _options && _options.highlight || highlight;
+  options.biblio = _options && _options.biblio && buildBiblio(_options.biblio) || {};
   assignBiblioIDs(ast, options);
   return (
     '<!DOCTYPE html><html>' +

--- a/src/print.js
+++ b/src/print.js
@@ -3,8 +3,8 @@ var visit = require('./visit');
 
 function print(ast, _options) {
   var options = {};
-  options.highlight = _options.highlight || highlight;
-  options.biblio = _options.biblio ? buildBiblio(_options.biblio) : {};
+  options.highlight = _options ? _options.highlight || highlight : highlight;
+  options.biblio = _options && _options.biblio ? buildBiblio(_options.biblio) : {};
   assignBiblioIDs(ast, options);
   return (
     '<!DOCTYPE html><html>' +


### PR DESCRIPTION
The using spec markdown docs, say we can call `html` like:

```
var fs = require('fs');
var specMarkdown = require('spec-md');
specMarkdown.html('./path/to/markdown.md').then(function (html) {
  fs.writeFile('./path/to/output.html', html);
});
```

not passing in `_options`.

But if you don't pass in `_options` you will get:

```
Unhandled rejection TypeError: Cannot read property 'highlight' of undefined
```

This checks for the existence of `_options`.