### PR TITLE
Adds sidebar showing TOC

### DIFF
--- a/css/spec.css
+++ b/css/spec.css
@@ -72,14 +72,14 @@ footer {
 /* Table of contents */
 
 .spec-toc {
-  margin: 1em 0 3em;
+  margin: 1rem 0 3rem;
 }
 
-.spec-toc::before {
+.spec-toc .title {
   content: 'Contents';
   display: block;
   font-weight: bold;
-  margin: 3em 0 1em;
+  margin: 3rem 0 1rem;
 }
 
 .spec-toc .spec-secid {
@@ -157,6 +157,71 @@ footer {
   overflow: hidden;
 }
 
+
+/* Sidebar */
+
+.spec-sidebar-toggle {
+  display: none;
+}
+
+.spec-sidebar-toggle + label {
+  position: fixed;
+  right: 0;
+  top: 0;
+  padding: 10px 15px;
+  font-size: 30px;
+  color: rgba(0,0,0,0.7);
+  z-index: 2;
+  cursor: pointer;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}
+
+.spec-sidebar {
+  display: none;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 320px;
+  font-size: 80%;
+  overflow-y: scroll;
+  height: 100%;
+  padding: 0 0 5rem 30px;
+  box-sizing: border-box;
+  background: #f0f0f0;
+}
+
+.spec-sidebar-toggle:checked ~ .spec-sidebar {
+  display: block;
+  box-shadow:
+    -1px 0 rgba(0,0,0,0.12),
+    -4px 0 8px -2px rgba(0,0,0,0.05);
+}
+
+.spec-sidebar .viewing > a:after {
+  color: #8b9;
+  content: '\2022';
+  margin-left: 1ex;
+}
+
+@media (min-width: 1240px) {
+  .spec-sidebar-toggle + label {
+    display: none;
+  }
+
+  .spec-sidebar {
+    display: block;
+    box-shadow:
+      inset 1px 0 rgba(0,0,0,0.05),
+      inset 4px 0 8px -2px rgba(0,0,0,0.08) !important;
+  }
+
+  body {
+    padding-right: 300px;
+  }
+}
 
 /* Notes and Todos */
 


### PR DESCRIPTION
This adds a sidebar showing the full TOC opened to the currently viewed section.

When there's not enough space to show a sidebar, it's collapsed under a toggle floating in the top corner.

Revisits @sevki's #2 

Fixes #3 