### PR TITLE
Add content to `<head>`

### DIFF
--- a/spec/Usage.md
+++ b/spec/Usage.md
@@ -37,7 +37,6 @@ The `spec-md` node module provides a few functions:
   * {visit(ast, visitor)} takes an {ast} and a {visitor}. It walks over the {ast}
     in a depth-first-traversal calling the {visitor} along the way.
 
-
 ## Print Options
 
 The {html(filePath, options)} and {print(filePath)} functions both take {options}
@@ -49,6 +48,8 @@ over the returned HTML, more options may be added in the future.
     argument being the language specified. This function should return well
     formed HTML, complete with escaped special characters.
 
+  * **head** - a string which is inserted in the `<head>` tag in the returned
+    HTML. Use this to introduce additional meta tags and scripts.
 
 ## Hot rebuilding with nodemon
 

--- a/spec/metadata.json
+++ b/spec/metadata.json
@@ -1,4 +1,5 @@
 {
+  "head": "<meta property=\"og:title\" content=\"Spec Markdown\" />",
   "biblio": {
     "http://people.mozilla.org/~jorendorff/es6-draft.html": {
       "Identifier": "#sec-names-and-keywords",

--- a/src/print.js
+++ b/src/print.js
@@ -8,6 +8,7 @@ function print(ast, _options) {
   var options = {};
   options.highlight = _options && _options.highlight || highlight;
   options.biblio = _options && _options.biblio && buildBiblio(_options.biblio) || {};
+  options.head = _options && _options.head || '';
   validateSecIDs(ast, options);
   assignExampleNumbers(ast, options);
   assignBiblioIDs(ast, options);
@@ -15,7 +16,7 @@ function print(ast, _options) {
     '<!DOCTYPE html>\n' +
     '<!-- Built with spec-md -->\n' +
     '<html>' +
-      '<head>' + printHead(ast) + '</head>' +
+      '<head>' + printHead(ast, options) + '</head>' +
       '<body>' + printBody(ast, options) + '</body>' +
     '</html>\n'
   );
@@ -82,13 +83,14 @@ function loadAllLanguages() {
   }
 }
 
-function printHead(ast) {
+function printHead(ast, options) {
   return (
     '<meta charset="utf-8">' +
     '<title>' + (ast.title ? ast.title.value : 'Spec') + '</title>' +
     '<style>' + readStatic('spec.css') + '</style>' +
     '<style>' + readStatic('prism.css') + '</style>' +
-    '<script>(function (){\n' + readStatic('highlightName.js') + '})()</script>'
+    '<script>(function (){\n' + readStatic('highlightName.js') + '})()</script>' +
+    options.head
   );
 }
 


### PR DESCRIPTION
This allows a new `head` option (via node API or within metadata.json) which provides the ability to insert any arbitrary string within the `<head>` tag of the output HTML.

This offers a way to add additional styles, scripts, and meta tags. As an example, you might use this feature to introduce KaTeX or MathJax.

Fixes #15