### PR TITLE
Prettier support

### DIFF
--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -86,8 +86,7 @@ Todo: Links do not yet support a title attribute.
 
 ### Emphasis
 
-Wrapping asterisks *(\*)* indicate emphasis. Like Github-flavored
-Markdown, Spec Markdown does not treat underscore *(_)* as emphasis.
+Wrapping asterisks *(\*)* or underscores _(\_)_ indicate emphasis. 
 
 ```
 Example of **bold** and *italic* and ***bold italic***.
@@ -96,6 +95,14 @@ Example of **bold** and *italic* and ***bold italic***.
 Produces the following:
 
 Example of **bold** and *italic* and ***bold italic***.
+
+```
+Example of **bold** and _italic_ and **_bold italic_**.
+```
+
+Produces the following:
+
+Example of **bold** and _italic_ and **_bold italic_**.
 
 
 

--- a/spec/Spec Additions.md
+++ b/spec/Spec Additions.md
@@ -24,15 +24,15 @@ referencing specific parts of your document easy. Try it here!
 
 ## Title and Introduction
 
-A Spec Markdown document should start with one Setext style header which will be
-used as the title of the document. Any content before the first atx (`#`) style
-header will become the introduction to the document.
+A Spec Markdown document should start with one bolded atx style header
+(`# **Title**`) which will be used as the title of the document. Any content
+before the next atx (`#`) style header will become the introduction to the
+document.
 
 A Spec Markdown document starts in this form:
 
 ```
-Spec Markdown
--------------
+# **Spec Markdown**
 
 Introductory paragraph.
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -223,7 +223,7 @@ textChar = escaped
 text = value:$textChar+ {
   return {
     type: 'Text',
-    value: value
+    value: value.replace(/\\([$_*])/g, '$1')
   };
 }
 
@@ -355,7 +355,7 @@ linkTextChar = escaped
 linkText = value:$linkTextChar+ {
   return {
     type: 'Text',
-    value: value
+    value: value.replace(/\\[$_*]/g, '$1')
   };
 }
 
@@ -449,9 +449,16 @@ tableCellText = value:$tableCellTextChar+ {
 
 // Names
 
-localName = $([_a-z][_a-zA-Z0-9]*)
-globalName = $([A-Z][_a-zA-Z]*)
-paramName = $([_a-zA-Z][_a-zA-Z0-9]*)
+localName = text:$(('\\_' / [_a-z]) ('\\_' / [_a-zA-Z0-9])*) {
+  return text.replace(/\\_/g, '_');
+}
+
+globalName = text:$([A-Z] ('\\_' / [_a-zA-Z])*) {
+  return text.replace(/\\_/g, '_');
+}
+paramName = text:$(('\\_' / [_a-zA-Z]) ('\\_' / [_a-zA-Z0-9])*) {
+  return text.replace(/\\_/g, '_');
+}
 
 
 // Algorithm
@@ -486,7 +493,7 @@ stringLiteral = '"' value:$([^"\n\r]/'\\"')* closer:'"'? {
   }
   return {
     type: 'StringLiteral',
-    value: '"' + value + '"'
+    value: '"' + value.replace(/\\([$_*])/g, '$1') + '"'
   };
 }
 
@@ -712,7 +719,7 @@ quotedTerminal = '`' value:$(([^`\n] / ('\\`'))+)? closer:'`' {
 terminal = value:$(([^ \n"/`] [^ \n"\`,\]\}]*)) {
   return {
     type: 'Terminal',
-    value: value.replace(/\\([$_])/g, '$1')
+    value: value.replace(/\\([$_*])/g, '$1')
   };
 }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -211,7 +211,7 @@ inlineEntity = inlineEdit / inlineCode / reference / bold / italic / link / imag
 content = inlineEntity / text
 
 textChar = escaped
-         / [^\n\r+\-{`*[!<]
+         / [^\n\r+\-{`*[!<_]
          / '++' !'}'
          / '+' !'+}'
          / '--' !'}'
@@ -248,12 +248,21 @@ bold = '**' contents:(inlineCode / link / italic / text)+ '**' {
   };
 }
 
-italic = '*' contents:(inlineCode / link / text)+ '*' {
+asteriskItalic = '*' contents:(inlineCode / link / text)+ '*' {
   return {
     type: 'Italic',
     contents: contents
   };
 }
+
+underscoreItalic = '_' contents:(inlineCode / link / text)+ '_' {
+  return {
+    type: 'Italic',
+    contents: contents
+  };
+}
+
+italic = underscoreItalic / asteriskItalic
 
 inlineEdit = ins / del
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -547,7 +547,7 @@ indentedRHS = INDENT defs:(listItemRHS+)? DEDENT &{ return defs !== null; } {
   return defs;
 }
 
-listItemRHS = LINE listBullet _ condition:condition? _ tokens:tokenListOneLine {
+listItemRHS = LINE listBullet _ condition:condition? _ tokens:tokenListMultiline {
   return {
     type: 'RHS',
     condition: condition,

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -27,12 +27,21 @@ document = title:title? contents:documentContent* EOF {
   };
 }
 
-title = BLOCK !'#' value:$NOT_NL+ NL ('---' '-'* / '===' '='*) &NL {
+oldTitle = BLOCK !'#' value:$NOT_NL+ NL ('---' '-'* / '===' '='*) &NL {
   return {
     type: 'DocumentTitle',
     value: value
   };
 }
+
+newTitle = BLOCK '# **' value:$([^*\r\n]+) '**' &NL {
+  return {
+    type: 'DocumentTitle',
+    value: value
+  };
+}
+
+title = newTitle / oldTitle
 
 SEC_CLOSE = _ '#'* &NL
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -703,7 +703,7 @@ quotedTerminal = '`' value:$(([^`\n] / ('\\`'))+)? closer:'`' {
 terminal = value:$(([^ \n"/`] [^ \n"\`,\]\}]*)) {
   return {
     type: 'Terminal',
-    value: value
+    value: value.replace(/\\([$_])/g, '$1')
   };
 }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -36,7 +36,9 @@ title = BLOCK !'#' value:$NOT_NL+ NL ('---' '-'* / '===' '='*) &NL {
 
 SEC_CLOSE = _ '#'* &NL
 
-sectionTitle = $titleChar+
+sectionTitle = t:$titleChar+ {
+  return t.replace(/\\_/g, '_');
+}
 titleChar = [^\n\r# ] / [# ] titleChar
 
 sectionID = start:$sectionIDStart rest:('.' $sectionIDPart)* '.' {

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -569,13 +569,13 @@ constraintAfterGap = _ constraint:constraint {
   return constraint;
 }
 
-token = token:unconstrainedToken quantifier:('+' / '?' / '*')? constraint:constraintAfterGap? {
+token = token:unconstrainedToken quantifier:('+' / '?' / '*' / '\\*')? constraint:constraintAfterGap? {
   if (quantifier) {
     token = {
       type: 'Quantified',
       token: token,
-      isList: quantifier === '+' || quantifier === '*',
-      isOptional: quantifier === '?' || quantifier === '*'
+      isList: quantifier === '+' || quantifier === '*' || quantifier === '\\*',
+      isOptional: quantifier === '?' || quantifier === '*' || quantifier === '\\*'
     };
   }
   if (constraint) {

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -458,14 +458,14 @@ tableCellText = value:$tableCellTextChar+ {
 
 // Names
 
-localName = text:$(('\\_' / [_a-z]) ('\\_' / [_a-zA-Z0-9])*) {
+localName = text:$($('\\_' / [_a-z]) $('\\_' / [_a-zA-Z0-9])*) {
   return text.replace(/\\_/g, '_');
 }
 
-globalName = text:$([A-Z] ('\\_' / [_a-zA-Z])*) {
+globalName = text:$([A-Z] $('\\_' / [_a-zA-Z])*) {
   return text.replace(/\\_/g, '_');
 }
-paramName = text:$(('\\_' / [_a-zA-Z]) ('\\_' / [_a-zA-Z0-9])*) {
+paramName = text:$($('\\_' / [_a-zA-Z]) $('\\_' / [_a-zA-Z0-9])*) {
   return text.replace(/\\_/g, '_');
 }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -276,7 +276,7 @@ htmlTag = tag:$('<' '/'? [a-z]+ [^>]* '>') {
   };
 }
 
-reference = '{' !('++'/'--') _ ref:(call / value / token)? _ close:'}'? {
+reference = '{' !('++'/'--') __ ref:(call / value / token)? __ close:'}'? {
   if (ref === null || close === null) {
     error('Malformed {reference}.');
   }
@@ -453,7 +453,7 @@ algorithm = BLOCK call:call _ ':' ':'? steps:list {
   };
 }
 
-call = name:(globalName / localName) '(' _ args:callArg* _ ')' {
+call = name:(globalName / localName) '(' __ args:callArg* __ ')' {
   return {
     type: 'Call',
     name: name,
@@ -461,7 +461,9 @@ call = name:(globalName / localName) '(' _ args:callArg* _ ')' {
   };
 }
 
-callArg = value:value [, ]* {
+callSep = __ ',' __ / __
+
+callArg = value:value callSep {
   return value;
 }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -592,7 +592,7 @@ tokenAfterSpace = _ token:token {
   return token;
 }
 
-tokenAfterSpaceOrNewline = __ token:token {
+tokenAfterSpaceOrNewline = __ !listBullet token:token {
   return token;
 }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -12,6 +12,10 @@
     return list;
   }
 
+  function markdownUnescape(text) {
+    return text.replace(/\\([$_*])/g, '$1');
+  }
+
   var htmlBlockName;
 
   var BLOCK_TAGS_RX = /^(?:p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)$/i;
@@ -46,7 +50,7 @@ title = newTitle / oldTitle
 SEC_CLOSE = _ '#'* &NL
 
 sectionTitle = t:$titleChar+ {
-  return t.replace(/\\_/g, '_');
+  return markdownUnescape(t);
 }
 titleChar = [^\n\r# ] / [# ] titleChar
 
@@ -232,7 +236,7 @@ textChar = escaped
 text = value:$textChar+ {
   return {
     type: 'Text',
-    value: value.replace(/\\([$_*])/g, '$1')
+    value: markdownUnescape(value)
   };
 }
 
@@ -364,7 +368,7 @@ linkTextChar = escaped
 linkText = value:$linkTextChar+ {
   return {
     type: 'Text',
-    value: value.replace(/\\[$_*]/g, '$1')
+    value: markdownUnescape(value)
   };
 }
 
@@ -459,14 +463,14 @@ tableCellText = value:$tableCellTextChar+ {
 // Names
 
 localName = text:$($('\\_' / [_a-z]) $('\\_' / [_a-zA-Z0-9])*) {
-  return text.replace(/\\_/g, '_');
+  return markdownUnescape(text);
 }
 
 globalName = text:$([A-Z] $('\\_' / [_a-zA-Z])*) {
-  return text.replace(/\\_/g, '_');
+  return markdownUnescape(text);
 }
 paramName = text:$($('\\_' / [_a-zA-Z]) $('\\_' / [_a-zA-Z0-9])*) {
-  return text.replace(/\\_/g, '_');
+  return markdownUnescape(text);
 }
 
 
@@ -502,7 +506,7 @@ stringLiteral = '"' value:$([^"\n\r]/'\\"')* closer:'"'? {
   }
   return {
     type: 'StringLiteral',
-    value: '"' + value.replace(/\\([$_*])/g, '$1') + '"'
+    value: '"' + markdownUnescape(value) + '"'
   };
 }
 
@@ -728,7 +732,7 @@ quotedTerminal = '`' value:$(([^`\n] / ('\\`'))+)? closer:'`' {
 terminal = value:$(([^ \n"/`] [^ \n"\`,\]\}]*)) {
   return {
     type: 'Terminal',
-    value: value.replace(/\\([$_*])/g, '$1')
+    value: markdownUnescape(value)
   };
 }
 

--- a/src/print.js
+++ b/src/print.js
@@ -42,6 +42,13 @@ function getPrismLanguage(lang) {
   if (!prism.languages[lang]) {
     loadAllLanguages();
   }
+  if (!prism.languages[lang] && lang.startsWith("raw")) {
+    // To prevent 'prettier' formatting code in your markdown, you may prefix
+    // the language with "raw" and we will still format it as you would expect
+    // in the output.
+    // e.g. ```graphql -> ```rawgraphql
+    return prism.languages[lang.substr(3)];
+  }
   return prism.languages[lang];
 }
 

--- a/src/print.js
+++ b/src/print.js
@@ -574,7 +574,7 @@ function printAll(list, options) {
                   return (
                     '<tr>\n' +
                       join(row.map(function (def) {
-                        return '<td class="spec-rhs">' + def + '</td>\n';
+                        return '<td class="spec-rhs">' + def + '</td>';
                       })) +
                     '</tr>\n'
                   );

--- a/src/print.js
+++ b/src/print.js
@@ -574,7 +574,7 @@ function printAll(list, options) {
                   return (
                     '<tr>\n' +
                       join(row.map(function (def) {
-                        return '<td class="spec-rhs">' + def + '</td>';
+                        return '<td class="spec-rhs">' + def + '</td>\n';
                       })) +
                     '</tr>\n'
                   );


### PR DESCRIPTION
This pull request adds support for spec-md parsing markdown that has been formatted by `prettier`. It has been tested against the GraphQL Spec only. It contains breaking changes.

Most notable changes:

- `# **Title**` is another accepted format for the main document title (rather than relying on a single Setext-style header.)
- `\*`, `\_` and `\$` are supported in many locations to support prettier's auto-escaping of ambigous markdown
- `_` is now supported for emphasis
- line feeds during productions are now allowed
- added support for `raw` prefix on languages

TODO:

- [x] Make it work with the GraphQL spec
- [ ] Everything else (tests, documentation, etc)  

### raw prefix on languages

Prettier likes to format embedded code blocks in our markdown. Generally, we like this too, except when we don't. Sometimes we deliberately want to format something "weird" to demonstrate that our language supports that; in those cases we don't want prettier to undo our "weird" formatting. To achieve this, we can use a raw codeblock:

````md
```rawgraphql
query         (      $V: ID)

{ ...ThisIsWeirdFormatting, }
```
````

We'll just trim the "raw" (unless it's legitimately the start of a language name that's supported by prismjs) and use the remaining text as the language to use for highlighting. This is much nicer (and more reliable) than putting `<!-- prettier-ignore -->` comments throughout the source markdown text.