### PR TITLE
Allow raw prefix on code block languages

### DIFF
--- a/spec/Spec Additions.md
+++ b/spec/Spec Additions.md
@@ -235,6 +235,19 @@ Produces the following:
 const baz = foo("bar");
 ```
 
+You may also prefix your highlight function with "raw" if you want to avoid
+other tools, such as Prettier, from interpreting a code block.
+
+    ```raw js
+    const baz = foo("bar");
+    ```
+
+Produces the following:
+
+```raw js
+const baz = foo("bar");
+```
+
 ### Examples
 
 Spec Markdown helps you write examples, visually indicaticating the difference

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -290,13 +290,14 @@ inlineCode = '`' code:$[^`\n\r]+ '`' {
   };
 }
 
-blockCode = BLOCK '```' deprecatedCounterExample:'!'? lang:codeLang? _ example:('example'/'counter-example')? NL code:$([^`] / '`' [^`] / '``' [^`])+ '```' {
+blockCode = BLOCK '```' raw:"raw "? deprecatedCounterExample:'!'? lang:codeLang? _ example:('example'/'counter-example')? NL code:$([^`] / '`' [^`] / '``' [^`])+ '```' {
   // dedent codeblock by current indent level?
   if (deprecatedCounterExample) {
     console.warn(line() + ':' + column() + ': Use of `!` is deprecated, use `counter-example` instead.');
   }
   return {
     type: 'Code',
+    raw: raw !== null,
     lang: lang,
     example: example !== null,
     counter: example === 'counter-example' || deprecatedCounterExample !== null,

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -103,6 +103,7 @@
         },
         {
           "type": "Code",
+          "raw": false,
           "lang": "sh",
           "example": false,
           "counter": false,
@@ -127,6 +128,7 @@
         },
         {
           "type": "Code",
+          "raw": false,
           "lang": "sh",
           "example": false,
           "counter": false,
@@ -134,6 +136,7 @@
         },
         {
           "type": "Code",
+          "raw": false,
           "lang": "js",
           "example": false,
           "counter": false,
@@ -321,6 +324,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -480,6 +484,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -592,6 +597,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -690,6 +696,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -739,6 +746,7 @@
               "contents": [
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -774,6 +782,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -859,6 +868,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -906,6 +916,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -943,6 +954,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": true,
                   "counter": false,
@@ -959,6 +971,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": true,
                   "counter": true,
@@ -1097,6 +1110,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": true,
                   "counter": false,
@@ -1215,6 +1229,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -1440,6 +1455,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -1477,6 +1493,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -1493,6 +1510,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": true,
                   "counter": true,
@@ -1664,6 +1682,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": null,
                       "example": false,
                       "counter": false,
@@ -1695,6 +1714,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": null,
                       "example": false,
                       "counter": false,
@@ -1954,6 +1974,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -2059,6 +2080,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -2108,6 +2130,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -2213,6 +2236,37 @@
             },
             {
               "type": "Code",
+              "raw": false,
+              "lang": "js",
+              "example": false,
+              "counter": false,
+              "code": "const baz = foo(\"bar\");\n"
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "You may also prefix your highlight function with \"raw\" if you want to avoid\nother tools, such as Prettier, from interpreting a code block."
+                }
+              ]
+            },
+            {
+              "type": "Code",
+              "code": "```raw js\nconst baz = foo(\"bar\");\n```"
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "Produces the following:"
+                }
+              ]
+            },
+            {
+              "type": "Code",
+              "raw": true,
               "lang": "js",
               "example": false,
               "counter": false,
@@ -2271,6 +2325,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": true,
                   "counter": false,
@@ -2308,6 +2363,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": "js",
                   "example": true,
                   "counter": false,
@@ -2381,6 +2437,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": "js",
                   "example": true,
                   "counter": true,
@@ -2406,6 +2463,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -2633,6 +2691,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -2674,6 +2733,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -2878,6 +2938,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -2947,6 +3008,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3073,6 +3135,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3171,6 +3234,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3272,6 +3336,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3357,6 +3422,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3585,6 +3651,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3646,6 +3713,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3699,6 +3767,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3817,6 +3886,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3878,6 +3948,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -3964,6 +4035,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": null,
                       "example": false,
                       "counter": false,
@@ -4112,6 +4184,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": null,
                       "example": false,
                       "counter": false,
@@ -4378,6 +4451,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": null,
                       "example": false,
                       "counter": false,
@@ -4545,6 +4619,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": "markdown",
                       "example": false,
                       "counter": false,
@@ -4648,6 +4723,7 @@
                     },
                     {
                       "type": "Code",
+                      "raw": false,
                       "lang": "markdown",
                       "example": true,
                       "counter": true,
@@ -4780,6 +4856,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -4910,6 +4987,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5159,6 +5237,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5395,6 +5474,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5648,6 +5728,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5708,6 +5789,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5774,6 +5856,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5871,6 +5954,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -5914,6 +5998,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -6175,6 +6260,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -6459,6 +6545,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -6736,6 +6823,7 @@
                 },
                 {
                   "type": "Code",
+                  "raw": false,
                   "lang": null,
                   "example": false,
                   "counter": false,
@@ -6801,6 +6889,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -6817,6 +6906,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -6833,6 +6923,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": null,
               "example": false,
               "counter": false,
@@ -7050,6 +7141,7 @@
         },
         {
           "type": "Code",
+          "raw": false,
           "lang": "sh",
           "example": false,
           "counter": false,
@@ -7096,6 +7188,7 @@
         },
         {
           "type": "Code",
+          "raw": false,
           "lang": "sh",
           "example": false,
           "counter": false,
@@ -7103,6 +7196,7 @@
         },
         {
           "type": "Code",
+          "raw": false,
           "lang": "js",
           "example": false,
           "counter": false,
@@ -7440,6 +7534,7 @@
             },
             {
               "type": "Code",
+              "raw": false,
               "lang": "sh",
               "example": false,
               "counter": false,

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1406,6 +1406,13 @@ const baz = foo(&quot;bar&quot;);
 <p>Produces the following:</p>
 <pre><code><span class="token keyword">const</span> baz <span class="token operator">=</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token string">"bar"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 </code></pre>
+<p>You may also prefix your highlight function with &ldquo;raw&rdquo; if you want to avoid other tools, such as Prettier, from interpreting a code block.</p>
+<pre><code>```raw js
+const baz = foo(&quot;bar&quot;);
+```</code></pre>
+<p>Produces the following:</p>
+<pre><code><span class="token keyword">const</span> baz <span class="token operator">=</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token string">"bar"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+</code></pre>
 <section id="sec-Examples" secid="3.7.1">
 <h4><span class="spec-secid" title="link to this section"><a href="#sec-Examples">3.7.1</a></span>Examples</h4>
 <p>Spec Markdown helps you write examples, visually indicaticating the difference from normative code blocks, and generating permalinks to those examples. Just write <code>example</code> after the <code>```</code>.</p>


### PR DESCRIPTION
Based on proposal in #31

> Prettier likes to format embedded code blocks in our markdown. Generally, we like this too, except when we don't. Sometimes we deliberately want to format something "weird" to demonstrate that our language supports that; in those cases we don't want prettier to undo our "weird" formatting. To achieve this, we can use a raw codeblock

However the implementation differs by requiring a space before the language name (which still thwarts tools like GH and prettier) and makes this part of the parsed AST rather than part of the highlight function name.