### PR TITLE
[Breaking] Support underscores for emphasis

### DIFF
--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -86,8 +86,7 @@ Todo: Links do not yet support a title attribute.
 
 ### Emphasis
 
-Wrapping asterisks *(\*)* indicate emphasis. Like Github-flavored
-Markdown, Spec Markdown does not treat underscore *(_)* as emphasis.
+Wrapping asterisks *(\*)* indicate emphasis.
 
 ```
 Example of **bold** and *italic* and ***bold italic***.
@@ -97,6 +96,15 @@ Produces the following:
 
 Example of **bold** and *italic* and ***bold italic***.
 
+Alternatively, use underscore *(\_)* for italic emphasis.
+
+```
+Example of _italic_ and **_bold italic_** or _**bold italic**_.
+```
+
+Produces the following:
+
+Example of _italic_ and **_bold italic_** or _**bold italic**_.
 
 
 ### Inline Code

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -209,7 +209,7 @@ inlineEntity = inlineEdit / inlineCode / reference / bold / italic / link / imag
 content = inlineEntity / text
 
 textChar = escaped
-         / [^\n\r+\-{`*[!<]
+         / [^\n\r+\-{`*_[!<]
          / '++' !'}'
          / '+' !'+}'
          / '--' !'}'
@@ -246,7 +246,16 @@ bold = '**' contents:(inlineCode / link / italic / text)+ '**' {
   };
 }
 
-italic = '*' contents:(inlineCode / link / text)+ '*' {
+italic = asteriskItalic / underscoreItalic
+
+asteriskItalic = '*' contents:(inlineCode / link / text)+ '*' {
+  return {
+    type: 'Italic',
+    contents: contents
+  };
+}
+
+underscoreItalic = '_' contents:(inlineCode / link / bold / text)+ '_' {
   return {
     type: 'Italic',
     contents: contents

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -578,20 +578,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " indicate emphasis. Like Github-flavored\nMarkdown, Spec Markdown does not treat underscore "
-                    },
-                    {
-                      "type": "Italic",
-                      "contents": [
-                        {
-                          "type": "Text",
-                          "value": "(_)"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "Text",
-                      "value": " as emphasis."
+                      "value": " indicate emphasis."
                     }
                   ]
                 },
@@ -650,6 +637,103 @@
                       "contents": [
                         {
                           "type": "Italic",
+                          "contents": [
+                            {
+                              "type": "Text",
+                              "value": "bold italic"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Text",
+                      "value": "."
+                    }
+                  ]
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Alternatively, use underscore "
+                    },
+                    {
+                      "type": "Italic",
+                      "contents": [
+                        {
+                          "type": "Text",
+                          "value": "(\\_)"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Text",
+                      "value": " for italic emphasis."
+                    }
+                  ]
+                },
+                {
+                  "type": "Code",
+                  "raw": false,
+                  "lang": null,
+                  "example": false,
+                  "counter": false,
+                  "code": "Example of _italic_ and **_bold italic_** or _**bold italic**_.\n"
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Produces the following:"
+                    }
+                  ]
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Example of "
+                    },
+                    {
+                      "type": "Italic",
+                      "contents": [
+                        {
+                          "type": "Text",
+                          "value": "italic"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Text",
+                      "value": " and "
+                    },
+                    {
+                      "type": "Bold",
+                      "contents": [
+                        {
+                          "type": "Italic",
+                          "contents": [
+                            {
+                              "type": "Text",
+                              "value": "bold italic"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Text",
+                      "value": " or "
+                    },
+                    {
+                      "type": "Italic",
+                      "contents": [
+                        {
+                          "type": "Bold",
                           "contents": [
                             {
                               "type": "Text",

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1080,11 +1080,16 @@ Links do not yet support a title attribute.</div>
 </section>
 <section id="sec-Emphasis" secid="2.2.3">
 <h4><span class="spec-secid" title="link to this section"><a href="#sec-Emphasis">2.2.3</a></span>Emphasis</h4>
-<p>Wrapping asterisks <em>(*)</em> indicate emphasis. Like Github&#8208;flavored Markdown, Spec Markdown does not treat underscore <em>(_)</em> as emphasis.</p>
+<p>Wrapping asterisks <em>(*)</em> indicate emphasis.</p>
 <pre><code>Example of **bold** and *italic* and ***bold italic***.
 </code></pre>
 <p>Produces the following:</p>
 <p>Example of <strong>bold</strong> and <em>italic</em> and <strong><em>bold italic</em></strong>.</p>
+<p>Alternatively, use underscore <em>(_)</em> for italic emphasis.</p>
+<pre><code>Example of _italic_ and **_bold italic_** or _**bold italic**_.
+</code></pre>
+<p>Produces the following:</p>
+<p>Example of <em>italic</em> and <strong><em>bold italic</em></strong> or <em><strong>bold italic</strong></em>.</p>
 </section>
 <section id="sec-Inline-Code" secid="2.2.4">
 <h4><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Code">2.2.4</a></span>Inline Code</h4>


### PR DESCRIPTION
Since GFM supports underscores for emphasis, we can do that here as well. Factored out of #31.

Note that this is breaking since previously if you have ambiguous underscores in open text that it may create a syntax error or italicize text. To correct this replace `_` with `\_`.