### PR TITLE
Support standard markdown titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Spec Markdown
-=============
+# Spec Markdown
 
 Renders Markdown with some additions into an HTML format commonly used for
 writing technical specification documents. Markdown additions include code

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": "./bin/spec-md",
   "main": "./src/index.js",
   "scripts": {
-    "build": "pegjs src/grammar.pegjs && mkdir -p out && echo 'spec-md.com' > out/CNAME && ./bin/spec-md -m spec/metadata.json README.md > out/index.html",
+    "build": "pegjs --allowed-start-rules initialDocument,importedDocument src/grammar.pegjs && mkdir -p out && echo 'spec-md.com' > out/CNAME && ./bin/spec-md -m spec/metadata.json README.md > out/index.html",
     "test": "node ./test/runner.js",
     "watch": "nodemon -e css,js,json,pegjs,md --ignore src/grammar.js --exec 'npm run build && npm test'"
   },

--- a/spec/Spec Additions.md
+++ b/spec/Spec Additions.md
@@ -24,21 +24,22 @@ referencing specific parts of your document easy. Try it here!
 
 ## Title and Introduction
 
-A Spec Markdown document should start with one Setext style header which will be
-used as the title of the document. Any content before the first atx (`#`) style
-header will become the introduction to the document.
+A Spec Markdown document must start with a header which will be used as the
+title of the document. Any content between this and the next header will become
+the introduction to the document.
 
 A Spec Markdown document starts in this form:
 
 ```
-Spec Markdown
--------------
+# Spec Markdown
 
 Introductory paragraph.
 
 # First Section Header
 ```
 
+Note: For backwards-compatibility, a setext style header can be used for a
+document title.
 
 ## Sections
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -19,7 +19,7 @@
 
 // Document
 
-document = title:title? contents:documentContent* EOF {
+initialDocument = title:title contents:documentContent* EOF {
   return {
     type: 'Document',
     title: title,
@@ -27,17 +27,37 @@ document = title:title? contents:documentContent* EOF {
   };
 }
 
-title = BLOCK !'#' value:$NOT_NL+ NL ('---' '-'* / '===' '='*) &NL {
+importedDocument = contents:documentContent* EOF {
+  return {
+    type: 'Document',
+    contents: contents
+  };
+}
+
+title = setextTitle / markdownTitle
+
+setextTitle = BLOCK !'#' value:$NOT_NL+ NL ('---' '-'* / '===' '='*) &NL {
   return {
     type: 'DocumentTitle',
     value: value
   };
 }
 
-SEC_CLOSE = _ '#'* &NL
+markdownTitle = BLOCK H1 value:headerText H_END {
+  return {
+    type: 'DocumentTitle',
+    value: value
+  };
+}
 
-sectionTitle = $titleChar+
-titleChar = [^\n\r# ] / [# ] titleChar
+H1 = '#' !'#' _
+H2 = '##' !'#' _
+H3 = '###' !'#' _
+H4 = '####' !'#' _
+H5 = '#####' !'#' _
+H_END = _ '#'* &NL
+headerText = $headerChar+
+headerChar = [^\n\r# ] / [# ] headerChar
 
 sectionID = start:$sectionIDStart rest:('.' $sectionIDPart)* '.' {
   return [start].concat(rest.map(function (nodes) {
@@ -47,7 +67,7 @@ sectionID = start:$sectionIDStart rest:('.' $sectionIDPart)* '.' {
 sectionIDStart = [0-9]+ / [A-Z]+ / '*'
 sectionIDPart = [0-9]+ / '*'
 
-section1 = BLOCK '#' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE contents:section1Content* {
+section1 = BLOCK H1 secID:sectionID? _ title:headerText H_END contents:section1Content* {
   return {
     type: 'Section',
     secID: secID,
@@ -56,7 +76,7 @@ section1 = BLOCK '#' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE cont
   };
 }
 
-section2 = BLOCK '##' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE contents:section2Content* {
+section2 = BLOCK H2 secID:sectionID? _ title:headerText H_END contents:section2Content* {
   return {
     type: 'Section',
     secID: secID,
@@ -65,7 +85,7 @@ section2 = BLOCK '##' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE con
   };
 }
 
-section3 = BLOCK '###' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE contents:section3Content* {
+section3 = BLOCK H3 secID:sectionID? _ title:headerText H_END contents:section3Content* {
   return {
     type: 'Section',
     secID: secID,
@@ -74,7 +94,7 @@ section3 = BLOCK '###' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE co
   };
 }
 
-section4 = BLOCK '####' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE contents:section4Content* {
+section4 = BLOCK H4 secID:sectionID? _ title:headerText H_END contents:section4Content* {
   return {
     type: 'Section',
     secID: secID,
@@ -83,7 +103,7 @@ section4 = BLOCK '####' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE c
   };
 }
 
-section5 = BLOCK '#####' !'#' _ secID:sectionID? _ title:sectionTitle SEC_CLOSE contents:section5Content* {
+section5 = BLOCK H5 secID:sectionID? _ title:headerText H_END contents:section5Content* {
   return {
     type: 'Section',
     secID: secID,
@@ -137,11 +157,11 @@ importLink = link:link &( BLOCK / EOF ) &{
 }
 
 importRel = BLOCK importLink:importLink &NL { return importLink; }
-import1 = BLOCK '#' _ importLink:importLink SEC_CLOSE { return importLink; }
-import2 = BLOCK '##' _ importLink:importLink SEC_CLOSE { return importLink; }
-import3 = BLOCK '###' _ importLink:importLink SEC_CLOSE { return importLink; }
-import4 = BLOCK '####' _ importLink:importLink SEC_CLOSE { return importLink; }
-import5 = BLOCK '#####' _ importLink:importLink SEC_CLOSE { return importLink; }
+import1 = BLOCK H1 importLink:importLink H_END { return importLink; }
+import2 = BLOCK H2 importLink:importLink H_END { return importLink; }
+import3 = BLOCK H3 importLink:importLink H_END { return importLink; }
+import4 = BLOCK H4 importLink:importLink H_END { return importLink; }
+import5 = BLOCK H5 importLink:importLink H_END { return importLink; }
 
 
 // Block Edit

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -1625,15 +1625,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A Spec Markdown document should start with one Setext style header which will be\nused as the title of the document. Any content before the first atx ("
-                },
-                {
-                  "type": "InlineCode",
-                  "code": "#"
-                },
-                {
-                  "type": "Text",
-                  "value": ") style\nheader will become the introduction to the document."
+                  "value": "A Spec Markdown document must start with a header which will be used as the\ntitle of the document. Any content between this and the next header will become\nthe introduction to the document."
                 }
               ]
             },
@@ -1652,7 +1644,16 @@
               "lang": null,
               "example": false,
               "counter": false,
-              "code": "Spec Markdown\n-------------\n\nIntroductory paragraph.\n\n# First Section Header\n"
+              "code": "# Spec Markdown\n\nIntroductory paragraph.\n\n# First Section Header\n"
+            },
+            {
+              "type": "Note",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "For backwards-compatibility, a setext style header can be used for a\ndocument title."
+                }
+              ]
             }
           ]
         },

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1330,15 +1330,17 @@ const code = sample();
 </section>
 <section id="sec-Title-and-Introduction" secid="3.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Title-and-Introduction">3.2</a></span>Title and Introduction</h3>
-<p>A Spec Markdown document should start with one Setext style header which will be used as the title of the document. Any content before the first atx (<code>#</code>) style header will become the introduction to the document.</p>
+<p>A Spec Markdown document must start with a header which will be used as the title of the document. Any content between this and the next header will become the introduction to the document.</p>
 <p>A Spec Markdown document starts in this form:</p>
-<pre><code>Spec Markdown
--------------
+<pre><code># Spec Markdown
 
 Introductory paragraph.
 
 # First Section Header
 </code></pre>
+<div id="note-f5587" class="spec-note">
+<a href="#note-f5587">Note</a>
+For backwards&#8208;compatibility, a setext style header can be used for a document title.</div>
 </section>
 <section id="sec-Sections" secid="3.3">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Sections">3.3</a></span>Sections</h3>


### PR DESCRIPTION
Supports use of standard markdown headers (`# Header`) as the title of a spec markdown document. Inspired by a similar change in #31 however this does not require wrapping the header in bold.

For some context, originally setext headers were required to differentiate between a document title and a section header in an imported file since spec-md did not differentiate between initial files and imported files. This change is possible by having pegjs support multiple starting positions for the parser and parse initial and imported documents differently.

This also allows us to remove the ast validation logic since that can now be encoded directly in the grammar.