### PR TITLE
[Breaking] Support up to H6 sections

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -55,6 +55,7 @@ H2 = '##' !'#' _
 H3 = '###' !'#' _
 H4 = '####' !'#' _
 H5 = '#####' !'#' _
+H6 = '######' !'#' _
 H_END = _ '#'* &NL
 headerText = $headerChar+
 headerChar = [^\n\r# ] / [# ] headerChar
@@ -112,6 +113,15 @@ section5 = BLOCK H5 secID:sectionID? _ title:headerText H_END contents:section5C
   };
 }
 
+section6 = BLOCK H6 secID:sectionID? _ title:headerText H_END contents:section6Content* {
+  return {
+    type: 'Section',
+    secID: secID,
+    title: title,
+    contents: contents
+  };
+}
+
 subsectionHeader = '**' title:$[^\n\r*]+ '**' &BLOCK {
   return title
 }
@@ -129,7 +139,8 @@ section1Content = import2 / section2 / subsection / importRel / sectionContent
 section2Content = import3 / section3 / subsection / importRel / sectionContent
 section3Content = import4 / section4 / subsection / importRel / sectionContent
 section4Content = import5 / section5 / subsection / importRel / sectionContent
-section5Content = subsection / importRel / sectionContent
+section5Content = import6 / section6 / subsection / importRel / sectionContent
+section6Content = subsection / importRel / sectionContent
 
 sectionContent = note
                / todo
@@ -162,6 +173,7 @@ import2 = BLOCK H2 importLink:importLink H_END { return importLink; }
 import3 = BLOCK H3 importLink:importLink H_END { return importLink; }
 import4 = BLOCK H4 importLink:importLink H_END { return importLink; }
 import5 = BLOCK H5 importLink:importLink H_END { return importLink; }
+import6 = BLOCK H6 importLink:importLink H_END { return importLink; }
 
 
 // Block Edit

--- a/src/print.js
+++ b/src/print.js
@@ -403,7 +403,7 @@ function printAll(list, options) {
     leave: function (node) {
       switch (node.type) {
         case 'Section': {
-          const level = node.secID.length + 1;
+          const level = Math.min(node.secID.length, 6);
           const secID = join(node.secID, '.');
           return (
             '<section id="' + node.id + '" secid="' + secID + '">\n' +

--- a/static/spec.css
+++ b/static/spec.css
@@ -91,27 +91,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 

--- a/test/duplicated-notes/output.html
+++ b/test/duplicated-notes/output.html
@@ -96,27 +96,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 

--- a/test/graphql-spec/output.html
+++ b/test/graphql-spec/output.html
@@ -96,27 +96,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 
@@ -1303,7 +1303,7 @@ This is an example of a non&#8208;normative note.</div>
 </nav>
 </header>
 <section id="sec-Overview" secid="1">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Overview">1</a></span>Overview</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Overview">1</a></span>Overview</h1>
 <p>GraphQL is a query language designed to build client applications by providing an intuitive and flexible syntax and system for describing their data requirements and interactions.</p>
 <p>For example, this GraphQL request will receive the name of the user with id 4 from the Facebook implementation of GraphQL.</p>
 <pre id="example-85684" class="spec-example"><a href="#example-85684">Example № 3</a><code><span class="token punctuation">{</span>
@@ -1332,7 +1332,7 @@ This is an example of a non&#8208;normative note.</div>
 <p>The following formal specification serves as a reference for those builders. It describes the language and its grammar, the type system and the introspection system used to query it, and the execution and validation engines with the algorithms to power them. The goal of this specification is to provide a foundation and framework for an ecosystem of GraphQL tools, client libraries, and service implementations&mdash;spanning both organizations and platforms&mdash;that has yet to be built. We look forward to working with the community in order to do that. </p>
 </section>
 <section id="sec-Language" secid="2">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language">2</a></span>Language</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Language">2</a></span>Language</h1>
 <p>Clients use the GraphQL query language to make requests to a GraphQL service. We refer to these request sources as documents. A document may contain operations (queries, mutations, and subscriptions) as well as fragments, a common unit of composition allowing for query reuse.</p>
 <p>A GraphQL document is defined as a syntactic grammar where terminal symbols are tokens (indivisible lexical units). These tokens are defined in a lexical grammar which matches patterns of source characters. In this document, syntactic grammar productions are distinguished with a colon <code>:</code> while lexical grammar productions are distinguished with a double&#8208;colon <code>::</code>.</p>
 <p>The source text of a GraphQL document must be a sequence of <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span>. The character sequence must be described by a sequence of <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span> and <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> lexical grammars. The lexical token sequence, omitting <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span>, must be described by a single <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span> syntactic grammar.</p>
@@ -1349,7 +1349,7 @@ See <a href="#sec-Appendix-Notation-Conventions">Appendix A</a> for more informa
 This typically has the same behavior as a &ldquo;<a href="https://en.wikipedia.org/wiki/Maximal_munch">maximal munch</a>&rdquo; longest possible match, however some lookahead restrictions include additional constraints.</div>
 </section>
 <section id="sec-Language.Source-Text" secid="2.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text">2.1</a></span>Source Text</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text">2.1</a></span>Source Text</h2>
 <div class="spec-production d2" id="SourceCharacter">
 <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><div class="spec-rhs"><span class="spec-prose">U+0009</span></div>
 <div class="spec-rhs"><span class="spec-prose">U+000A</span></div>
@@ -1358,7 +1358,7 @@ This typically has the same behavior as a &ldquo;<a href="https://en.wikipedia.o
 </div>
 <p>GraphQL documents are expressed as a sequence of <a href="https://unicode.org/standard/standard.html">Unicode</a> characters. However, with few exceptions, most of GraphQL is expressed only in the original non&#8208;control ASCII range so as to be as widely compatible with as many existing tools, languages, and serialization formats as possible and avoid display issues in text editors and source control.</p>
 <section id="sec-Unicode" secid="2.1.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Unicode">2.1.1</a></span>Unicode</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Unicode">2.1.1</a></span>Unicode</h3>
 <div class="spec-production d2" id="UnicodeBOM">
 <span class="spec-nt"><a href="#UnicodeBOM" data-name="UnicodeBOM">UnicodeBOM</a></span><div class="spec-rhs"><span class="spec-prose">Byte Order Mark (U+FEFF)</span></div>
 </div>
@@ -1366,7 +1366,7 @@ This typically has the same behavior as a &ldquo;<a href="https://en.wikipedia.o
 <p>The &ldquo;Byte Order Mark&rdquo; is a special Unicode character which may appear at the beginning of a file containing Unicode which programs may use to determine the fact that the text stream is Unicode, what endianness the text stream is in, and which of several Unicode encodings to interpret.</p>
 </section>
 <section id="sec-White-Space" secid="2.1.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-White-Space">2.1.2</a></span>White Space</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-White-Space">2.1.2</a></span>White Space</h3>
 <div class="spec-production d2" id="WhiteSpace">
 <span class="spec-nt"><a href="#WhiteSpace" data-name="WhiteSpace">WhiteSpace</a></span><div class="spec-rhs"><span class="spec-prose">Horizontal Tab (U+0009)</span></div>
 <div class="spec-rhs"><span class="spec-prose">Space (U+0020)</span></div>
@@ -1377,7 +1377,7 @@ This typically has the same behavior as a &ldquo;<a href="https://en.wikipedia.o
 GraphQL intentionally does not consider Unicode &ldquo;Zs&rdquo; category characters as white&#8208;space, avoiding misinterpretation by text editors and source control tools.</div>
 </section>
 <section id="sec-Line-Terminators" secid="2.1.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Line-Terminators">2.1.3</a></span>Line Terminators</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Line-Terminators">2.1.3</a></span>Line Terminators</h3>
 <div class="spec-production d2" id="LineTerminator">
 <span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span><div class="spec-rhs"><span class="spec-prose">New Line (U+000A)</span></div>
 <div class="spec-rhs"><span class="spec-prose">Carriage Return (U+000D)</span><span class="spec-lookahead not"><span class="spec-prose">New Line (U+000A)</span></span></div>
@@ -1389,7 +1389,7 @@ GraphQL intentionally does not consider Unicode &ldquo;Zs&rdquo; category charac
 Any error reporting which provides the line number in the source of the offending syntax should use the preceding amount of <span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span> to produce the line number.</div>
 </section>
 <section id="sec-Comments" secid="2.1.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Comments">2.1.4</a></span>Comments</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Comments">2.1.4</a></span>Comments</h3>
 <div class="spec-production d2" id="Comment">
 <span class="spec-nt"><a href="#Comment" data-name="Comment">Comment</a></span><div class="spec-rhs"><span class="spec-t">#</span><span class="spec-quantified"><span class="spec-nt"><a href="#CommentChar" data-name="CommentChar">CommentChar</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-lookahead ntset not"><span class="spec-nt"><a href="#CommentChar" data-name="CommentChar">CommentChar</a></span></span></div>
 </div>
@@ -1401,7 +1401,7 @@ Any error reporting which provides the line number in the source of the offendin
 <p>Comments are <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> like white space and may appear after any token, or before a <span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span>, and have no significance to the semantic meaning of a GraphQL Document.</p>
 </section>
 <section id="sec-Insignificant-Commas" secid="2.1.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Insignificant-Commas">2.1.5</a></span>Insignificant Commas</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Insignificant-Commas">2.1.5</a></span>Insignificant Commas</h3>
 <div class="spec-production d2" id="Comma">
 <span class="spec-nt"><a href="#Comma" data-name="Comma">Comma</a></span><div class="spec-rhs"><span class="spec-t">,</span></div>
 </div>
@@ -1409,7 +1409,7 @@ Any error reporting which provides the line number in the source of the offendin
 <p>Non&#8208;significant comma characters ensure that the absence or presence of a comma does not meaningfully alter the interpreted syntax of the document, as this can be a common user&#8208;error in other languages. It also allows for the stylistic use of either trailing commas or line&#8208;terminators as list delimiters which are both often desired for legibility and maintainability of source code.</p>
 </section>
 <section id="sec-Language.Source-Text.Lexical-Tokens" secid="2.1.6">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text.Lexical-Tokens">2.1.6</a></span>Lexical Tokens</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text.Lexical-Tokens">2.1.6</a></span>Lexical Tokens</h3>
 <div class="spec-production d2" id="Token">
 <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#Punctuator" data-name="Punctuator">Punctuator</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span></div>
@@ -1421,7 +1421,7 @@ Any error reporting which provides the line number in the source of the offendin
 <p>Tokens are later used as terminal symbols in GraphQL syntactic grammar rules.</p>
 </section>
 <section id="sec-Language.Source-Text.Ignored-Tokens" secid="2.1.7">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text.Ignored-Tokens">2.1.7</a></span>Ignored Tokens</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text.Ignored-Tokens">2.1.7</a></span>Ignored Tokens</h3>
 <div class="spec-production d2" id="Ignored">
 <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#UnicodeBOM" data-name="UnicodeBOM">UnicodeBOM</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#WhiteSpace" data-name="WhiteSpace">WhiteSpace</a></span></div>
@@ -1433,7 +1433,7 @@ Any error reporting which provides the line number in the source of the offendin
 <p>Any amount of <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> may appear before and after every lexical token. No ignored regions of a source document are significant, however <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span> which appear in <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> may also appear within a lexical <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span> in a significant way, for example a <span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span> may contain white space characters. No <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> may appear <em>within</em> a <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span>, for example no white space characters are permitted between the characters defining a <span class="spec-nt"><a href="#FloatValue" data-name="FloatValue">FloatValue</a></span>.</p>
 </section>
 <section id="sec-Punctuators" secid="2.1.8">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Punctuators">2.1.8</a></span>Punctuators</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Punctuators">2.1.8</a></span>Punctuators</h3>
 <div class="spec-production d2" id="Punctuator">
 <span class="spec-nt"><a href="#Punctuator" data-name="Punctuator">Punctuator</a></span><div class="spec-oneof"><table>
 <tr>
@@ -1443,7 +1443,7 @@ Any error reporting which provides the line number in the source of the offendin
 <p>GraphQL documents include punctuation in order to describe structure. GraphQL is a data description language and not a programming language, therefore GraphQL lacks the punctuation often used to describe mathematical expressions.</p>
 </section>
 <section id="sec-Names" secid="2.1.9">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Names">2.1.9</a></span>Names</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Names">2.1.9</a></span>Names</h3>
 <div class="spec-production d2" id="Name">
 <span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#NameContinue" data-name="NameContinue">NameContinue</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-lookahead ntset not"><span class="spec-nt"><a href="#NameContinue" data-name="NameContinue">NameContinue</a></span></span></div>
 </div>
@@ -1483,7 +1483,7 @@ Names in GraphQL are limited to the Latin <acronym>ASCII</acronym> subset of <sp
 </section>
 </section>
 <section id="sec-Document" secid="2.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Document">2.2</a></span>Document</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Document">2.2</a></span>Document</h2>
 <div class="spec-production" id="Document">
 <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Definition" data-name="Definition">Definition</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span></div>
 </div>
@@ -1502,7 +1502,7 @@ Names in GraphQL are limited to the Latin <acronym>ASCII</acronym> subset of <sp
 <p>GraphQL services which only seek to provide GraphQL query execution may choose to only include <span class="spec-nt"><a href="#ExecutableDefinition" data-name="ExecutableDefinition">ExecutableDefinition</a></span> and omit the <span class="spec-nt"><a href="#TypeSystemDefinition" data-name="TypeSystemDefinition">TypeSystemDefinition</a></span> and <span class="spec-nt"><a href="#TypeSystemExtension" data-name="TypeSystemExtension">TypeSystemExtension</a></span> rules from <span class="spec-nt"><a href="#Definition" data-name="Definition">Definition</a></span>.</p>
 </section>
 <section id="sec-Language.Operations" secid="2.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Operations">2.3</a></span>Operations</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Operations">2.3</a></span>Operations</h2>
 <div class="spec-production" id="OperationDefinition">
 <span class="spec-nt"><a href="#OperationDefinition" data-name="OperationDefinition">OperationDefinition</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#OperationType" data-name="OperationType">OperationType</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#VariableDefinitions" data-name="VariableDefinitions">VariableDefinitions</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#SelectionSet" data-name="SelectionSet">SelectionSet</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#SelectionSet" data-name="SelectionSet">SelectionSet</a></span></div>
@@ -1543,7 +1543,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 </section>
 </section>
 <section id="sec-Selection-Sets" secid="2.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Selection-Sets">2.4</a></span>Selection Sets</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Selection-Sets">2.4</a></span>Selection Sets</h2>
 <div class="spec-production" id="SelectionSet">
 <span class="spec-nt"><a href="#SelectionSet" data-name="SelectionSet">SelectionSet</a></span><div class="spec-rhs"><span class="spec-t">{</span><span class="spec-quantified"><span class="spec-nt"><a href="#Selection" data-name="Selection">Selection</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">}</span></div>
 </div>
@@ -1562,7 +1562,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 <p>In this query, the <code>id</code>, <code>firstName</code>, and <code>lastName</code> fields form a selection set. Selection sets may also contain fragment references.</p>
 </section>
 <section id="sec-Language.Fields" secid="2.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Fields">2.5</a></span>Fields</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Fields">2.5</a></span>Fields</h2>
 <div class="spec-production" id="Field">
 <span class="spec-nt"><a href="#Field" data-name="Field">Field</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Alias" data-name="Alias">Alias</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Arguments" data-name="Arguments">Arguments</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#SelectionSet" data-name="SelectionSet">SelectionSet</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -1602,7 +1602,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 </code></pre>
 </section>
 <section id="sec-Language.Arguments" secid="2.6">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Arguments">2.6</a></span>Arguments</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Arguments">2.6</a></span>Arguments</h2>
 <div class="spec-production" id="Arguments">
 <span class="spec-nt"><a href="#Arguments" data-name="Arguments">Arguments</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-t">(</span><span class="spec-quantified"><span class="spec-nt"><a href="#Argument" data-name="Argument">Argument</a><span class="spec-params"><span class="spec-param conditional">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">)</span></div>
 </div>
@@ -1643,7 +1643,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 </section>
 </section>
 <section id="sec-Field-Alias" secid="2.7">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Field-Alias">2.7</a></span>Field Alias</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Field-Alias">2.7</a></span>Field Alias</h2>
 <div class="spec-production" id="Alias">
 <span class="spec-nt"><a href="#Alias" data-name="Alias">Alias</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-t">:</span></div>
 </div>
@@ -1687,7 +1687,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 <p>A field&rsquo;s response key is its alias if an alias is provided, and it is otherwise the field&rsquo;s name.</p>
 </section>
 <section id="sec-Language.Fragments" secid="2.8">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Fragments">2.8</a></span>Fragments</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Fragments">2.8</a></span>Fragments</h2>
 <div class="spec-production" id="FragmentSpread">
 <span class="spec-nt"><a href="#FragmentSpread" data-name="FragmentSpread">FragmentSpread</a></span><div class="spec-rhs"><span class="spec-t">...</span><span class="spec-nt"><a href="#FragmentName" data-name="FragmentName">FragmentName</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -1758,7 +1758,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 </code></pre>
 <p>The queries <code>noFragments</code>, <code>withFragments</code>, and <code>withNestedFragments</code> all produce the same response object.</p>
 <section id="sec-Type-Conditions" secid="2.8.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Type-Conditions">2.8.1</a></span>Type Conditions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-Conditions">2.8.1</a></span>Type Conditions</h3>
 <div class="spec-production" id="TypeCondition">
 <span class="spec-nt"><a href="#TypeCondition" data-name="TypeCondition">TypeCondition</a></span><div class="spec-rhs"><span class="spec-t">on</span><span class="spec-nt"><a href="#NamedType" data-name="NamedType">NamedType</a></span></div>
 </div>
@@ -1803,7 +1803,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 </code></pre>
 </section>
 <section id="sec-Inline-Fragments" secid="2.8.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Fragments">2.8.2</a></span>Inline Fragments</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Fragments">2.8.2</a></span>Inline Fragments</h3>
 <div class="spec-production" id="InlineFragment">
 <span class="spec-nt"><a href="#InlineFragment" data-name="InlineFragment">InlineFragment</a></span><div class="spec-rhs"><span class="spec-t">...</span><span class="spec-quantified"><span class="spec-nt"><a href="#TypeCondition" data-name="TypeCondition">TypeCondition</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#SelectionSet" data-name="SelectionSet">SelectionSet</a></span></div>
 </div>
@@ -1840,7 +1840,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 </section>
 </section>
 <section id="sec-Input-Values" secid="2.9">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Values">2.9</a></span>Input Values</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Input-Values">2.9</a></span>Input Values</h2>
 <div class="spec-production" id="Value">
 <span class="spec-nt"><a href="#Value" data-name="Value">Value</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-condition not">Const</span><span class="spec-nt"><a href="#Variable" data-name="Variable">Variable</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#IntValue" data-name="IntValue">IntValue</a></span></div>
@@ -1855,7 +1855,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 <p>Field and directive arguments accept input values of various literal primitives; input values can be scalars, enumeration values, lists, or input objects.</p>
 <p>If not defined as constant (for example, in <span class="spec-nt"><a href="#DefaultValue" data-name="DefaultValue">DefaultValue</a></span>), input values can be specified as a variable. List and inputs objects may also contain variables (unless defined to be constant).</p>
 <section id="sec-Int-Value" secid="2.9.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Int-Value">2.9.1</a></span>Int Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Int-Value">2.9.1</a></span>Int Value</h3>
 <div class="spec-production d2" id="IntValue">
 <span class="spec-nt"><a href="#IntValue" data-name="IntValue">IntValue</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#IntegerPart" data-name="IntegerPart">IntegerPart</a></span><span class="spec-lookahead set not"><span class="spec-nt"><a href="#Digit" data-name="Digit">Digit</a></span><span class="spec-t">.</span><span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span></span></div>
 </div>
@@ -1874,7 +1874,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 <p>An <span class="spec-nt"><a href="#IntValue" data-name="IntValue">IntValue</a></span> must not be followed by a <span class="spec-t">.</span> or <span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span>. If either <span class="spec-t">.</span> or <span class="spec-nt"><a href="#ExponentIndicator" data-name="ExponentIndicator">ExponentIndicator</a></span> follows then the token must only be interpreted as a possible <span class="spec-nt"><a href="#FloatValue" data-name="FloatValue">FloatValue</a></span>. No other <span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span> character can follow. For example the sequences <code>0x123</code> and <code>123L</code> have no valid lexical representations.</p>
 </section>
 <section id="sec-Float-Value" secid="2.9.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Float-Value">2.9.2</a></span>Float Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Float-Value">2.9.2</a></span>Float Value</h3>
 <div class="spec-production d2" id="FloatValue">
 <span class="spec-nt"><a href="#FloatValue" data-name="FloatValue">FloatValue</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#IntegerPart" data-name="IntegerPart">IntegerPart</a></span><span class="spec-nt"><a href="#FractionalPart" data-name="FractionalPart">FractionalPart</a></span><span class="spec-nt"><a href="#ExponentPart" data-name="ExponentPart">ExponentPart</a></span><span class="spec-lookahead set not"><span class="spec-nt"><a href="#Digit" data-name="Digit">Digit</a></span><span class="spec-t">.</span><span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#IntegerPart" data-name="IntegerPart">IntegerPart</a></span><span class="spec-nt"><a href="#FractionalPart" data-name="FractionalPart">FractionalPart</a></span><span class="spec-lookahead set not"><span class="spec-nt"><a href="#Digit" data-name="Digit">Digit</a></span><span class="spec-t">.</span><span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span></span></div>
@@ -1907,7 +1907,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 The numeric literals <span class="spec-nt"><a href="#IntValue" data-name="IntValue">IntValue</a></span> and <span class="spec-nt"><a href="#FloatValue" data-name="FloatValue">FloatValue</a></span> both restrict being immediately followed by a letter (or other <span class="spec-nt"><a href="#NameStart" data-name="NameStart">NameStart</a></span>) to reduce confusion or unexpected behavior since GraphQL only supports decimal numbers.</div>
 </section>
 <section id="sec-Boolean-Value" secid="2.9.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Boolean-Value">2.9.3</a></span>Boolean Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Boolean-Value">2.9.3</a></span>Boolean Value</h3>
 <div class="spec-production" id="BooleanValue">
 <span class="spec-nt"><a href="#BooleanValue" data-name="BooleanValue">BooleanValue</a></span><div class="spec-oneof"><table>
 <tr>
@@ -1917,7 +1917,7 @@ The numeric literals <span class="spec-nt"><a href="#IntValue" data-name="IntVal
 <p>The two keywords <code>true</code> and <code>false</code> represent the two boolean values.</p>
 </section>
 <section id="sec-String-Value" secid="2.9.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-String-Value">2.9.4</a></span>String Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-String-Value">2.9.4</a></span>String Value</h3>
 <div class="spec-production d2" id="StringValue">
 <span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;&quot;</span><span class="spec-lookahead not"><span class="spec-t">&quot;</span></span></div>
 <div class="spec-rhs"><span class="spec-t">&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">&quot;</span></div>
@@ -2107,7 +2107,7 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
 </section>
 </section>
 <section id="sec-Null-Value" secid="2.9.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Null-Value">2.9.5</a></span>Null Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Null-Value">2.9.5</a></span>Null Value</h3>
 <div class="spec-production" id="NullValue">
 <span class="spec-nt"><a href="#NullValue" data-name="NullValue">NullValue</a></span><div class="spec-rhs"><span class="spec-t">null</span></div>
 </div>
@@ -2129,14 +2129,14 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
 The same two methods of representing the lack of a value are possible via variables by either providing the variable value as <span class="spec-keyword">null</span> or not providing a variable value at all.</div>
 </section>
 <section id="sec-Enum-Value" secid="2.9.6">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Enum-Value">2.9.6</a></span>Enum Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Enum-Value">2.9.6</a></span>Enum Value</h3>
 <div class="spec-production" id="EnumValue">
 <span class="spec-nt"><a href="#EnumValue" data-name="EnumValue">EnumValue</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-butnot"><span class="spec-t">true</span><span class="spec-t">false</span><span class="spec-t">null</span></span></span></div>
 </div>
 <p>Enum values are represented as unquoted names (ex. <code>MOBILE_WEB</code>). It is recommended that Enum values be &ldquo;all caps&rdquo;. Enum values are only used in contexts where the precise enumeration type is known. Therefore it&rsquo;s not necessary to supply an enumeration type name in the literal.</p>
 </section>
 <section id="sec-List-Value" secid="2.9.7">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-List-Value">2.9.7</a></span>List Value</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-List-Value">2.9.7</a></span>List Value</h3>
 <div class="spec-production" id="ListValue">
 <span class="spec-nt"><a href="#ListValue" data-name="ListValue">ListValue</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-t">[</span><span class="spec-t">]</span></div>
 <div class="spec-rhs"><span class="spec-t">[</span><span class="spec-quantified"><span class="spec-nt"><a href="#Value" data-name="Value">Value</a><span class="spec-params"><span class="spec-param conditional">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">]</span></div>
@@ -2166,7 +2166,7 @@ The same two methods of representing the lack of a value are possible via variab
 </section>
 </section>
 <section id="sec-Input-Object-Values" secid="2.9.8">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Values">2.9.8</a></span>Input Object Values</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Values">2.9.8</a></span>Input Object Values</h3>
 <div class="spec-production" id="ObjectValue">
 <span class="spec-nt"><a href="#ObjectValue" data-name="ObjectValue">ObjectValue</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-t">{</span><span class="spec-t">}</span></div>
 <div class="spec-rhs"><span class="spec-t">{</span><span class="spec-quantified"><span class="spec-nt"><a href="#ObjectField" data-name="ObjectField">ObjectField</a><span class="spec-params"><span class="spec-param conditional">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">}</span></div>
@@ -2213,7 +2213,7 @@ The same two methods of representing the lack of a value are possible via variab
 </section>
 </section>
 <section id="sec-Language.Variables" secid="2.10">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Variables">2.10</a></span>Variables</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Variables">2.10</a></span>Variables</h2>
 <div class="spec-production" id="Variable">
 <span class="spec-nt"><a href="#Variable" data-name="Variable">Variable</a></span><div class="spec-rhs"><span class="spec-t">$</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span></div>
 </div>
@@ -2249,7 +2249,7 @@ The same two methods of representing the lack of a value are possible via variab
 </section>
 </section>
 <section id="sec-Type-References" secid="2.11">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-References">2.11</a></span>Type References</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-References">2.11</a></span>Type References</h2>
 <div class="spec-production" id="Type">
 <span class="spec-nt"><a href="#Type" data-name="Type">Type</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#NamedType" data-name="NamedType">NamedType</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#ListType" data-name="ListType">ListType</a></span></div>
@@ -2296,7 +2296,7 @@ The same two methods of representing the lack of a value are possible via variab
 </section>
 </section>
 <section id="sec-Language.Directives" secid="2.12">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Directives">2.12</a></span>Directives</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Language.Directives">2.12</a></span>Directives</h2>
 <div class="spec-production" id="Directives">
 <span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Directive" data-name="Directive">Directive</a><span class="spec-params"><span class="spec-param conditional">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span></div>
 </div>
@@ -2324,7 +2324,7 @@ The same two methods of representing the lack of a value are possible via variab
 </section>
 </section>
 <section id="sec-Type-System" secid="3">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-System">3</a></span>Type System</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Type-System">3</a></span>Type System</h1>
 <p>The GraphQL Type system describes the capabilities of a GraphQL service and is used to determine if a query is valid. The type system also describes the input types of query variables to determine if values provided at runtime are valid.</p>
 <div class="spec-production" id="TypeSystemDefinition">
 <span class="spec-nt"><a href="#TypeSystemDefinition" data-name="TypeSystemDefinition">TypeSystemDefinition</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#SchemaDefinition" data-name="SchemaDefinition">SchemaDefinition</a></span></div>
@@ -2338,7 +2338,7 @@ The same two methods of representing the lack of a value are possible via variab
 <a href="#note-d5e8e">Note</a>
 The type system definition language is used throughout the remainder of this specification document when illustrating example type systems.</div>
 <section id="sec-Type-System-Extensions" secid="3.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-System-Extensions">3.1</a></span>Type System Extensions</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-System-Extensions">3.1</a></span>Type System Extensions</h2>
 <div class="spec-production" id="TypeSystemExtension">
 <span class="spec-nt"><a href="#TypeSystemExtension" data-name="TypeSystemExtension">TypeSystemExtension</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#SchemaExtension" data-name="SchemaExtension">SchemaExtension</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#TypeExtension" data-name="TypeExtension">TypeExtension</a></span></div>
@@ -2346,7 +2346,7 @@ The type system definition language is used throughout the remainder of this spe
 <p>Type system extensions are used to represent a GraphQL type system which has been extended from some original type system. For example, this might be used by a local service to represent data a GraphQL client only accesses locally, or by a GraphQL service which is itself an extension of another GraphQL service.</p>
 </section>
 <section id="sec-Descriptions" secid="3.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Descriptions">3.2</a></span>Descriptions</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Descriptions">3.2</a></span>Descriptions</h2>
 <div class="spec-production" id="Description">
 <span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span></div>
 </div>
@@ -2396,7 +2396,7 @@ The set of languages supported by `translate`.
 </code></pre>
 </section>
 <section id="sec-Schema" secid="3.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Schema">3.3</a></span>Schema</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Schema">3.3</a></span>Schema</h2>
 <div class="spec-production" id="SchemaDefinition">
 <span class="spec-nt"><a href="#SchemaDefinition" data-name="SchemaDefinition">SchemaDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">schema</span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">{</span><span class="spec-quantified"><span class="spec-nt"><a href="#RootOperationTypeDefinition" data-name="RootOperationTypeDefinition">RootOperationTypeDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">}</span></div>
 </div>
@@ -2409,7 +2409,7 @@ The set of languages supported by `translate`.
 <p>All directives within a GraphQL schema must have unique names.</p>
 <p>All types and directives defined within a schema must not have a name which begins with <span class="spec-string">"__"</span> (two underscores), as this is used exclusively by GraphQL&rsquo;s introspection system.</p>
 <section id="sec-Root-Operation-Types" secid="3.3.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Root-Operation-Types">3.3.1</a></span>Root Operation Types</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Root-Operation-Types">3.3.1</a></span>Root Operation Types</h3>
 <p>A schema defines the initial root operation type for each kind of operation it supports: query, mutation, and subscription; this determines the place in the type system where those operations begin.</p>
 <p>The <code>query</code> root operation type must be provided and must be an Object type.</p>
 <p>The <code>mutation</code> root operation type is optional; if it is not provided, the service does not support mutations. If it is provided, it must be an Object type.</p>
@@ -2458,7 +2458,7 @@ The set of languages supported by `translate`.
 </section>
 </section>
 <section id="sec-Schema-Extension" secid="3.3.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Schema-Extension">3.3.2</a></span>Schema Extension</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Schema-Extension">3.3.2</a></span>Schema Extension</h3>
 <div class="spec-production" id="SchemaExtension">
 <span class="spec-nt"><a href="#SchemaExtension" data-name="SchemaExtension">SchemaExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">schema</span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">{</span><span class="spec-quantified"><span class="spec-nt"><a href="#RootOperationTypeDefinition" data-name="RootOperationTypeDefinition">RootOperationTypeDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">}</span></div>
 <div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">schema</span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
@@ -2475,7 +2475,7 @@ The set of languages supported by `translate`.
 </section>
 </section>
 <section id="sec-Types" secid="3.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Types">3.4</a></span>Types</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Types">3.4</a></span>Types</h2>
 <div class="spec-production" id="TypeDefinition">
 <span class="spec-nt"><a href="#TypeDefinition" data-name="TypeDefinition">TypeDefinition</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#ScalarTypeDefinition" data-name="ScalarTypeDefinition">ScalarTypeDefinition</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#ObjectTypeDefinition" data-name="ObjectTypeDefinition">ObjectTypeDefinition</a></span></div>
@@ -2492,14 +2492,14 @@ The set of languages supported by `translate`.
 <p>A <code>Union</code> defines a list of possible types; similar to interfaces, whenever the type system claims a union will be returned, one of the possible types will be returned.</p>
 <p>Finally, oftentimes it is useful to provide complex structs as inputs to GraphQL field arguments or variables; the <code>Input Object</code> type allows the schema to define exactly what data is expected.</p>
 <section id="sec-Wrapping-Types" secid="3.4.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Wrapping-Types">3.4.1</a></span>Wrapping Types</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Wrapping-Types">3.4.1</a></span>Wrapping Types</h3>
 <p>All of the types so far are assumed to be both nullable and singular: e.g. a scalar string returns either null or a singular string.</p>
 <p>A GraphQL schema may describe that a field represents a list of another type; the <code>List</code> type is provided for this reason, and wraps another type.</p>
 <p>Similarly, the <code>Non-Null</code> type wraps another type, and denotes that the resulting value will never be <span class="spec-keyword">null</span> (and that an error cannot result in a <span class="spec-keyword">null</span> value).</p>
 <p>These two types are referred to as &ldquo;wrapping types&rdquo;; non&#8208;wrapping types are referred to as &ldquo;named types&rdquo;. A wrapping type has an underlying named type, found by continually unwrapping the type until a named type is found.</p>
 </section>
 <section id="sec-Input-and-Output-Types" secid="3.4.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-and-Output-Types">3.4.2</a></span>Input and Output Types</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-and-Output-Types">3.4.2</a></span>Input and Output Types</h3>
 <p>Types are used throughout GraphQL to describe both the values accepted as input to arguments and variables as well as the values output by fields. These two uses categorize types as <em>input types</em> and <em>output types</em>. Some kinds of types, like Scalar and Enum types, can be used as both input types and output types; other kinds of types can only be used in one or the other. Input Object types can only be used as input types. Object, Interface, and Union types can only be used as output types. Lists and Non&#8208;Null types may be used as input types or output types depending on how the wrapped type may be used.</p>
 <div class="spec-algo" id="IsInputType()">
 <span class="spec-call"><a href="#IsInputType()" data-name="IsInputType">IsInputType</a>(<var data-name="type">type</var>)</span><ol>
@@ -2531,7 +2531,7 @@ The set of languages supported by `translate`.
 </div>
 </section>
 <section id="sec-Type-Extensions" secid="3.4.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Type-Extensions">3.4.3</a></span>Type Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-Extensions">3.4.3</a></span>Type Extensions</h3>
 <div class="spec-production" id="TypeExtension">
 <span class="spec-nt"><a href="#TypeExtension" data-name="TypeExtension">TypeExtension</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#ScalarTypeExtension" data-name="ScalarTypeExtension">ScalarTypeExtension</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#ObjectTypeExtension" data-name="ObjectTypeExtension">ObjectTypeExtension</a></span></div>
@@ -2544,7 +2544,7 @@ The set of languages supported by `translate`.
 </section>
 </section>
 <section id="sec-Scalars" secid="3.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Scalars">3.5</a></span>Scalars</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Scalars">3.5</a></span>Scalars</h2>
 <div class="spec-production" id="ScalarTypeDefinition">
 <span class="spec-nt"><a href="#ScalarTypeDefinition" data-name="ScalarTypeDefinition">ScalarTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">scalar</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -2574,7 +2574,7 @@ The set of languages supported by `translate`.
 <p>For all types below, with the exception of Non&#8208;Null, if the explicit value <span class="spec-keyword">null</span> is provided, then the result of input coercion is <span class="spec-keyword">null</span>.</p>
 </section>
 <section id="sec-Int" secid="3.5.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Int">3.5.1</a></span>Int</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Int">3.5.1</a></span>Int</h3>
 <p>The Int scalar type represents a signed 32&#8208;bit numeric non&#8208;fractional value. Response formats that support a 32&#8208;bit integer or a number type should use that type to represent this scalar.</p>
 <section id="sec-Int.Result-Coercion" class="subsec">
 <h6><a href="#sec-Int.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
@@ -2591,7 +2591,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-Float" secid="3.5.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Float">3.5.2</a></span>Float</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Float">3.5.2</a></span>Float</h3>
 <p>The Float scalar type represents signed double&#8208;precision fractional values as specified by <a href="https://en.wikipedia.org/wiki/IEEE_floating_point">IEEE 754</a>. Response formats that support an appropriate double&#8208;precision number type should use that type to represent this scalar.</p>
 <section id="sec-Float.Result-Coercion" class="subsec">
 <h6><a href="#sec-Float.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
@@ -2604,7 +2604,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-String" secid="3.5.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-String">3.5.3</a></span>String</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-String">3.5.3</a></span>String</h3>
 <p>The String scalar type represents textual data, represented as UTF&#8208;8 character sequences. The String type is most often used by GraphQL to represent free&#8208;form human&#8208;readable text. All response formats must support string representations, and that representation must be used here.</p>
 <section id="sec-String.Result-Coercion" class="subsec">
 <h6><a href="#sec-String.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
@@ -2617,7 +2617,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-Boolean" secid="3.5.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Boolean">3.5.4</a></span>Boolean</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Boolean">3.5.4</a></span>Boolean</h3>
 <p>The Boolean scalar type represents <code>true</code> or <code>false</code>. Response formats should use a built&#8208;in boolean type if supported; otherwise, they should use their representation of the integers <code>1</code> and <code>0</code>.</p>
 <section id="sec-Boolean.Result-Coercion" class="subsec">
 <h6><a href="#sec-Boolean.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
@@ -2630,7 +2630,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-ID" secid="3.5.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-ID">3.5.5</a></span>ID</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-ID">3.5.5</a></span>ID</h3>
 <p>The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a <span class="spec-nt"><span data-name="String">String</span></span>; however, it is not intended to be human&#8208;readable. While it is often numeric, it should always serialize as a <span class="spec-nt"><span data-name="String">String</span></span>.</p>
 <section id="sec-ID.Result-Coercion" class="subsec">
 <h6><a href="#sec-ID.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
@@ -2643,7 +2643,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-Scalar-Extensions" secid="3.5.6">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Scalar-Extensions">3.5.6</a></span>Scalar Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Scalar-Extensions">3.5.6</a></span>Scalar Extensions</h3>
 <div class="spec-production" id="ScalarTypeExtension">
 <span class="spec-nt"><a href="#ScalarTypeExtension" data-name="ScalarTypeExtension">ScalarTypeExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">scalar</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
 </div>
@@ -2659,7 +2659,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-Objects" secid="3.6">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Objects">3.6</a></span>Objects</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Objects">3.6</a></span>Objects</h2>
 <div class="spec-production" id="ObjectTypeDefinition">
 <span class="spec-nt"><a href="#ObjectTypeDefinition" data-name="ObjectTypeDefinition">ObjectTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">type</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ImplementsInterfaces" data-name="ImplementsInterfaces">ImplementsInterfaces</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#FieldsDefinition" data-name="FieldsDefinition">FieldsDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -2881,7 +2881,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </div>
 </section>
 <section id="sec-Field-Arguments" secid="3.6.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Field-Arguments">3.6.1</a></span>Field Arguments</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Field-Arguments">3.6.1</a></span>Field Arguments</h3>
 <div class="spec-production" id="ArgumentsDefinition">
 <span class="spec-nt"><a href="#ArgumentsDefinition" data-name="ArgumentsDefinition">ArgumentsDefinition</a></span><div class="spec-rhs"><span class="spec-t">(</span><span class="spec-quantified"><span class="spec-nt"><a href="#InputValueDefinition" data-name="InputValueDefinition">InputValueDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">)</span></div>
 </div>
@@ -2912,7 +2912,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 <p>The type of an object field argument must be an input type (any type except an Object, Interface, or Union type).</p>
 </section>
 <section id="sec-Field-Deprecation" secid="3.6.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Field-Deprecation">3.6.2</a></span>Field Deprecation</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Field-Deprecation">3.6.2</a></span>Field Deprecation</h3>
 <p>Fields in an object may be marked as deprecated as deemed necessary by the application. It is still legal to query for these fields (to ensure existing clients are not broken by the change), but the fields should be appropriately treated in documentation and tooling.</p>
 <p>When using the type system definition language, <code>@deprecated</code> directives are used to indicate that a field is deprecated:</p>
 <pre id="example-013ef" class="spec-example"><a href="#example-013ef">Example № 61</a><code><span class="token keyword">type</span> <span class="token class-name">ExampleType</span> <span class="token punctuation">{</span>
@@ -2921,7 +2921,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </code></pre>
 </section>
 <section id="sec-Object-Extensions" secid="3.6.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Object-Extensions">3.6.3</a></span>Object Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Object-Extensions">3.6.3</a></span>Object Extensions</h3>
 <div class="spec-production" id="ObjectTypeExtension">
 <span class="spec-nt"><a href="#ObjectTypeExtension" data-name="ObjectTypeExtension">ObjectTypeExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">type</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ImplementsInterfaces" data-name="ImplementsInterfaces">ImplementsInterfaces</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#FieldsDefinition" data-name="FieldsDefinition">FieldsDefinition</a></span></div>
 <div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">type</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ImplementsInterfaces" data-name="ImplementsInterfaces">ImplementsInterfaces</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
@@ -2952,7 +2952,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 </section>
 <section id="sec-Interfaces" secid="3.7">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Interfaces">3.7</a></span>Interfaces</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Interfaces">3.7</a></span>Interfaces</h2>
 <div class="spec-production" id="InterfaceTypeDefinition">
 <span class="spec-nt"><a href="#InterfaceTypeDefinition" data-name="InterfaceTypeDefinition">InterfaceTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">interface</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ImplementsInterfaces" data-name="ImplementsInterfaces">ImplementsInterfaces</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#FieldsDefinition" data-name="FieldsDefinition">FieldsDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -3088,7 +3088,7 @@ interface Named implements Node &amp; Named {
 </ol>
 </section>
 <section id="sec-Interface-Extensions" secid="3.7.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Interface-Extensions">3.7.1</a></span>Interface Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Interface-Extensions">3.7.1</a></span>Interface Extensions</h3>
 <div class="spec-production" id="InterfaceTypeExtension">
 <span class="spec-nt"><a href="#InterfaceTypeExtension" data-name="InterfaceTypeExtension">InterfaceTypeExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">interface</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ImplementsInterfaces" data-name="ImplementsInterfaces">ImplementsInterfaces</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#FieldsDefinition" data-name="FieldsDefinition">FieldsDefinition</a></span></div>
 <div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">interface</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ImplementsInterfaces" data-name="ImplementsInterfaces">ImplementsInterfaces</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
@@ -3127,7 +3127,7 @@ interface Named implements Node &amp; Named {
 </section>
 </section>
 <section id="sec-Unions" secid="3.8">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Unions">3.8</a></span>Unions</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Unions">3.8</a></span>Unions</h2>
 <div class="spec-production" id="UnionTypeDefinition">
 <span class="spec-nt"><a href="#UnionTypeDefinition" data-name="UnionTypeDefinition">UnionTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">union</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#UnionMemberTypes" data-name="UnionMemberTypes">UnionMemberTypes</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -3196,7 +3196,7 @@ interface Named implements Node &amp; Named {
 </ol>
 </section>
 <section id="sec-Union-Extensions" secid="3.8.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Union-Extensions">3.8.1</a></span>Union Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Union-Extensions">3.8.1</a></span>Union Extensions</h3>
 <div class="spec-production" id="UnionTypeExtension">
 <span class="spec-nt"><a href="#UnionTypeExtension" data-name="UnionTypeExtension">UnionTypeExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">union</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#UnionMemberTypes" data-name="UnionMemberTypes">UnionMemberTypes</a></span></div>
 <div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">union</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
@@ -3216,7 +3216,7 @@ interface Named implements Node &amp; Named {
 </section>
 </section>
 <section id="sec-Enums" secid="3.9">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Enums">3.9</a></span>Enums</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Enums">3.9</a></span>Enums</h2>
 <div class="spec-production" id="EnumTypeDefinition">
 <span class="spec-nt"><a href="#EnumTypeDefinition" data-name="EnumTypeDefinition">EnumTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">enum</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#EnumValuesDefinition" data-name="EnumValuesDefinition">EnumValuesDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -3253,7 +3253,7 @@ interface Named implements Node &amp; Named {
 </ol>
 </section>
 <section id="sec-Enum-Extensions" secid="3.9.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Enum-Extensions">3.9.1</a></span>Enum Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Enum-Extensions">3.9.1</a></span>Enum Extensions</h3>
 <div class="spec-production" id="EnumTypeExtension">
 <span class="spec-nt"><a href="#EnumTypeExtension" data-name="EnumTypeExtension">EnumTypeExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">enum</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#EnumValuesDefinition" data-name="EnumValuesDefinition">EnumValuesDefinition</a></span></div>
 <div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">enum</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
@@ -3272,7 +3272,7 @@ interface Named implements Node &amp; Named {
 </section>
 </section>
 <section id="sec-Input-Objects" secid="3.10">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Objects">3.10</a></span>Input Objects</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Input-Objects">3.10</a></span>Input Objects</h2>
 <div class="spec-production" id="InputObjectTypeDefinition">
 <span class="spec-nt"><a href="#InputObjectTypeDefinition" data-name="InputObjectTypeDefinition">InputObjectTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">input</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><a href="#InputFieldsDefinition" data-name="InputFieldsDefinition">InputFieldsDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
@@ -3365,7 +3365,7 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 </ol>
 </section>
 <section id="sec-Input-Object-Extensions" secid="3.10.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Extensions">3.10.1</a></span>Input Object Extensions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Extensions">3.10.1</a></span>Input Object Extensions</h3>
 <div class="spec-production" id="InputObjectTypeExtension">
 <span class="spec-nt"><a href="#InputObjectTypeExtension" data-name="InputObjectTypeExtension">InputObjectTypeExtension</a></span><div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">input</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#InputFieldsDefinition" data-name="InputFieldsDefinition">InputFieldsDefinition</a></span></div>
 <div class="spec-rhs"><span class="spec-t">extend</span><span class="spec-t">input</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span></div>
@@ -3384,7 +3384,7 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 </section>
 </section>
 <section id="sec-Type-System.List" secid="3.11">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.List">3.11</a></span>List</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.List">3.11</a></span>List</h2>
 <p>A GraphQL list is a special collection type which declares the type of each item in the List (referred to as the <em>item type</em> of the list). List values are serialized as ordered lists, where each item in the list is serialized as per the item type.</p>
 <p>To denote that a field uses a List type the item type is wrapped in square brackets like this: <code>pets: [Pet]</code>. Nesting lists is allowed: <code>matrix: [[Int]]</code>.</p>
 <section id="sec-Type-System.List.Result-Coercion" class="subsec">
@@ -3429,7 +3429,7 @@ For more information on the error handling process, see &ldquo;Errors and Non&#8
 </section>
 </section>
 <section id="sec-Type-System.Non-Null" secid="3.12">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.Non-Null">3.12</a></span>Non-Null</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.Non-Null">3.12</a></span>Non-Null</h2>
 <p>By default, all types in GraphQL are nullable; the <span class="spec-keyword">null</span> value is a valid response for all of the above types. To declare a type that disallows null, the GraphQL Non&#8208;Null type can be used. This type wraps an underlying type, and this type acts identically to that wrapped type, with the exception that <span class="spec-keyword">null</span> is not a valid response for the wrapping type. A trailing exclamation mark is used to denote a field that uses a Non&#8208;Null type like this: <code>name: String!</code>.</p>
 <section id="sec-Type-System.Non-Null.Nullable-vs-Optional" class="subsec">
 <h6><a href="#sec-Type-System.Non-Null.Nullable-vs-Optional" title="link to this subsection">Nullable vs. Optional</a></h6>
@@ -3473,7 +3473,7 @@ The Validation section defines providing a nullable variable type to a non&#8208
 </ol>
 </section>
 <section id="sec-Combining-List-and-Non-Null" secid="3.12.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Combining-List-and-Non-Null">3.12.1</a></span>Combining List and Non-Null</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Combining-List-and-Non-Null">3.12.1</a></span>Combining List and Non-Null</h3>
 <p>The List and Non&#8208;Null wrapping types can compose, representing more complex types. The rules for result coercion and input coercion of Lists and Non&#8208;Null types apply in a recursive fashion.</p>
 <p>For example if the inner item type of a List is Non&#8208;Null (e.g. <code>[T!]</code>), then that List may not contain any <span class="spec-keyword">null</span> items. However if the inner type of a Non&#8208;Null is a List (e.g. <code>[T]!</code>), then <span class="spec-keyword">null</span> is not accepted however an empty list is accepted.</p>
 <p>Following are examples of result coercion with various types and values:</p>
@@ -3521,7 +3521,7 @@ The Validation section defines providing a nullable variable type to a non&#8208
 </section>
 </section>
 <section id="sec-Type-System.Directives" secid="3.13">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.Directives">3.13</a></span>Directives</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.Directives">3.13</a></span>Directives</h2>
 <div class="spec-production" id="DirectiveDefinition">
 <span class="spec-nt"><a href="#DirectiveDefinition" data-name="DirectiveDefinition">DirectiveDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">directive</span><span class="spec-t">@</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#ArgumentsDefinition" data-name="ArgumentsDefinition">ArgumentsDefinition</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-t">repeatable</span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">on</span><span class="spec-nt"><a href="#DirectiveLocations" data-name="DirectiveLocations">DirectiveLocations</a></span></div>
 </div>
@@ -3639,7 +3639,7 @@ The order in which directives appear may be significant, including repeatable di
 </ol>
 </section>
 <section id="sec--skip" secid="3.13.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec--skip">3.13.1</a></span>@skip</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec--skip">3.13.1</a></span>@skip</h3>
 <pre><code><span class="token keyword">directive</span> <span class="token directive function">@skip</span><span class="token punctuation">(</span><span class="token attr-name">if</span><span class="token punctuation">:</span> Boolean<span class="token operator">!</span><span class="token punctuation">)</span> <span class="token keyword">on</span> <span class="token class-name">FIELD</span> <span class="token operator">|</span> <span class="token constant">FRAGMENT_SPREAD</span> <span class="token operator">|</span> <span class="token constant">INLINE_FRAGMENT</span>
 </code></pre>
 <p>The <code>@skip</code> directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument.</p>
@@ -3650,7 +3650,7 @@ The order in which directives appear may be significant, including repeatable di
 </code></pre>
 </section>
 <section id="sec--include" secid="3.13.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec--include">3.13.2</a></span>@include</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec--include">3.13.2</a></span>@include</h3>
 <pre><code><span class="token keyword">directive</span> <span class="token directive function">@include</span><span class="token punctuation">(</span><span class="token attr-name">if</span><span class="token punctuation">:</span> Boolean<span class="token operator">!</span><span class="token punctuation">)</span> <span class="token keyword">on</span> <span class="token class-name">FIELD</span> <span class="token operator">|</span> <span class="token constant">FRAGMENT_SPREAD</span> <span class="token operator">|</span> <span class="token constant">INLINE_FRAGMENT</span>
 </code></pre>
 <p>The <code>@include</code> directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument.</p>
@@ -3664,7 +3664,7 @@ The order in which directives appear may be significant, including repeatable di
 Neither <code>@skip</code> nor <code>@include</code> has precedence over the other. In the case that both the <code>@skip</code> and <code>@include</code> directives are provided on the same field or fragment, it <em>must</em> be queried only if the <code>@skip</code> condition is false <em>and</em> the <code>@include</code> condition is true. Stated conversely, the field or fragment must <em>not</em> be queried if either the <code>@skip</code> condition is true <em>or</em> the <code>@include</code> condition is false.</div>
 </section>
 <section id="sec--deprecated" secid="3.13.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec--deprecated">3.13.3</a></span>@deprecated</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec--deprecated">3.13.3</a></span>@deprecated</h3>
 <pre><code><span class="token keyword">directive</span> <span class="token directive function">@deprecated</span><span class="token punctuation">(</span>
   <span class="token attr-name">reason</span><span class="token punctuation">:</span> String <span class="token operator">=</span> <span class="token string">"No longer supported"</span>
 <span class="token punctuation">)</span> <span class="token keyword">on</span> <span class="token class-name">FIELD_DEFINITION</span> <span class="token operator">|</span> <span class="token constant">ENUM_VALUE</span>
@@ -3681,7 +3681,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 </section>
 <section id="sec-Introspection" secid="4">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Introspection">4</a></span>Introspection</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Introspection">4</a></span>Introspection</h1>
 <p>A GraphQL service supports introspection over its schema. This schema is queried using GraphQL itself, creating a powerful platform for tool&#8208;building.</p>
 <p>Take an example query for a trivial app. In this case there is a User type with three fields: id, name, and birthday.</p>
 <p>For example, given a service with the following type definition:</p>
@@ -3726,26 +3726,26 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 <span class="token punctuation">}</span>
 </code></pre>
 <section id="sec-Reserved-Names" secid="4.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Reserved-Names">4.1</a></span>Reserved Names</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Reserved-Names">4.1</a></span>Reserved Names</h2>
 <p>Types and fields required by the GraphQL introspection system that are used in the same context as user&#8208;defined types and fields are prefixed with <span class="spec-string">"__"</span> two underscores. This in order to avoid naming collisions with user&#8208;defined GraphQL types. Conversely, GraphQL type system authors must not define any types, fields, arguments, or any other type system artifact with two leading underscores.</p>
 </section>
 <section id="sec-Documentation" secid="4.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Documentation">4.2</a></span>Documentation</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Documentation">4.2</a></span>Documentation</h2>
 <p>All types in the introspection system provide a <code>description</code> field of type <code>String</code> to allow type designers to publish documentation in addition to capabilities. A GraphQL service may return the <code>description</code> field using Markdown syntax (as specified by <a href="https://commonmark.org/">CommonMark</a>). Therefore it is recommended that any tool that displays <code>description</code> use a CommonMark&#8208;compliant Markdown renderer.</p>
 </section>
 <section id="sec-Deprecation" secid="4.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Deprecation">4.3</a></span>Deprecation</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Deprecation">4.3</a></span>Deprecation</h2>
 <p>To support the management of backwards compatibility, GraphQL fields and enum values can indicate whether or not they are deprecated (<code>isDeprecated: Boolean</code>) and a description of why it is deprecated (<code>deprecationReason: String</code>).</p>
 <p>Tools built using GraphQL introspection should respect deprecation by discouraging deprecated use through information hiding or developer&#8208;facing warnings.</p>
 </section>
 <section id="sec-Type-Name-Introspection" secid="4.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-Name-Introspection">4.4</a></span>Type Name Introspection</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-Name-Introspection">4.4</a></span>Type Name Introspection</h2>
 <p>GraphQL supports type name introspection at any point within a query by the meta&#8208;field <code>__typename: String!</code> when querying against any Object, Interface, or Union. It returns the name of the object type currently being queried.</p>
 <p>This is most often used when querying against Interface or Union types to identify which actual type of the possible types has been returned.</p>
 <p>This field is implicit and does not appear in the fields list in any defined type.</p>
 </section>
 <section id="sec-Schema-Introspection" secid="4.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Schema-Introspection">4.5</a></span>Schema Introspection</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Schema-Introspection">4.5</a></span>Schema Introspection</h2>
 <p>The schema introspection system is accessible from the meta&#8208;fields <code>__schema</code> and <code>__type</code> which are accessible from the type of the root of a query operation.</p>
 <pre><code><span class="token attr-name">__schema</span><span class="token punctuation">:</span> __Schema<span class="token operator">!</span>
 <span class="token attr-name">__type</span><span class="token punctuation">(</span><span class="token attr-name">name</span><span class="token punctuation">:</span> String<span class="token operator">!</span><span class="token punctuation">)</span><span class="token punctuation">:</span> __Type
@@ -3850,15 +3850,15 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 <span class="token punctuation">}</span>
 </code></pre>
 <section id="sec-The-__Type-Type" secid="4.5.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-The-__Type-Type">4.5.1</a></span>The __Type Type</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-The-__Type-Type">4.5.1</a></span>The __Type Type</h3>
 <p><code>__Type</code> is at the core of the type introspection system. It represents scalars, interfaces, object types, unions, enums, input objects types in the system.</p>
 <p><code>__Type</code> also represents type modifiers, which are used to modify a type that it refers to (<code>ofType: __Type</code>). This is how we represent lists, non&#8208;nullable types, and the combinations thereof.</p>
 </section>
 <section id="sec-Type-Kinds" secid="4.5.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds">4.5.2</a></span>Type Kinds</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds">4.5.2</a></span>Type Kinds</h3>
 <p>There are several different kinds of type. In each kind, different fields are actually valid. These kinds are listed in the <code>__TypeKind</code> enumeration.</p>
 <section id="sec-Scalar" secid="4.5.2.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Scalar">4.5.2.1</a></span>Scalar</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Scalar">4.5.2.1</a></span>Scalar</h4>
 <p>Represents scalar types such as Int, String, and Boolean. Scalars cannot have fields.</p>
 <p>A GraphQL type designer should describe the data format and scalar coercion rules in the description field of any scalar.</p>
 <p>Fields</p>
@@ -3870,7 +3870,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Object" secid="4.5.2.2">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Object">4.5.2.2</a></span>Object</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Object">4.5.2.2</a></span>Object</h4>
 <p>Object types represent concrete instantiations of sets of fields. The introspection types (e.g. <code>__Type</code>, <code>__Field</code>, etc) are examples of objects.</p>
 <p>Fields</p>
 <ul>
@@ -3886,7 +3886,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Union" secid="4.5.2.3">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Union">4.5.2.3</a></span>Union</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Union">4.5.2.3</a></span>Union</h4>
 <p>Unions are an abstract type where no common fields are declared. The possible types of a union are explicitly listed out in <code>possibleTypes</code>. Types can be made parts of unions without modification of that type.</p>
 <p>Fields</p>
 <ul>
@@ -3898,7 +3898,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Interface" secid="4.5.2.4">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Interface">4.5.2.4</a></span>Interface</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Interface">4.5.2.4</a></span>Interface</h4>
 <p>Interfaces are an abstract type where there are common fields declared. Any type that implements an interface must define all the fields with names and types exactly matching. The implementations of this interface are explicitly listed out in <code>possibleTypes</code>.</p>
 <p>Fields</p>
 <ul>
@@ -3915,7 +3915,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Enum" secid="4.5.2.5">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Enum">4.5.2.5</a></span>Enum</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Enum">4.5.2.5</a></span>Enum</h4>
 <p>Enums are special scalars that can only have a defined set of values.</p>
 <p>Fields</p>
 <ul>
@@ -3930,7 +3930,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Input-Object" secid="4.5.2.6">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object">4.5.2.6</a></span>Input Object</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object">4.5.2.6</a></span>Input Object</h4>
 <p>Input objects are composite types used as inputs into queries defined as a list of named input values.</p>
 <p>For example the input object <code>Point</code> could be defined as:</p>
 <pre id="example-a0e6d" class="spec-example"><a href="#example-a0e6d">Example № 95</a><code><span class="token keyword">input</span> Point <span class="token punctuation">{</span>
@@ -3948,7 +3948,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Type-Kinds.List" secid="4.5.2.7">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds.List">4.5.2.7</a></span>List</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds.List">4.5.2.7</a></span>List</h4>
 <p>Lists represent sequences of values in GraphQL. A List type is a type modifier: it wraps another type instance in the <code>ofType</code> field, which defines the type of each item in the list.</p>
 <p>Fields</p>
 <ul>
@@ -3958,7 +3958,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-Type-Kinds.Non-Null" secid="4.5.2.8">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds.Non-Null">4.5.2.8</a></span>Non-Null</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds.Non-Null">4.5.2.8</a></span>Non-Null</h4>
 <p>GraphQL types are nullable. The value <span class="spec-keyword">null</span> is a valid response for field type.</p>
 <p>A Non&#8208;null type is a type modifier: it wraps another type instance in the <code>ofType</code> field. Non&#8208;null types do not allow <span class="spec-keyword">null</span> as a response, and indicate required inputs for arguments and input object fields.</p>
 <ul>
@@ -3969,7 +3969,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 </section>
 <section id="sec-The-__Field-Type" secid="4.5.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-The-__Field-Type">4.5.3</a></span>The __Field Type</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-The-__Field-Type">4.5.3</a></span>The __Field Type</h3>
 <p>The <code>__Field</code> type represents each field in an Object or Interface type.</p>
 <p>Fields</p>
 <ul>
@@ -3982,7 +3982,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-The-__InputValue-Type" secid="4.5.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-The-__InputValue-Type">4.5.4</a></span>The __InputValue Type</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-The-__InputValue-Type">4.5.4</a></span>The __InputValue Type</h3>
 <p>The <code>__InputValue</code> type represents field and directive arguments as well as the <code>inputFields</code> of an input object.</p>
 <p>Fields</p>
 <ul>
@@ -3993,7 +3993,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-The-__EnumValue-Type" secid="4.5.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-The-__EnumValue-Type">4.5.5</a></span>The __EnumValue Type</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-The-__EnumValue-Type">4.5.5</a></span>The __EnumValue Type</h3>
 <p>The <code>__EnumValue</code> type represents one of possible values of an enum.</p>
 <p>Fields</p>
 <ul>
@@ -4004,7 +4004,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </ul>
 </section>
 <section id="sec-The-__Directive-Type" secid="4.5.6">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-The-__Directive-Type">4.5.6</a></span>The __Directive Type</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-The-__Directive-Type">4.5.6</a></span>The __Directive Type</h3>
 <p>The <code>__Directive</code> type represents a Directive that a service supports.</p>
 <p>Fields</p>
 <ul>
@@ -4018,7 +4018,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 </section>
 <section id="sec-Validation" secid="5">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation">5</a></span>Validation</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Validation">5</a></span>Validation</h1>
 <p>GraphQL does not just verify if a request is syntactically correct, but also ensures that it is unambiguous and mistake&#8208;free in the context of a given GraphQL schema.</p>
 <p>An invalid request is still technically executable, and will always produce a stable result as defined by the algorithms in the Execution section, however that result may be ambiguous, surprising, or unexpected relative to a request containing validation errors, so execution should only occur for valid requests.</p>
 <p>Typically validation is performed in the context of a request immediately before execution, however a GraphQL service may execute a request without explicitly validating it if that exact same request is known to have been validated before. For example: the request may be validated during development, provided it does not later change, or a service may validate a request once and memoize the result to avoid validating the same request again in the future. Any client&#8208;side or development&#8208;time tool should report validation errors and not allow the formulation or execution of requests known to be invalid at that given point in time.</p>
@@ -4077,9 +4077,9 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </code></pre>
 </section>
 <section id="sec-Documents" secid="5.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Documents">5.1</a></span>Documents</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Documents">5.1</a></span>Documents</h2>
 <section id="sec-Executable-Definitions" secid="5.1.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Executable-Definitions">5.1.1</a></span>Executable Definitions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Executable-Definitions">5.1.1</a></span>Executable Definitions</h3>
 <section id="sec-Executable-Definitions.Formal-Specification" class="subsec">
 <h6><a href="#sec-Executable-Definitions.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4108,11 +4108,11 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 </section>
 <section id="sec-Validation.Operations" secid="5.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Operations">5.2</a></span>Operations</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Operations">5.2</a></span>Operations</h2>
 <section id="sec-Named-Operation-Definitions" secid="5.2.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Named-Operation-Definitions">5.2.1</a></span>Named Operation Definitions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Named-Operation-Definitions">5.2.1</a></span>Named Operation Definitions</h3>
 <section id="sec-Operation-Name-Uniqueness" secid="5.2.1.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Operation-Name-Uniqueness">5.2.1.1</a></span>Operation Name Uniqueness</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Operation-Name-Uniqueness">5.2.1.1</a></span>Operation Name Uniqueness</h4>
 <section id="sec-Operation-Name-Uniqueness.Formal-Specification" class="subsec">
 <h6><a href="#sec-Operation-Name-Uniqueness.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4175,9 +4175,9 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 </section>
 <section id="sec-Anonymous-Operation-Definitions" secid="5.2.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Anonymous-Operation-Definitions">5.2.2</a></span>Anonymous Operation Definitions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Anonymous-Operation-Definitions">5.2.2</a></span>Anonymous Operation Definitions</h3>
 <section id="sec-Lone-Anonymous-Operation" secid="5.2.2.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Lone-Anonymous-Operation">5.2.2.1</a></span>Lone Anonymous Operation</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Lone-Anonymous-Operation">5.2.2.1</a></span>Lone Anonymous Operation</h4>
 <section id="sec-Lone-Anonymous-Operation.Formal-Specification" class="subsec">
 <h6><a href="#sec-Lone-Anonymous-Operation.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4218,9 +4218,9 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 </section>
 <section id="sec-Subscription-Operation-Definitions" secid="5.2.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Subscription-Operation-Definitions">5.2.3</a></span>Subscription Operation Definitions</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Subscription-Operation-Definitions">5.2.3</a></span>Subscription Operation Definitions</h3>
 <section id="sec-Single-root-field" secid="5.2.3.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Single-root-field">5.2.3.1</a></span>Single root field</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Single-root-field">5.2.3.1</a></span>Single root field</h4>
 <section id="sec-Single-root-field.Formal-Specification" class="subsec">
 <h6><a href="#sec-Single-root-field.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4292,9 +4292,9 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Validation.Fields" secid="5.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Fields">5.3</a></span>Fields</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Fields">5.3</a></span>Fields</h2>
 <section id="sec-Field-Selections" secid="5.3.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Field-Selections">5.3.1</a></span>Field Selections</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Field-Selections">5.3.1</a></span>Field Selections</h3>
 <p>Field selections must exist on Object, Interface, and Union types.</p>
 <section id="sec-Field-Selections.Formal-Specification" class="subsec">
 <h6><a href="#sec-Field-Selections.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
@@ -4348,7 +4348,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Field-Selection-Merging" secid="5.3.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Field-Selection-Merging">5.3.2</a></span>Field Selection Merging</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Field-Selection-Merging">5.3.2</a></span>Field Selection Merging</h3>
 <section id="sec-Field-Selection-Merging.Formal-Specification" class="subsec">
 <h6><a href="#sec-Field-Selection-Merging.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4490,7 +4490,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Leaf-Field-Selections" secid="5.3.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Leaf-Field-Selections">5.3.3</a></span>Leaf Field Selections</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Leaf-Field-Selections">5.3.3</a></span>Leaf Field Selections</h3>
 <section id="sec-Leaf-Field-Selections.Formal-Specification" class="subsec">
 <h6><a href="#sec-Leaf-Field-Selections.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4546,10 +4546,10 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Validation.Arguments" secid="5.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Arguments">5.4</a></span>Arguments</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Arguments">5.4</a></span>Arguments</h2>
 <p>Arguments are provided to both fields and directives. The following validation rules apply in both cases.</p>
 <section id="sec-Argument-Names" secid="5.4.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Argument-Names">5.4.1</a></span>Argument Names</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Argument-Names">5.4.1</a></span>Argument Names</h3>
 <section id="sec-Argument-Names.Formal-Specification" class="subsec">
 <h6><a href="#sec-Argument-Names.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4608,7 +4608,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Argument-Uniqueness" secid="5.4.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Argument-Uniqueness">5.4.2</a></span>Argument Uniqueness</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Argument-Uniqueness">5.4.2</a></span>Argument Uniqueness</h3>
 <p>Fields and directives treat arguments as a mapping of argument name to value. More than one argument with the same name in an argument set is ambiguous and invalid.</p>
 <section id="sec-Argument-Uniqueness.Formal-Specification" class="subsec">
 <h6><a href="#sec-Argument-Uniqueness.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
@@ -4620,7 +4620,7 @@ While each subscription must have exactly one root field, a document may contain
 </ul>
 </section>
 <section id="sec-Required-Arguments" secid="5.4.2.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Required-Arguments">5.4.2.1</a></span>Required Arguments</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Required-Arguments">5.4.2.1</a></span>Required Arguments</h4>
 <ul>
 <li>For each Field or Directive in the document.</li>
 <li>Let <var data-name="arguments">arguments</var> be the arguments provided by the Field or Directive.</li>
@@ -4672,11 +4672,11 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Validation.Fragments" secid="5.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Fragments">5.5</a></span>Fragments</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Fragments">5.5</a></span>Fragments</h2>
 <section id="sec-Fragment-Declarations" secid="5.5.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Declarations">5.5.1</a></span>Fragment Declarations</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Declarations">5.5.1</a></span>Fragment Declarations</h3>
 <section id="sec-Fragment-Name-Uniqueness" secid="5.5.1.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Name-Uniqueness">5.5.1.1</a></span>Fragment Name Uniqueness</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Name-Uniqueness">5.5.1.1</a></span>Fragment Name Uniqueness</h4>
 <section id="sec-Fragment-Name-Uniqueness.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragment-Name-Uniqueness.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4728,7 +4728,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Fragment-Spread-Type-Existence" secid="5.5.1.2">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Spread-Type-Existence">5.5.1.2</a></span>Fragment Spread Type Existence</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Spread-Type-Existence">5.5.1.2</a></span>Fragment Spread Type Existence</h4>
 <section id="sec-Fragment-Spread-Type-Existence.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragment-Spread-Type-Existence.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4771,7 +4771,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Fragments-On-Composite-Types" secid="5.5.1.3">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragments-On-Composite-Types">5.5.1.3</a></span>Fragments On Composite Types</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragments-On-Composite-Types">5.5.1.3</a></span>Fragments On Composite Types</h4>
 <section id="sec-Fragments-On-Composite-Types.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragments-On-Composite-Types.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4811,7 +4811,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Fragments-Must-Be-Used" secid="5.5.1.4">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragments-Must-Be-Used">5.5.1.4</a></span>Fragments Must Be Used</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragments-Must-Be-Used">5.5.1.4</a></span>Fragments Must Be Used</h4>
 <section id="sec-Fragments-Must-Be-Used.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragments-Must-Be-Used.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4837,10 +4837,10 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Fragment-Spreads" secid="5.5.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Spreads">5.5.2</a></span>Fragment Spreads</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-Spreads">5.5.2</a></span>Fragment Spreads</h3>
 <p>Field selection is also determined by spreading fragments into one another. The selection set of the target fragment is unioned with the selection set at the level at which the target fragment is referenced.</p>
 <section id="sec-Fragment-spread-target-defined" secid="5.5.2.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-spread-target-defined">5.5.2.1</a></span>Fragment spread target defined</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-spread-target-defined">5.5.2.1</a></span>Fragment spread target defined</h4>
 <section id="sec-Fragment-spread-target-defined.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragment-spread-target-defined.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4861,7 +4861,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Fragment-spreads-must-not-form-cycles" secid="5.5.2.2">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-spreads-must-not-form-cycles">5.5.2.2</a></span>Fragment spreads must not form cycles</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-spreads-must-not-form-cycles">5.5.2.2</a></span>Fragment spreads must not form cycles</h4>
 <section id="sec-Fragment-spreads-must-not-form-cycles.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragment-spreads-must-not-form-cycles.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4940,7 +4940,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Fragment-spread-is-possible" secid="5.5.2.3">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-spread-is-possible">5.5.2.3</a></span>Fragment spread is possible</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Fragment-spread-is-possible">5.5.2.3</a></span>Fragment spread is possible</h4>
 <section id="sec-Fragment-spread-is-possible.Formal-Specification" class="subsec">
 <h6><a href="#sec-Fragment-spread-is-possible.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -4964,7 +4964,7 @@ While each subscription must have exactly one root field, a document may contain
 <p>Fragments are declared on a type and will only apply when the runtime object type matches the type condition. They also are spread within the context of a parent type. A fragment spread is only valid if its type condition could ever apply within the parent type.</p>
 </section>
 <section id="sec-Object-Spreads-In-Object-Scope" secid="5.5.2.3.1">
-<h6><span class="spec-secid" title="link to this section"><a href="#sec-Object-Spreads-In-Object-Scope">5.5.2.3.1</a></span>Object Spreads In Object Scope</h6>
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Object-Spreads-In-Object-Scope">5.5.2.3.1</a></span>Object Spreads In Object Scope</h5>
 <p>In the scope of an object type, the only valid object type fragment spread is one that applies to the same type that is in scope.</p>
 <p>For example</p>
 <pre id="example-0fc38" class="spec-example"><a href="#example-0fc38">Example № 143</a><code><span class="token keyword">fragment</span> <span class="token fragment function">dogFragment</span> <span class="token keyword">on</span> <span class="token class-name">Dog</span> <span class="token punctuation">{</span>
@@ -4982,7 +4982,7 @@ While each subscription must have exactly one root field, a document may contain
 </code></pre>
 </section>
 <section id="sec-Abstract-Spreads-in-Object-Scope" secid="5.5.2.3.2">
-<h6><span class="spec-secid" title="link to this section"><a href="#sec-Abstract-Spreads-in-Object-Scope">5.5.2.3.2</a></span>Abstract Spreads in Object Scope</h6>
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Abstract-Spreads-in-Object-Scope">5.5.2.3.2</a></span>Abstract Spreads in Object Scope</h5>
 <p>In scope of an object type, unions or interface spreads can be used if the object type implements the interface or is a member of the union.</p>
 <p>For example</p>
 <pre id="example-2c8d0" class="spec-example"><a href="#example-2c8d0">Example № 145</a><code><span class="token keyword">fragment</span> <span class="token fragment function">petNameFragment</span> <span class="token keyword">on</span> <span class="token class-name">Pet</span> <span class="token punctuation">{</span>
@@ -5008,7 +5008,7 @@ While each subscription must have exactly one root field, a document may contain
 <p>is valid because <span class="spec-nt"><span data-name="Dog">Dog</span></span> is a member of the <span class="spec-nt"><span data-name="CatOrDog">CatOrDog</span></span> union. It is worth noting that if one inspected the contents of the <span class="spec-nt"><span data-name="CatOrDogNameFragment">CatOrDogNameFragment</span></span> you could note that no valid results would ever be returned. However we do not specify this as invalid because we only consider the fragment declaration, not its body.</p>
 </section>
 <section id="sec-Object-Spreads-In-Abstract-Scope" secid="5.5.2.3.3">
-<h6><span class="spec-secid" title="link to this section"><a href="#sec-Object-Spreads-In-Abstract-Scope">5.5.2.3.3</a></span>Object Spreads In Abstract Scope</h6>
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Object-Spreads-In-Abstract-Scope">5.5.2.3.3</a></span>Object Spreads In Abstract Scope</h5>
 <p>Union or interface spreads can be used within the context of an object type fragment, but only if the object type is one of the possible types of that interface or union.</p>
 <p>For example, the following fragments are valid:</p>
 <pre id="example-85110" class="spec-example"><a href="#example-85110">Example № 147</a><code><span class="token keyword">fragment</span> <span class="token fragment function">petFragment</span> <span class="token keyword">on</span> <span class="token class-name">Pet</span> <span class="token punctuation">{</span>
@@ -5041,7 +5041,7 @@ While each subscription must have exactly one root field, a document may contain
 <p><span class="spec-nt"><span data-name="Dog">Dog</span></span> does not implement the interface <span class="spec-nt"><span data-name="Sentient">Sentient</span></span> and therefore <var data-name="sentientFragment">sentientFragment</var> can never return meaningful results. Therefore the fragment is invalid. Likewise <span class="spec-nt"><span data-name="Cat">Cat</span></span> is not a member of the union <span class="spec-nt"><span data-name="HumanOrAlien">HumanOrAlien</span></span>, and it can also never return meaningful results, making it invalid.</p>
 </section>
 <section id="sec-Abstract-Spreads-in-Abstract-Scope" secid="5.5.2.3.4">
-<h6><span class="spec-secid" title="link to this section"><a href="#sec-Abstract-Spreads-in-Abstract-Scope">5.5.2.3.4</a></span>Abstract Spreads in Abstract Scope</h6>
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Abstract-Spreads-in-Abstract-Scope">5.5.2.3.4</a></span>Abstract Spreads in Abstract Scope</h5>
 <p>Union or interfaces fragments can be used within each other. As long as there exists at least <em>one</em> object type that exists in the intersection of the possible types of the scope and the spread, the spread is considered valid.</p>
 <p>So for example</p>
 <pre id="example-dc875" class="spec-example"><a href="#example-dc875">Example № 149</a><code><span class="token keyword">fragment</span> <span class="token fragment function">unionWithInterface</span> <span class="token keyword">on</span> <span class="token class-name">Pet</span> <span class="token punctuation">{</span>
@@ -5092,9 +5092,9 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Values" secid="5.6">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Values">5.6</a></span>Values</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Values">5.6</a></span>Values</h2>
 <section id="sec-Values-of-Correct-Type" secid="5.6.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Values-of-Correct-Type">5.6.1</a></span>Values of Correct Type</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Values-of-Correct-Type">5.6.1</a></span>Values of Correct Type</h3>
 <section id="sec-Values-of-Correct-Type.Formal-Specification" class="subsec">
 <h6><a href="#sec-Values-of-Correct-Type.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5135,7 +5135,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Input-Object-Field-Names" secid="5.6.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Field-Names">5.6.2</a></span>Input Object Field Names</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Field-Names">5.6.2</a></span>Input Object Field Names</h3>
 <section id="sec-Input-Object-Field-Names.Formal-Specification" class="subsec">
 <h6><a href="#sec-Input-Object-Field-Names.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5161,7 +5161,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Input-Object-Field-Uniqueness" secid="5.6.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Field-Uniqueness">5.6.3</a></span>Input Object Field Uniqueness</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Field-Uniqueness">5.6.3</a></span>Input Object Field Uniqueness</h3>
 <section id="sec-Input-Object-Field-Uniqueness.Formal-Specification" class="subsec">
 <h6><a href="#sec-Input-Object-Field-Uniqueness.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5185,7 +5185,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Input-Object-Required-Fields" secid="5.6.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Required-Fields">5.6.4</a></span>Input Object Required Fields</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-Object-Required-Fields">5.6.4</a></span>Input Object Required Fields</h3>
 <section id="sec-Input-Object-Required-Fields.Formal-Specification" class="subsec">
 <h6><a href="#sec-Input-Object-Required-Fields.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5216,9 +5216,9 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Validation.Directives" secid="5.7">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Directives">5.7</a></span>Directives</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Directives">5.7</a></span>Directives</h2>
 <section id="sec-Directives-Are-Defined" secid="5.7.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Directives-Are-Defined">5.7.1</a></span>Directives Are Defined</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Directives-Are-Defined">5.7.1</a></span>Directives Are Defined</h3>
 <section id="sec-Directives-Are-Defined.Formal-Specification" class="subsec">
 <h6><a href="#sec-Directives-Are-Defined.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5234,7 +5234,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Directives-Are-In-Valid-Locations" secid="5.7.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Directives-Are-In-Valid-Locations">5.7.2</a></span>Directives Are In Valid Locations</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Directives-Are-In-Valid-Locations">5.7.2</a></span>Directives Are In Valid Locations</h3>
 <section id="sec-Directives-Are-In-Valid-Locations.Formal-Specification" class="subsec">
 <h6><a href="#sec-Directives-Are-In-Valid-Locations.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5257,7 +5257,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Directives-Are-Unique-Per-Location" secid="5.7.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Directives-Are-Unique-Per-Location">5.7.3</a></span>Directives Are Unique Per Location</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Directives-Are-Unique-Per-Location">5.7.3</a></span>Directives Are Unique Per Location</h3>
 <section id="sec-Directives-Are-Unique-Per-Location.Formal-Specification" class="subsec">
 <h6><a href="#sec-Directives-Are-Unique-Per-Location.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5295,9 +5295,9 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Validation.Variables" secid="5.8">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Variables">5.8</a></span>Variables</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Validation.Variables">5.8</a></span>Variables</h2>
 <section id="sec-Variable-Uniqueness" secid="5.8.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Variable-Uniqueness">5.8.1</a></span>Variable Uniqueness</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Variable-Uniqueness">5.8.1</a></span>Variable Uniqueness</h3>
 <section id="sec-Variable-Uniqueness.Formal-Specification" class="subsec">
 <h6><a href="#sec-Variable-Uniqueness.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5339,7 +5339,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-Variables-Are-Input-Types" secid="5.8.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Variables-Are-Input-Types">5.8.2</a></span>Variables Are Input Types</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Variables-Are-Input-Types">5.8.2</a></span>Variables Are Input Types</h3>
 <section id="sec-Variables-Are-Input-Types.Formal-Specification" class="subsec">
 <h6><a href="#sec-Variables-Are-Input-Types.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5399,7 +5399,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-All-Variable-Uses-Defined" secid="5.8.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-All-Variable-Uses-Defined">5.8.3</a></span>All Variable Uses Defined</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-All-Variable-Uses-Defined">5.8.3</a></span>All Variable Uses Defined</h3>
 <section id="sec-All-Variable-Uses-Defined.Formal-Specification" class="subsec">
 <h6><a href="#sec-All-Variable-Uses-Defined.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5510,7 +5510,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-All-Variables-Used" secid="5.8.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-All-Variables-Used">5.8.4</a></span>All Variables Used</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-All-Variables-Used">5.8.4</a></span>All Variables Used</h3>
 <section id="sec-All-Variables-Used.Formal-Specification" class="subsec">
 <h6><a href="#sec-All-Variables-Used.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5575,7 +5575,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 </section>
 <section id="sec-All-Variable-Usages-are-Allowed" secid="5.8.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-All-Variable-Usages-are-Allowed">5.8.5</a></span>All Variable Usages are Allowed</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-All-Variable-Usages-are-Allowed">5.8.5</a></span>All Variable Usages are Allowed</h3>
 <section id="sec-All-Variable-Usages-are-Allowed.Formal-Specification" class="subsec">
 <h6><a href="#sec-All-Variable-Usages-are-Allowed.Formal-Specification" title="link to this subsection">Formal Specification</a></h6>
 <ul>
@@ -5696,7 +5696,7 @@ The value <span class="spec-keyword">null</span> could still be provided to such
 </section>
 </section>
 <section id="sec-Execution" secid="6">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Execution">6</a></span>Execution</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Execution">6</a></span>Execution</h1>
 <p>GraphQL generates a response from a request via execution.</p>
 <p>A request for execution consists of a few pieces of information:</p>
 <ul>
@@ -5708,7 +5708,7 @@ The value <span class="spec-keyword">null</span> could still be provided to such
 </ul>
 <p>Given this information, the result of <span class="spec-call"><a href="#ExecuteRequest()" data-name="ExecuteRequest">ExecuteRequest</a>()</span> produces the response, to be formatted according to the Response section below.</p>
 <section id="sec-Executing-Requests" secid="6.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Requests">6.1</a></span>Executing Requests</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Requests">6.1</a></span>Executing Requests</h2>
 <p>To execute a request, the executor must have a parsed <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span> and a selected operation name to run if the document defines multiple operations, otherwise the document is expected to only contain a single operation. The result of the request is determined by the result of executing this operation according to the &ldquo;Executing Operations&rdquo; section below.</p>
 <div class="spec-algo" id="ExecuteRequest()">
 <span class="spec-call"><a href="#ExecuteRequest()" data-name="ExecuteRequest">ExecuteRequest</a>(<var data-name="schema">schema</var>, <var data-name="document">document</var>, <var data-name="operationName">operationName</var>, <var data-name="variableValues">variableValues</var>, <var data-name="initialValue">initialValue</var>)</span><ol>
@@ -5747,13 +5747,13 @@ The value <span class="spec-keyword">null</span> could still be provided to such
 </ol>
 </div>
 <section id="sec-Validating-Requests" secid="6.1.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Validating-Requests">6.1.1</a></span>Validating Requests</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Validating-Requests">6.1.1</a></span>Validating Requests</h3>
 <p>As explained in the Validation section, only requests which pass all validation rules should be executed. If validation errors are known, they should be reported in the list of &ldquo;errors&rdquo; in the response and the request must fail without execution.</p>
 <p>Typically validation is performed in the context of a request immediately before execution, however a GraphQL service may execute a request without immediately validating it if that exact same request is known to have been validated before. A GraphQL service should only execute requests which <em>at some point</em> were known to be free of any validation errors, and have since not changed.</p>
 <p>For example: the request may be validated during development, provided it does not later change, or a service may validate a request once and memoize the result to avoid validating the same request again in the future.</p>
 </section>
 <section id="sec-Coercing-Variable-Values" secid="6.1.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Coercing-Variable-Values">6.1.2</a></span>Coercing Variable Values</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Coercing-Variable-Values">6.1.2</a></span>Coercing Variable Values</h3>
 <p>If the operation has defined any variables, then the values for those variables need to be coerced using the input coercion rules of variable&rsquo;s declared type. If a query error is encountered during input coercion of variable values, then the operation fails without execution.</p>
 <div class="spec-algo" id="CoerceVariableValues()">
 <span class="spec-call"><a href="#CoerceVariableValues()" data-name="CoerceVariableValues">CoerceVariableValues</a>(<var data-name="schema">schema</var>, <var data-name="operation">operation</var>, <var data-name="variableValues">variableValues</var>)</span><ol>
@@ -5795,10 +5795,10 @@ This algorithm is very similar to <span class="spec-call"><a href="#CoerceArgume
 </section>
 </section>
 <section id="sec-Executing-Operations" secid="6.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Operations">6.2</a></span>Executing Operations</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Operations">6.2</a></span>Executing Operations</h2>
 <p>The type system, as described in the &ldquo;Type System&rdquo; section of the spec, must provide a query root object type. If mutations or subscriptions are supported, it must also provide a mutation or subscription root object type, respectively.</p>
 <section id="sec-Query" secid="6.2.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Query">6.2.1</a></span>Query</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Query">6.2.1</a></span>Query</h3>
 <p>If the operation is a query, the result of the operation is the result of executing the query&rsquo;s top level selection set with the query root object type.</p>
 <p>An initial value may be provided when executing a query.</p>
 <div class="spec-algo" id="ExecuteQuery()">
@@ -5813,7 +5813,7 @@ This algorithm is very similar to <span class="spec-call"><a href="#CoerceArgume
 </div>
 </section>
 <section id="sec-Mutation" secid="6.2.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Mutation">6.2.2</a></span>Mutation</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Mutation">6.2.2</a></span>Mutation</h3>
 <p>If the operation is a mutation, the result of the operation is the result of executing the mutation&rsquo;s top level selection set on the mutation root object type. This selection set should be executed serially.</p>
 <p>It is expected that the top level fields in a mutation operation perform side&#8208;effects on the underlying data system. Serial execution of the provided mutations ensures against race conditions during these side&#8208;effects.</p>
 <div class="spec-algo" id="ExecuteMutation()">
@@ -5828,7 +5828,7 @@ This algorithm is very similar to <span class="spec-call"><a href="#CoerceArgume
 </div>
 </section>
 <section id="sec-Subscription" secid="6.2.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Subscription">6.2.3</a></span>Subscription</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Subscription">6.2.3</a></span>Subscription</h3>
 <p>If the operation is a subscription, the result is an event stream called the &ldquo;Response Stream&rdquo; where each event in the event stream is the result of executing the operation for each new event on an underlying &ldquo;Source Stream&rdquo;.</p>
 <p>Executing a subscription creates a persistent function on the service that maps an underlying Source Stream to a returned Response Stream.</p>
 <div class="spec-algo" id="Subscribe()">
@@ -5874,7 +5874,7 @@ In large scale subscription systems, the <span class="spec-call"><a href="#Subsc
 <p>GraphQL subscriptions do not require any specific serialization format or transport mechanism. Subscriptions specifies algorithms for the creation of a stream, the content of each payload on that stream, and the closing of that stream. There are intentionally no specifications for message acknowledgement, buffering, resend requests, or any other quality of service (QoS) details. Message serialization, transport mechanisms, and quality of service details should be chosen by the implementing service.</p>
 </section>
 <section id="sec-Source-Stream" secid="6.2.3.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Source-Stream">6.2.3.1</a></span>Source Stream</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Source-Stream">6.2.3.1</a></span>Source Stream</h4>
 <p>A Source Stream represents the sequence of events, each of which will trigger a GraphQL execution corresponding to that event. Like field value resolution, the logic to create a Source Stream is application&#8208;specific.</p>
 <div class="spec-algo" id="CreateSourceEventStream()">
 <span class="spec-call"><a href="#CreateSourceEventStream()" data-name="CreateSourceEventStream">CreateSourceEventStream</a>(<var data-name="subscription">subscription</var>, <var data-name="schema">schema</var>, <var data-name="variableValues">variableValues</var>, <var data-name="initialValue">initialValue</var>)</span><ol>
@@ -5901,7 +5901,7 @@ In large scale subscription systems, the <span class="spec-call"><a href="#Subsc
 This <span class="spec-call"><a href="#ResolveFieldEventStream()" data-name="ResolveFieldEventStream">ResolveFieldEventStream</a>()</span> algorithm is intentionally similar to <span class="spec-call"><a href="#ResolveFieldValue()" data-name="ResolveFieldValue">ResolveFieldValue</a>()</span> to enable consistency when defining resolvers on any operation type.</div>
 </section>
 <section id="sec-Response-Stream" secid="6.2.3.2">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Response-Stream">6.2.3.2</a></span>Response Stream</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Response-Stream">6.2.3.2</a></span>Response Stream</h4>
 <p>Each event in the underlying Source Stream triggers execution of the subscription selection set using that event as a root value.</p>
 <div class="spec-algo" id="MapSourceToResponseEvent()">
 <span class="spec-call"><a href="#MapSourceToResponseEvent()" data-name="MapSourceToResponseEvent">MapSourceToResponseEvent</a>(<var data-name="sourceStream">sourceStream</var>, <var data-name="subscription">subscription</var>, <var data-name="schema">schema</var>, <var data-name="variableValues">variableValues</var>)</span><ol>
@@ -5929,7 +5929,7 @@ This <span class="spec-call"><a href="#ResolveFieldEventStream()" data-name="Res
 The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="ExecuteSubscriptionEvent">ExecuteSubscriptionEvent</a>()</span> algorithm is intentionally similar to <span class="spec-call"><a href="#ExecuteQuery()" data-name="ExecuteQuery">ExecuteQuery</a>()</span> since this is how each event result is produced.</div>
 </section>
 <section id="sec-Unsubscribe" secid="6.2.3.3">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Unsubscribe">6.2.3.3</a></span>Unsubscribe</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Unsubscribe">6.2.3.3</a></span>Unsubscribe</h4>
 <p>Unsubscribe cancels the Response Stream when a client no longer wishes to receive payloads for a subscription. This may in turn also cancel the Source Stream. This is also a good opportunity to clean up any other resources used by the subscription.</p>
 <div class="spec-algo" id="Unsubscribe()">
 <span class="spec-call"><a href="#Unsubscribe()" data-name="Unsubscribe">Unsubscribe</a>(<var data-name="responseStream">responseStream</var>)</span><ol>
@@ -5940,7 +5940,7 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 </section>
 </section>
 <section id="sec-Executing-Selection-Sets" secid="6.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Selection-Sets">6.3</a></span>Executing Selection Sets</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Selection-Sets">6.3</a></span>Executing Selection Sets</h2>
 <p>To execute a selection set, the object value being evaluated and the object type need to be known, as well as whether it must be executed serially, or may be executed in parallel.</p>
 <p>First, the selection set is turned into a grouped field set; then, each represented field in the grouped field set produces an entry into a response map.</p>
 <div class="spec-algo" id="ExecuteSelectionSet()">
@@ -5970,7 +5970,7 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 <p>See the <a href="#sec-Errors-and-Non-Nullability">Errors and Non&#8208;Nullability</a> section of Field Execution for more about this behavior.</p>
 </section>
 <section id="sec-Normal-and-Serial-Execution" secid="6.3.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Normal-and-Serial-Execution">6.3.1</a></span>Normal and Serial Execution</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Normal-and-Serial-Execution">6.3.1</a></span>Normal and Serial Execution</h3>
 <p>Normally the executor can execute the entries in a grouped field set in whatever order it chooses (normally in parallel). Because the resolution of fields other than top&#8208;level mutation fields must always be side effect&#8208;free and idempotent, the execution order must not affect the result, and hence the service has the freedom to execute the field entries in whatever order it deems optimal.</p>
 <p>For example, given the following grouped field set to be executed normally:</p>
 <pre id="example-65e7d" class="spec-example"><a href="#example-65e7d">Example № 185</a><code><span class="token punctuation">{</span>
@@ -6037,7 +6037,7 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 </code></pre>
 </section>
 <section id="sec-Field-Collection" secid="6.3.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Field-Collection">6.3.2</a></span>Field Collection</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Field-Collection">6.3.2</a></span>Field Collection</h3>
 <p>Before execution, the selection set is converted to a grouped field set by calling <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span>. Each entry in the grouped field set is a list of fields that share a response key (the alias if defined, otherwise the field name). This ensures all fields with the same response key included via referenced fragments are executed at the same time.</p>
 <p>As an example, collecting the fields of this selection set would collect two instances of the field <code>a</code> and one of field <code>b</code>:</p>
 <pre id="example-fdbb7" class="spec-example"><a href="#example-fdbb7">Example № 189</a><code><span class="token punctuation">{</span>
@@ -6132,7 +6132,7 @@ The steps in <span class="spec-call"><a href="#CollectFields()" data-name="Colle
 </section>
 </section>
 <section id="sec-Executing-Fields" secid="6.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Fields">6.4</a></span>Executing Fields</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Executing-Fields">6.4</a></span>Executing Fields</h2>
 <p>Each field requested in the grouped field set that is defined on the selected objectType will result in an entry in the response map. Field execution first coerces any provided argument values, then resolves a value for the field, and finally completes that value either by recursively executing another selection set or coercing a scalar value.</p>
 <div class="spec-algo" id="ExecuteField()">
 <span class="spec-call"><a href="#ExecuteField()" data-name="ExecuteField">ExecuteField</a>(<var data-name="objectType">objectType</var>, <var data-name="objectValue">objectValue</var>, <var data-name="fieldType">fieldType</var>, <var data-name="fields">fields</var>, <var data-name="variableValues">variableValues</var>)</span><ol>
@@ -6144,7 +6144,7 @@ The steps in <span class="spec-call"><a href="#CollectFields()" data-name="Colle
 </ol>
 </div>
 <section id="sec-Coercing-Field-Arguments" secid="6.4.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Coercing-Field-Arguments">6.4.1</a></span>Coercing Field Arguments</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Coercing-Field-Arguments">6.4.1</a></span>Coercing Field Arguments</h3>
 <p>Fields may include arguments which are provided to the underlying runtime in order to correctly produce a value. These arguments are defined by the field in the type system to have a specific input type.</p>
 <p>At each argument position in a query may be a literal <span class="spec-nt"><a href="#Value" data-name="Value">Value</a></span>, or a <span class="spec-nt"><a href="#Variable" data-name="Variable">Variable</a></span> to be provided at runtime.</p>
 <div class="spec-algo" id="CoerceArgumentValues()">
@@ -6198,7 +6198,7 @@ The steps in <span class="spec-call"><a href="#CollectFields()" data-name="Colle
 Variable values are not coerced because they are expected to be coerced before executing the operation in <span class="spec-call"><a href="#CoerceVariableValues()" data-name="CoerceVariableValues">CoerceVariableValues</a>()</span>, and valid queries must only allow usage of variables of appropriate types.</div>
 </section>
 <section id="sec-Value-Resolution" secid="6.4.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Value-Resolution">6.4.2</a></span>Value Resolution</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Value-Resolution">6.4.2</a></span>Value Resolution</h3>
 <p>While nearly all of GraphQL execution can be described generically, ultimately the internal system exposing the GraphQL interface must provide values. This is exposed via <span class="spec-nt"><span data-name="ResolveFieldValue">ResolveFieldValue</span></span>, which produces a value for a given field on a type for a real value.</p>
 <p>As an example, this might accept the <var data-name="objectType">objectType</var> <code>Person</code>, the <var data-name="field">field</var> <span class="spec-string">"soulMate"</span>, and the <var data-name="objectValue">objectValue</var> representing John Lennon. It would be expected to yield the value representing Yoko Ono.</p>
 <div class="spec-algo" id="ResolveFieldValue()">
@@ -6212,7 +6212,7 @@ Variable values are not coerced because they are expected to be coerced before e
 It is common for <var data-name="resolver">resolver</var> to be asynchronous due to relying on reading an underlying database or networked service to produce a value. This necessitates the rest of a GraphQL executor to handle an asynchronous execution flow.</div>
 </section>
 <section id="sec-Value-Completion" secid="6.4.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Value-Completion">6.4.3</a></span>Value Completion</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Value-Completion">6.4.3</a></span>Value Completion</h3>
 <p>After resolving the value for a field, it is completed by ensuring it adheres to the expected return type. If the return type is another Object type, then the field execution process continues recursively.</p>
 <div class="spec-algo" id="CompleteValue()">
 <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>(<var data-name="fieldType">fieldType</var>, <var data-name="fields">fields</var>, <var data-name="result">result</var>, <var data-name="variableValues">variableValues</var>)</span><ol>
@@ -6290,7 +6290,7 @@ A common method of determining the Object type for an <var data-name="objectValu
 </section>
 </section>
 <section id="sec-Errors-and-Non-Nullability" secid="6.4.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Errors-and-Non-Nullability">6.4.4</a></span>Errors and Non-Nullability</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Errors-and-Non-Nullability">6.4.4</a></span>Errors and Non-Nullability</h3>
 <p>If an error is thrown while resolving a field, it should be treated as though the field returned <span class="spec-keyword">null</span>, and an error must be added to the <span class="spec-string">"errors"</span> list in the response.</p>
 <p>If the result of resolving a field is <span class="spec-keyword">null</span> (either because the function to resolve the field returned <span class="spec-keyword">null</span> or because an error occurred), and that field is of a <code>Non-Null</code> type, then a field error is thrown. The error must be added to the <span class="spec-string">"errors"</span> list in the response.</p>
 <p>If the field returns <span class="spec-keyword">null</span> because of an error which has already been added to the <span class="spec-string">"errors"</span> list in the response, the <span class="spec-string">"errors"</span> list must not be further affected. That is, only one error should be added to the errors list per field.</p>
@@ -6301,11 +6301,11 @@ A common method of determining the Object type for an <var data-name="objectValu
 </section>
 </section>
 <section id="sec-Response" secid="7">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Response">7</a></span>Response</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Response">7</a></span>Response</h1>
 <p>When a GraphQL service receives a request, it must return a well&#8208;formed response. The service&rsquo;s response describes the result of executing the requested operation if successful, and describes any errors encountered during the request.</p>
 <p>A response may contain both a partial response as well as encountered errors in the case that a field error occurred on a field which was replaced with <span class="spec-keyword">null</span>.</p>
 <section id="sec-Response-Format" secid="7.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Response-Format">7.1</a></span>Response Format</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Response-Format">7.1</a></span>Response Format</h2>
 <p>A response to a GraphQL operation must be a map.</p>
 <p>If the operation encountered any errors, the response map must contain an entry with key <code>errors</code>. The value of this entry is described in the &ldquo;Errors&rdquo; section. If the operation completed without encountering any errors, this entry must not be present.</p>
 <p>If the operation included execution, the response map must contain an entry with key <code>data</code>. The value of this entry is described in the &ldquo;Data&rdquo; section. If the operation failed before execution, due to a syntax error, missing information, or validation error, this entry must not be present.</p>
@@ -6315,13 +6315,13 @@ A common method of determining the Object type for an <var data-name="objectValu
 <a href="#note-6f005">Note</a>
 When <code>errors</code> is present in the response, it may be helpful for it to appear first when serialized to make it more clear when errors are present in a response during debugging.</div>
 <section id="sec-Data" secid="7.1.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Data">7.1.1</a></span>Data</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Data">7.1.1</a></span>Data</h3>
 <p>The <code>data</code> entry in the response will be the result of the execution of the requested operation. If the operation was a query, this output will be an object of the schema&rsquo;s query root type; if the operation was a mutation, this output will be an object of the schema&rsquo;s mutation root type.</p>
 <p>If an error was encountered before execution begins, the <code>data</code> entry should not be present in the result.</p>
 <p>If an error was encountered during the execution that prevented a valid response, the <code>data</code> entry in the response should be <code>null</code>.</p>
 </section>
 <section id="sec-Errors" secid="7.1.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Errors">7.1.2</a></span>Errors</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Errors">7.1.2</a></span>Errors</h3>
 <p>The <code>errors</code> entry in the response is a non&#8208;empty list of errors, where each error is a map.</p>
 <p>If no errors were encountered during the requested operation, the <code>errors</code> entry should not be present in the result.</p>
 <p>If the <code>data</code> entry in the response is not present, the <code>errors</code> entry in the response must not be empty. It must contain at least one error. The errors it contains should indicate why no data was able to be returned.</p>
@@ -6436,7 +6436,7 @@ Previous versions of this spec did not describe the <code>extensions</code> entr
 </section>
 </section>
 <section id="sec-Serialization-Format" secid="7.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Serialization-Format">7.2</a></span>Serialization Format</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Serialization-Format">7.2</a></span>Serialization Format</h2>
 <p>GraphQL does not require a specific serialization format. However, clients should use a serialization format that supports the major primitives in the GraphQL response. In particular, the serialization format must at least support representations of the following four primitives:</p>
 <ul>
 <li>Map</li>
@@ -6453,7 +6453,7 @@ Previous versions of this spec did not describe the <code>extensions</code> entr
 </ul>
 <p>This is not meant to be an exhaustive list of what a serialization format may encode. For example custom scalars representing a Date, Time, URI, or number with a different precision may be represented in whichever relevant format a given serialization format may support.</p>
 <section id="sec-JSON-Serialization" secid="7.2.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-JSON-Serialization">7.2.1</a></span>JSON Serialization</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-JSON-Serialization">7.2.1</a></span>JSON Serialization</h3>
 <p>JSON is the most common serialization format for GraphQL. Though as mentioned above, GraphQL does not require a specific serialization format.</p>
 <p>When using JSON as a serialization of GraphQL responses, the following JSON values should be used to encode the related GraphQL values:</p>
 <table>
@@ -6485,7 +6485,7 @@ Previous versions of this spec did not describe the <code>extensions</code> entr
 For consistency and ease of notation, examples of responses are given in JSON format throughout this document.</div>
 </section>
 <section id="sec-Serialized-Map-Ordering" secid="7.2.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Serialized-Map-Ordering">7.2.2</a></span>Serialized Map Ordering</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Serialized-Map-Ordering">7.2.2</a></span>Serialized Map Ordering</h3>
 <p>Since the result of evaluating a selection set is ordered, the serialized Map of results should preserve this order by writing the map entries in the same order as those fields were requested as defined by query execution. Producing a serialized response where fields are represented in the same order in which they appear in the request improves human readability during debugging and enables more efficient parsing of responses if the order of properties can be anticipated.</p>
 <p>Serialization formats which represent an ordered map should preserve the order of requested fields as defined by <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span> in the Execution section. Serialization formats which only represent unordered maps but where order is still implicit in the serialization&rsquo;s textual order (such as JSON) should preserve the order of requested fields textually.</p>
 <p>For example, if the request was <code>{ name, age }</code>, a GraphQL service responding in JSON should respond with <code>{ &quot;name&quot;: &quot;Mark&quot;, &quot;age&quot;: 30 }</code> and should not respond with <code>{ &quot;age&quot;: 30, &quot;name&quot;: &quot;Mark&quot; }</code>.</p>
@@ -6497,11 +6497,11 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 </section>
 </section>
 <section id="sec-Appendix-Notation-Conventions" secid="A">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Notation-Conventions">A</a></span>Appendix: Notation Conventions</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Notation-Conventions">A</a></span>Appendix: Notation Conventions</h1>
 <p>This specification document contains a number of notation conventions used to describe technical concepts such as language grammar and semantics as well as runtime algorithms.</p>
 <p>This appendix seeks to explain these notations in greater detail to avoid ambiguity.</p>
 <section id="sec-Context-Free-Grammar" secid="A.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Context-Free-Grammar">A.1</a></span>Context-Free Grammar</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Context-Free-Grammar">A.1</a></span>Context-Free Grammar</h2>
 <p>A context&#8208;free grammar consists of a number of productions. Each production has an abstract symbol called a &ldquo;non&#8208;terminal&rdquo; as its left&#8208;hand side, and zero or more possible sequences of non&#8208;terminal symbols and or terminal characters as its right&#8208;hand side.</p>
 <p>Starting from a single goal non&#8208;terminal symbol, a context&#8208;free grammar describes a language: the set of possible sequences of characters that can be described by repeatedly replacing any non&#8208;terminal in the goal sequence with one of the sequences it is defined by, until all non&#8208;terminal symbols have been replaced by terminal characters.</p>
 <p>Terminals are represented in this document in a monospace font in two forms: a specific Unicode character or sequence of Unicode characters (ie. <span class="spec-t">=</span> or <span class="spec-t">terminal</span>), and prose typically describing a specific Unicode code&#8208;point <span class="spec-string">"Space (U+0020)"</span>. Sequences of Unicode characters only appear in syntactic grammars and represent a <span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span> token of that specific sequence.</p>
@@ -6521,7 +6521,7 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 </div>
 </section>
 <section id="sec-Lexical-and-Syntactical-Grammar" secid="A.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Lexical-and-Syntactical-Grammar">A.2</a></span>Lexical and Syntactical Grammar</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Lexical-and-Syntactical-Grammar">A.2</a></span>Lexical and Syntactical Grammar</h2>
 <p>The GraphQL language is defined in a syntactic grammar where terminal symbols are tokens. Tokens are defined in a lexical grammar which matches patterns of source characters. The result of parsing a source text sequence of Unicode characters first produces a sequence of lexical tokens according to the lexical grammar which then produces abstract syntax tree (AST) according to the syntactical grammar.</p>
 <p>A lexical grammar production describes non&#8208;terminal &ldquo;tokens&rdquo; by patterns of terminal Unicode characters. No &ldquo;whitespace&rdquo; or other ignored characters may appear between any terminal Unicode characters in the lexical grammar production. A lexical grammar production is distinguished by a two colon <code>::</code> definition.</p>
 <div class="spec-production d2" id="Word">
@@ -6533,7 +6533,7 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 </div>
 </section>
 <section id="sec-Grammar-Notation" secid="A.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Notation">A.3</a></span>Grammar Notation</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Notation">A.3</a></span>Grammar Notation</h2>
 <p>This specification uses some additional notation to describe common patterns, such as optional or repeated patterns, or parameterized alterations of the definition of a non&#8208;terminal. This section explains these short&#8208;hand notations and their expanded definitions in the context&#8208;free grammar.</p>
 <section id="sec-Grammar-Notation.Constraints" class="subsec">
 <h6><a href="#sec-Grammar-Notation.Constraints" title="link to this subsection">Constraints</a></h6>
@@ -6609,7 +6609,7 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 </section>
 </section>
 <section id="sec-Grammar-Semantics" secid="A.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Semantics">A.4</a></span>Grammar Semantics</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Semantics">A.4</a></span>Grammar Semantics</h2>
 <p>This specification describes the semantic value of many grammar productions in the form of a list of algorithmic steps.</p>
 <p>For example, this describes how a parser should interpret a string literal:</p>
 <div class="spec-semantic d2">
@@ -6626,7 +6626,7 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 </div>
 </section>
 <section id="sec-Algorithms" secid="A.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">A.5</a></span>Algorithms</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">A.5</a></span>Algorithms</h2>
 <p>This specification describes some algorithms used by the static and runtime semantics, they&rsquo;re defined in the form of a function&#8208;like syntax with the algorithm&rsquo;s name and the arguments it accepts along with a list of algorithmic steps to take in the order listed. Each step may establish references to other values, check various conditions, call other algorithms, and eventually return a value representing the outcome of the algorithm for the provided arguments.</p>
 <p>For example, the following example describes an algorithm named <span class="spec-nt"><span data-name="Fibonacci">Fibonacci</span></span> which accepts a single argument <var data-name="number">number</var>. The algoritm&rsquo;s steps produce the next number in the Fibonacci sequence:</p>
 <div class="spec-algo" id="Fibonacci()">
@@ -6650,9 +6650,9 @@ Algorithms described in this document are written to be easy to understand. Impl
 </section>
 </section>
 <section id="sec-Appendix-Grammar-Summary" secid="B">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary">B</a></span>Appendix: Grammar Summary</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary">B</a></span>Appendix: Grammar Summary</h1>
 <section id="sec-Appendix-Grammar-Summary.Source-Text" secid="B.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary.Source-Text">B.1</a></span>Source Text</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary.Source-Text">B.1</a></span>Source Text</h2>
 <div class="spec-production d2" id="SourceCharacter">
 <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><div class="spec-rhs"><span class="spec-prose">U+0009</span></div>
 <div class="spec-rhs"><span class="spec-prose">U+000A</span></div>
@@ -6661,7 +6661,7 @@ Algorithms described in this document are written to be easy to understand. Impl
 </div>
 </section>
 <section id="sec-Appendix-Grammar-Summary.Ignored-Tokens" secid="B.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary.Ignored-Tokens">B.2</a></span>Ignored Tokens</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary.Ignored-Tokens">B.2</a></span>Ignored Tokens</h2>
 <div class="spec-production d2" id="Ignored">
 <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#UnicodeBOM" data-name="UnicodeBOM">UnicodeBOM</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#WhiteSpace" data-name="WhiteSpace">WhiteSpace</a></span></div>
@@ -6692,7 +6692,7 @@ Algorithms described in this document are written to be easy to understand. Impl
 </div>
 </section>
 <section id="sec-Appendix-Grammar-Summary.Lexical-Tokens" secid="B.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary.Lexical-Tokens">B.3</a></span>Lexical Tokens</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Grammar-Summary.Lexical-Tokens">B.3</a></span>Lexical Tokens</h2>
 <div class="spec-production d2" id="Token">
 <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#Punctuator" data-name="Punctuator">Punctuator</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span></div>
@@ -6800,7 +6800,7 @@ Algorithms described in this document are written to be easy to understand. Impl
 Block string values are interpreted to exclude blank initial and trailing lines and uniform indentation with <span class="spec-call"><a href="#BlockStringValue()" data-name="BlockStringValue">BlockStringValue</a>()</span>.</div>
 </section>
 <section id="sec-Document-Syntax" secid="B.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Document-Syntax">B.4</a></span>Document Syntax</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Document-Syntax">B.4</a></span>Document Syntax</h2>
 <div class="spec-production" id="Document">
 <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Definition" data-name="Definition">Definition</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span></div>
 </div>

--- a/test/productions/output.html
+++ b/test/productions/output.html
@@ -96,27 +96,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 
@@ -908,7 +908,7 @@ pre[class*="language-"] {
 </nav>
 </header>
 <section id="sec-Grammar" secid="1">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar">1</a></span>Grammar</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Grammar">1</a></span>Grammar</h1>
 <p>A production can be on one line</p>
 <div class="spec-production" id="PBJ">
 <span class="spec-nt"><a href="#PBJ" data-name="PBJ">PBJ</a></span><div class="spec-rhs"><span class="spec-nt"><span data-name="Bread">Bread</span></span><span class="spec-nt"><span data-name="PeanutButter">PeanutButter</span></span><span class="spec-nt"><span data-name="Jelly">Jelly</span></span><span class="spec-nt"><span data-name="Bread">Bread</span></span></div>
@@ -949,7 +949,7 @@ pre[class*="language-"] {
 </div>
 </section>
 <section id="sec-Algorithms" secid="2">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">2</a></span>Algorithms</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">2</a></span>Algorithms</h1>
 <p>An algoritm can have no args</p>
 <div class="spec-algo" id="Algo()">
 <span class="spec-call"><a href="#Algo()" data-name="Algo">Algo</a>()</span><ol>

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -96,27 +96,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 
@@ -1039,7 +1039,7 @@ This is not a normative spec for Spec Markdown, but just documentation of this t
 </nav>
 </header>
 <section id="sec-Getting-Started" secid="1">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Getting-Started">1</a></span>Getting Started</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Getting-Started">1</a></span>Getting Started</h1>
 <p>To use Spec Markdown, just write Markdown files. There are some conventions used by Spec Markdown which you can read about in <a href="#sec-Spec-Additions">Spec additions</a>.</p>
 <p>To convert your Markdown files into an HTML spec document, use the <code>spec-md</code> utility.</p>
 <pre><code>npm install -g spec-md
@@ -1057,15 +1057,15 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <p>Spec Markdown also provides utilities for generating and operating on an intermediate representation of the markdown, which you can explore in <a href="#sec-Using-Spec-Markdown">Using Spec Markdown</a>.</p>
 </section>
 <section id="sec-Markdown" secid="2">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Markdown">2</a></span>Markdown</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Markdown">2</a></span>Markdown</h1>
 <p>Spec Markdown is first and foremost <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a>. More specifically, it&rsquo;s based on <a href="https://help.github.com/articles/github-flavored-markdown/">Github&#8208;flavored Markdown</a>.</p>
 <p>This section explains the syntax and capabilities of Markdown that Spec Markdown supports and augments.</p>
 <section id="sec-Character-Encoding" secid="2.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Character-Encoding">2.1</a></span>Character Encoding</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Character-Encoding">2.1</a></span>Character Encoding</h2>
 <p>Markdown allows you to write text which uses &amp;, &lt;, and &gt;. The output HTML will automatically use the <code>&amp;amp;</code>, <code>&amp;lt;</code>, and <code>&amp;gt;</code> entities.</p>
 <p>Well formed HTML entities can be written inline directly. If you write <code>&amp;copy;</code>, it will appear in the HTML output as &copy;.</p>
 <section id="sec-Escape-sequence" secid="2.1.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Escape-sequence">2.1.1</a></span>Escape sequence</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Escape-sequence">2.1.1</a></span>Escape sequence</h3>
 <p>Markdown makes use of certain characters to format text, in order to render one explicitly, place a backslash before it.</p>
 <p>You can type *literal asterisks* instead of emphasis by typing <code>\*literal asterisks\*</code>.</p>
 <p>Escaping does not apply within code.</p>
@@ -1089,16 +1089,16 @@ _   underscore
 </section>
 </section>
 <section id="sec-Inline-formatting" secid="2.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Inline-formatting">2.2</a></span>Inline formatting</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Inline-formatting">2.2</a></span>Inline formatting</h2>
 <p>Markdown allows for inline stylistic and structual formatting. Inline formatting is allowed in paragraphs, list items, and table cells.</p>
 <section id="sec-Inline-HTML" secid="2.2.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Inline-HTML">2.2.1</a></span>Inline HTML</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Inline-HTML">2.2.1</a></span>Inline HTML</h3>
 <p>Markdown is not a replacement for HTML and instead leverages HTML by allowing its use inline within paragraphs, links, etc.</p>
 <p>This code has <blink>blinking</blink> and <em>emphasized</em> formatting.</p>
 <p>Markdown syntax can continue to be <u>used <em>within</em> inline HTML</u>.</p>
 </section>
 <section id="sec-Links" secid="2.2.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Links">2.2.2</a></span>Links</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Links">2.2.2</a></span>Links</h3>
 <p>Use <code>[ ]</code> square brackets to indicate linked text followed immediately by <code>( )</code> parenthesis to describe the URL the text will link to.</p>
 <p>The linked text can contain any other inline formatting.</p>
 <pre><code>This is an [--&gt;*example*&lt;--](https://www.facebook.com) of a link.
@@ -1111,7 +1111,7 @@ Links do not yet support a reference style short&#8208;form.</div>
 Links do not yet support a title attribute.</div>
 </section>
 <section id="sec-Emphasis" secid="2.2.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Emphasis">2.2.3</a></span>Emphasis</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Emphasis">2.2.3</a></span>Emphasis</h3>
 <p>Wrapping asterisks <em>(*)</em> indicate emphasis.</p>
 <pre><code>Example of **bold** and *italic* and ***bold italic***.
 </code></pre>
@@ -1124,7 +1124,7 @@ Links do not yet support a title attribute.</div>
 <p>Example of <em>italic</em> and <strong><em>bold italic</em></strong> or <em><strong>bold italic</strong></em>.</p>
 </section>
 <section id="sec-Inline-Code" secid="2.2.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Code">2.2.4</a></span>Inline Code</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Code">2.2.4</a></span>Inline Code</h3>
 <p>Wrapping back&#8208;ticks <em>(`)</em> indicate inline code, text inside back&#8208;ticks is not formatted, allowing for special characters to be used in inline code without escapes.</p>
 <pre><code>This is an `example` of some inline code.
 </code></pre>
@@ -1134,7 +1134,7 @@ Links do not yet support a title attribute.</div>
 Markdown&rsquo;s double&#8208;back&#8208;tick syntax is not yet supported.</div>
 </section>
 <section id="sec-Images" secid="2.2.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Images">2.2.5</a></span>Images</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Images">2.2.5</a></span>Images</h3>
 <pre><code>![Specs](http://i.imgur.com/aV8o3rE.png)
 </code></pre>
 <p>Produces the following:</p>
@@ -1160,10 +1160,10 @@ the title attribute is not yet supported</div>
 </section>
 </section>
 <section id="sec-Blocks" secid="2.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Blocks">2.3</a></span>Blocks</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Blocks">2.3</a></span>Blocks</h2>
 <p>Markdown allows for block&#8208;level structual formatting. Every block is seperated by at least two new lines. Spec Markdown makes use of Markdown&rsquo;s blocks to produce more specific structural formatting.</p>
 <section id="sec-Block-HTML" secid="2.3.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Block-HTML">2.3.1</a></span>Block HTML</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Block-HTML">2.3.1</a></span>Block HTML</h3>
 <p>Markdown is not a replacement for HTML and instead leverages HTML by allowing its use as complete blocks when separated from surrounding content by blank lines.</p>
 <div id="note-eb0b0" class="spec-note">
 <a href="#note-eb0b0">Note</a>
@@ -1231,7 +1231,7 @@ how do you like your blueeyed boy
 Mister Death
 </pre></section>
 <section id="sec-Blocks.Section-Headers" secid="2.3.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Blocks.Section-Headers">2.3.2</a></span>Section Headers</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Blocks.Section-Headers">2.3.2</a></span>Section Headers</h3>
 <p>Regular Markdown supports two styles of headers, Setext and atx, however Spec Markdown generally only supports atx style headers.</p>
 <pre id="example-d82de" class="spec-example"><a href="#example-d82de">Example № 1</a><code># Header
 </code></pre>
@@ -1245,11 +1245,11 @@ Mister Death
 Spec Markdown requires that documents start with <code>#</code> and that each section contained within is only one level deeper. An &lt;h1&gt; section may only contain &lt;h2&gt; sections.</div>
 </section>
 <section id="sec-Paragraphs" secid="2.3.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Paragraphs">2.3.3</a></span>Paragraphs</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Paragraphs">2.3.3</a></span>Paragraphs</h3>
 <p>Paragraphs are the most simple Markdown blocks. Lines are appended together to form a single &lt;p&gt; tag. Any inline syntax is allowed within a paragraph.</p>
 </section>
 <section id="sec-Lists" secid="2.3.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Lists">2.3.4</a></span>Lists</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Lists">2.3.4</a></span>Lists</h3>
 <p>Markdown lists are lines which each start with either a ordered bullet <code>1.</code> or unordered bullet, <code>*</code>, <code>-</code>, or <code>+</code>. Lists are optionally indented by two spaces.</p>
 <p>Lists can be nested within other lists by indenting by at least two spaces.</p>
 <pre id="example-4d8ec" class="spec-example"><a href="#example-4d8ec">Example № 3</a><code>  1. this
@@ -1269,7 +1269,7 @@ Spec Markdown requires that documents start with <code>#</code> and that each se
 <li>list</li>
 </ol>
 <section id="sec-Task-Lists" secid="2.3.4.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Task-Lists">2.3.4.1</a></span>Task Lists</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Task-Lists">2.3.4.1</a></span>Task Lists</h4>
 <p>Spec Markdown also supports task lists. Start a list item with <code>[ ]</code> or <code>[x]</code> to render a checkbox. This can be useful for keeping your tasks inline with in&#8208;progress draft specifications.</p>
 <pre id="example-f34a9" class="spec-example"><a href="#example-f34a9">Example № 4</a><code>  1. this
   2. [ ] is
@@ -1296,7 +1296,7 @@ Spec Markdown requires that documents start with <code>#</code> and that each se
 </section>
 </section>
 <section id="sec-Code-Block" secid="2.3.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Code-Block">2.3.5</a></span>Code Block</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Code-Block">2.3.5</a></span>Code Block</h3>
 <p>A block of code is formed by either indenting by 4 spaces, or wrapping with <code>```</code> on their own lines.</p>
 <pre><code>```
 const code = sample();
@@ -1306,30 +1306,30 @@ const code = sample();
 </code></pre>
 </section>
 <section id="sec-Block-Quotes" secid="2.3.6">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Block-Quotes">2.3.6</a></span>Block Quotes</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Block-Quotes">2.3.6</a></span>Block Quotes</h3>
 <p>Spec markdown does not yet support Markdown&rsquo;s <code>&gt;</code> style block quotes.</p>
 </section>
 <section id="sec-Horizontal-Rules" secid="2.3.7">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Horizontal-Rules">2.3.7</a></span>Horizontal Rules</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Horizontal-Rules">2.3.7</a></span>Horizontal Rules</h3>
 <p>Spec Markdown does not yet support Markdown&rsquo;s <code>---</code> style &lt;hr&gt;.</p>
 </section>
 <section id="sec-Automatic-Links" secid="2.3.8">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Automatic-Links">2.3.8</a></span>Automatic Links</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Automatic-Links">2.3.8</a></span>Automatic Links</h3>
 <p>Spec Markdown does not yet automatically link urls. </p>
 </section>
 </section>
 </section>
 <section id="sec-Spec-Additions" secid="3">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Spec-Additions">3</a></span>Spec Additions</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Spec-Additions">3</a></span>Spec Additions</h1>
 <p>Spec Markdown makes some additions to Markdown to support cases relevant to writing technical specs and documentation. It attempts to be as minimally invasive as possible, leveraging existing Markdown formatting features whenever possible so Spec Markdown documents may render adequately as regular Markdown.</p>
 <p>Spec Markdown also makes restrictions to the overall format of the Markdown document in order to derive a structure to the entire document.</p>
 <section id="sec-Link-Anything" secid="3.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Link-Anything">3.1</a></span>Link Anything</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Link-Anything">3.1</a></span>Link Anything</h2>
 <p>Everything unique in a Spec Markdown file has a link created for it. Sections each have a link, as do named <a href="#sec-Algorithms">Algorithms</a> and <a href="#sec-Grammar">Grammar</a>. You&rsquo;ll find that <a href="#sec-Note">Notes</a> and <a href="#sec-Examples">Examples</a> are also given stable links based on their contents, just in case things move around.</p>
 <p>However, you can also link <em>anything</em> in a Spec Markdown file. Just highlight any bit of text and a link will be created just for that selection, making referencing specific parts of your document easy. Try it here!</p>
 </section>
 <section id="sec-Title-and-Introduction" secid="3.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Title-and-Introduction">3.2</a></span>Title and Introduction</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Title-and-Introduction">3.2</a></span>Title and Introduction</h2>
 <p>A Spec Markdown document must start with a header which will be used as the title of the document. Any content between this and the next header will become the introduction to the document.</p>
 <p>A Spec Markdown document starts in this form:</p>
 <pre><code># Spec Markdown
@@ -1343,10 +1343,10 @@ Introductory paragraph.
 For backwards&#8208;compatibility, a setext style header can be used for a document title.</div>
 </section>
 <section id="sec-Sections" secid="3.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Sections">3.3</a></span>Sections</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Sections">3.3</a></span>Sections</h2>
 <p>A Spec Markdown document is separated into a sequence and hierarchy of sections. Those sections can then be used as navigation points and can be used to create a table of contents. A section is started by a header and ends at either the next header of similar or greater precedence or the end of the document. A section can contain other sections if their headers are of lower precedence.</p>
 <section id="sec-Sections.Section-Headers" secid="3.3.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Sections.Section-Headers">3.3.1</a></span>Section Headers</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Sections.Section-Headers">3.3.1</a></span>Section Headers</h3>
 <p>Regular Markdown supports two styles of headers, Setext and atx, however Spec Markdown only supports atx style headers as section headers.</p>
 <pre><code># Header
 </code></pre>
@@ -1357,7 +1357,7 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 <p>Spec Markdown also requires that only single <code>#</code> headers appear at the top of a document, and that only a <code>##</code> header (and not a <code>###</code> header) can be contained with the section started by a <code>#</code> header.</p>
 </section>
 <section id="sec-Subsection-Headers" secid="3.3.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Subsection-Headers">3.3.2</a></span>Subsection Headers</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Subsection-Headers">3.3.2</a></span>Subsection Headers</h3>
 <p>While sections are numbered and appear in the table of contents, a subsection is similar but not numbered or in the table of contents.</p>
 <section id="sec-Subsection-Headers.This-is-a-subsection" class="subsec">
 <h6><a href="#sec-Subsection-Headers.This-is-a-subsection" title="link to this subsection">This is a subsection</a></h6>
@@ -1369,22 +1369,22 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 </section>
 </section>
 <section id="sec-Table-of-Contents" secid="3.3.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Table-of-Contents">3.3.3</a></span>Table of Contents</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Table-of-Contents">3.3.3</a></span>Table of Contents</h3>
 <p>A table of contents is automatically generated from the hierarchy of sections in the Spec Markdown document.</p>
 </section>
 <section id="sec-Section-Numbers" secid="3.3.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Section-Numbers">3.3.4</a></span>Section Numbers</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Section-Numbers">3.3.4</a></span>Section Numbers</h3>
 <p>A number is associated with each section, starting with 1. In a hierarchy of sections, the parent sections are joined with dots. This provides an unambiguous location identifier for a given section in a document.</p>
 <p>You can specify these section numbers directly in your Markdown documents if you wish by writing them directly after the <code>#</code> and before the text of the header.</p>
 <section id="sec-Custom-Numbers" secid="3.3.4.8">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Custom-Numbers">3.3.4.8</a></span>Custom Numbers</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Custom-Numbers">3.3.4.8</a></span>Custom Numbers</h4>
 <p>If the section number is written in the document, the last number will be used as the number for that section. This is useful when writing a proposal against an existing spec and wish to reference a particular section.</p>
 <p>The header for this section was written as</p>
 <pre><code>#### 3.2.3.8. Custom Numbers
 </code></pre>
 </section>
 <section id="sec-Appendix-Annex-Sections" secid="3.3.4.9">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Annex-Sections">3.3.4.9</a></span>Appendix / Annex Sections</h5>
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Appendix-Annex-Sections">3.3.4.9</a></span>Appendix / Annex Sections</h4>
 <p>If a top level section is written with a letter, such as <code>A</code> instead of a number, that will begin an Appendix section.</p>
 <pre><code># A. Appendix: Grammar
 </code></pre>
@@ -1392,10 +1392,10 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 </section>
 </section>
 <section id="sec-Smart-Characters" secid="3.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Smart-Characters">3.4</a></span>Smart Characters</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Smart-Characters">3.4</a></span>Smart Characters</h2>
 <p>The Spec Markdown renderer will replace easy to type characters like quotes and dashes with their appropriate typographic entities. These replacements will not occur within blocks of code.</p>
 <section id="sec-Quotes-and-Dashes" secid="3.4.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Quotes-and-Dashes">3.4.1</a></span>Quotes and Dashes</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Quotes-and-Dashes">3.4.1</a></span>Quotes and Dashes</h3>
 <p>Prose text has &ldquo;smart quotes&rdquo;, hyphens, en&#8208;dashes and em&#8208;dashes&mdash;you shouldn&rsquo;t have to think about it, they&rsquo;ll just work.</p>
 <p>For example, a quote of a quote (with an inner apostrophe and emphasis for flair):</p>
 <p><code>&quot;She told me that &#x27;he isn&#x27;t here right *now*&#x27; - so I left.&quot;</code></p>
@@ -1403,20 +1403,20 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 <p>&ldquo;She told me that&lsquo;he isn&rsquo;t here right <em>now</em>&rsquo; &ndash; so I left.&rdquo;</p>
 </section>
 <section id="sec-Math" secid="3.4.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Math">3.4.2</a></span>Math</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Math">3.4.2</a></span>Math</h3>
 <p>Math operators like &ge;, &le;, and &cong; can be written as <code>&gt;=</code>, <code>&lt;=</code>, and <code>~=</code>.</p>
 </section>
 <section id="sec-Arrows" secid="3.4.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Arrows">3.4.3</a></span>Arrows</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Arrows">3.4.3</a></span>Arrows</h3>
 <p>Smart arrows &rarr; and &larr; and &harr; can be written as <code>-&gt;</code>, <code>&lt;-</code> and <code>&lt;-&gt;</code>.</p>
 <p>Fat smart arrows &rArr; and &lArr; and &hArr; can be written as <code>=&gt;</code>, <code>&lt;==</code> and <code>&lt;=&gt;</code>.</p>
 </section>
 <section id="sec-Additional-escape-sequence" secid="3.4.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Additional-escape-sequence">3.4.4</a></span>Additional escape sequence</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Additional-escape-sequence">3.4.4</a></span>Additional escape sequence</h3>
 <p>Spec Markdown allows escaping &lt; &gt; and | character with <code>\&gt;</code>, <code>\&lt;</code>, and <code>\|</code>.</p>
 </section>
 <section id="sec-Tables" secid="3.4.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Tables">3.4.5</a></span>Tables</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Tables">3.4.5</a></span>Tables</h3>
 <p>Similar to Github flavored Markdown</p>
 <pre><code>| This | is a | table |
 | ---- | ---- | ----- |
@@ -1438,7 +1438,7 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 </section>
 </section>
 <section id="sec-Note" secid="3.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Note">3.5</a></span>Note</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Note">3.5</a></span>Note</h2>
 <p>Notes can be written inline with a spec document, and are often helpful to supply non&#8208;normative explanatory text or caveats in a differently formatted style. Case insensitive, the <code>:</code> is optional.</p>
 <p>Notes automatically have short links generated for them. If the contents of the note changes, so will the link URL. However if a note moves around, or content around the note changes the existing links will still point to the right place, very useful for consistently evolving specifications!</p>
 <pre><code>Note: Notes are awesome.
@@ -1449,7 +1449,7 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 Notes are awesome.</div>
 </section>
 <section id="sec-Todo" secid="3.6">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Todo">3.6</a></span>Todo</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Todo">3.6</a></span>Todo</h2>
 <p>It&rsquo;s often helpful to write a draft of a document and leave &ldquo;to&#8208;do&rdquo; comments in not&#8208;yet&#8208;completed sections. Case insensitive, the <code>:</code> is optional.</p>
 <pre><code>TODO: finish this section
 </code></pre>
@@ -1461,7 +1461,7 @@ finish this section</div>
 You can also write <code>TK</code> in place of <code>TODO</code>, nerds.</div>
 </section>
 <section id="sec-Syntax-Highlighting" secid="3.7">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Syntax-Highlighting">3.7</a></span>Syntax Highlighting</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Syntax-Highlighting">3.7</a></span>Syntax Highlighting</h2>
 <p>Spec Markdown will apply syntax highlighting to blocks of code if a github&#8208;flavored&#8208;markdown style language is supplied.</p>
 <p>You may provide a <code>highlight</code> function as an option to customize this behavior.</p>
 <p>To render this highlighted javascript:</p>
@@ -1479,7 +1479,7 @@ const baz = foo(&quot;bar&quot;);
 <pre><code><span class="token keyword">const</span> baz <span class="token operator">=</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token string">"bar"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 </code></pre>
 <section id="sec-Examples" secid="3.7.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Examples">3.7.1</a></span>Examples</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Examples">3.7.1</a></span>Examples</h3>
 <p>Spec Markdown helps you write examples, visually indicaticating the difference from normative code blocks, and generating permalinks to those examples. Just write <code>example</code> after the <code>```</code>.</p>
 <pre><code>```example
 const great = useOf.example(&quot;code&quot;);
@@ -1496,7 +1496,7 @@ const great = useOf.example(&quot;code&quot;);
 </code></pre>
 </section>
 <section id="sec-Counter-Examples" secid="3.7.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Counter-Examples">3.7.2</a></span>Counter Examples</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Counter-Examples">3.7.2</a></span>Counter Examples</h3>
 <p>In addition to examples, Spec Markdown helps you write <em>counter&#8208;examples</em>, which are examples of things you should not do. These are visually indicated as different from normative code blocks and other examples. Just write <code>counter-example</code> after the <code>```</code> (and optional language).</p>
 <pre><code>```js counter-example
 const shit = dontSwear();
@@ -1507,19 +1507,19 @@ const shit = dontSwear();
 </section>
 </section>
 <section id="sec-Imports" secid="3.8">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Imports">3.8</a></span>Imports</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Imports">3.8</a></span>Imports</h2>
 <p>When compiled, an import reference will be inlined into the same document. An import reference looks like a link to a &ldquo;.md&rdquo; file as a single paragraph.</p>
 <pre><code>[AnythingGoesHere](SomeName.md)
 </code></pre>
 <p>You can optionally prefix the import reference with <code>#</code> characters to describe at what section level the import should apply. By default an import reference will be imported as a child of the current section.</p>
 </section>
 <section id="sec-Inline-editing" secid="3.9">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Inline-editing">3.9</a></span>Inline editing</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Inline-editing">3.9</a></span>Inline editing</h2>
 <p>A portion of the <a href="http://criticmarkup.com/">CriticMarkup</a> spec is supported.</p>
 <p>For example, we can <ins>add</ins> or <del>remove</del> text with the <code>{++add++}</code> or <code>{--remove--}</code> syntax.</p>
 </section>
 <section id="sec-Block-editing" secid="3.10">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Block-editing">3.10</a></span>Block editing</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Block-editing">3.10</a></span>Block editing</h2>
 <p>We can also add and remove entire blocks of content, by using <code>{++</code> or <code>{--</code> on their own line with empty lines on either side:</p>
 <div class="spec-added"><p>These paragraphs</p>
 <p>have been <em>added</em>.</p>
@@ -1552,7 +1552,7 @@ have been *removed*.
 imports and section headers cannot be included in a added or removed section to preserve the ability to render a table of contents.</div>
 </section>
 <section id="sec-Algorithms" secid="3.11">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">3.11</a></span>Algorithms</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">3.11</a></span>Algorithms</h2>
 <p>Specifications for procedures or algorithms can be defined in terms of nested markdown lists. These lists can be of any kind, but will always have ordered formatting. The bullet labeling for algorithms is specific will cycle between decimal, lower&#8208;alpha, and lower&#8208;roman.</p>
 <p>An algorithm definition also describes its arguments in terms of variables.</p>
 <pre><code>Algorithm(arg) :
@@ -1582,11 +1582,11 @@ imports and section headers cannot be included in a added or removed section to 
 </div>
 </section>
 <section id="sec-Grammar" secid="3.12">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Grammar">3.12</a></span>Grammar</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar">3.12</a></span>Grammar</h2>
 <p>Spec Markdown makes it easier to describe context&#8208;free grammatical productions.</p>
 <p>Grammars are defined by a sequence of <em>terminal</em> characters or sequence of characters, which are then referenced by <em>non&#8208;terminal</em> rules. The definition of a non&#8208;terminal is referred to as a <em>production</em>.</p>
 <section id="sec-Grammar-Production" secid="3.12.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Production">3.12.1</a></span>Grammar Production</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Production">3.12.1</a></span>Grammar Production</h3>
 <p>The <code>:</code> token indicates an &ldquo;is defined as&rdquo; production for a non&#8208;terminal, where a single definition can be written directly after the <code>:</code>.</p>
 <pre><code>PBJ : Bread PeanutButter Jelly Bread
 </code></pre>
@@ -1618,7 +1618,7 @@ imports and section headers cannot be included in a added or removed section to 
 </div>
 </section>
 <section id="sec-Production-types" secid="3.12.2">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Production-types">3.12.2</a></span>Production types</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Production-types">3.12.2</a></span>Production types</h3>
 <p>Often languages wish to specify different types of grammar productions, such as lexical or syntactical, or if certain characters line whitespace or newlines are permitted between symbols in the right&#8208;hand&#8208;side. Spec&#8208;md allows this this distinction based on the number of colons:</p>
 <pre><code>TypeOne : `type` `one`
 
@@ -1638,7 +1638,7 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-One-of" secid="3.12.3">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-One-of">3.12.3</a></span>One of</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-One-of">3.12.3</a></span>One of</h3>
 <p>If each definition option is a single token, it can be expressed as a &ldquo;one of&rdquo; expression instead of a markdown list.</p>
 <pre><code>AssignmentOperator : one of *= `/=` %= += -= &lt;&lt;= &gt;&gt;= &gt;&gt;&gt;= &amp;= ^= |=
 </code></pre>
@@ -1686,11 +1686,11 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-Non-Terminal-Token" secid="3.12.4">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Non-Terminal-Token">3.12.4</a></span>Non Terminal Token</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Non-Terminal-Token">3.12.4</a></span>Non Terminal Token</h3>
 <p>Non&#8208;terminal tokens with a defined as a grammar production can be referred to in other grammar productions. Non&#8208;terminals must match the regular expression <span class="spec-rx">/[A-Z][_a-zA-Z]*/</span>. That is, they must start with an uppercase letter, followed by any number of letters or underscores.</p>
 </section>
 <section id="sec-Prose" secid="3.12.5">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Prose">3.12.5</a></span>Prose</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Prose">3.12.5</a></span>Prose</h3>
 <p>Grammars can describe arbitrary rules by using prose within a grammar definition by using <code>&quot;quotes&quot;</code>.</p>
 <pre><code>Sandwich : Bread &quot;Any kind of topping&quot; Bread
 </code></pre>
@@ -1700,7 +1700,7 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-Terminal-Token" secid="3.12.6">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Terminal-Token">3.12.6</a></span>Terminal Token</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Terminal-Token">3.12.6</a></span>Terminal Token</h3>
 <p>Terminal tokens refer to a character or sequence of characters. They can be written unadorned in the grammar definition.</p>
 <pre><code>BalancedParens : ( BalancedParens )
 </code></pre>
@@ -1724,7 +1724,7 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-Regular-Expression" secid="3.12.7">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Regular-Expression">3.12.7</a></span>Regular Expression</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Regular-Expression">3.12.7</a></span>Regular Expression</h3>
 <p>When a grammar is intended to be interpretted as a single token and can be clearly written as a regular expression, you can do so directly.</p>
 <pre><code>UppercaseWord : /[A-Z][a-z]*/
 </code></pre>
@@ -1734,7 +1734,7 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-Quantifiers" secid="3.12.8">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Quantifiers">3.12.8</a></span>Quantifiers</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Quantifiers">3.12.8</a></span>Quantifiers</h3>
 <p>Tokens can be followed by quantifiers to alter their meaning and as a short&#8208;hand for common patterns of optionality and repetition.</p>
 <section id="sec-Quantifiers.Optional-Tokens" class="subsec">
 <h6><a href="#sec-Quantifiers.Optional-Tokens" title="link to this subsection">Optional Tokens</a></h6>
@@ -1821,7 +1821,7 @@ TypeThree ::: `type` `three`
 </section>
 </section>
 <section id="sec-Conditional-Parameters" secid="3.12.9">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Conditional-Parameters">3.12.9</a></span>Conditional Parameters</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Conditional-Parameters">3.12.9</a></span>Conditional Parameters</h3>
 <p>It can be a useful short&#8208;hand to provide conditional parameters when defining a non&#8208;terminal token rather than defining two very similar non&#8208;terminals.</p>
 <p>A conditional parameter is written in braces <code>Token[Param]</code> and renders as <span class="spec-nt"><span data-name="Token">Token</span><span class="spec-params"><span class="spec-param">Param</span></span></span>. When used in definitions is shorthand for two symbol definitions: one appended with that parameter name, the other without.</p>
 <pre><code>Example[WithCondition] : &quot;Definition TBD&quot;
@@ -1928,7 +1928,7 @@ TypeThree ::: `type` `three`
 <p><span class="spec-quantified"><span class="spec-nt"><a href="#Example" data-name="Example">Example</a><span class="spec-params"><span class="spec-param">P</span><span class="spec-param conditional">Q</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span></p>
 </section>
 <section id="sec-Constraints" secid="3.12.10">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Constraints">3.12.10</a></span>Constraints</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Constraints">3.12.10</a></span>Constraints</h3>
 <p>Any token can be followed by &ldquo;but not&rdquo; or &ldquo;but not one of&rdquo; to place a further constraint on the previous token:</p>
 <pre><code>Example : A B but not foo or bar
 </code></pre>
@@ -1945,7 +1945,7 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-Meta-Tokens" secid="3.12.11">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Meta-Tokens">3.12.11</a></span>Meta Tokens</h4>
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Meta-Tokens">3.12.11</a></span>Meta Tokens</h3>
 <p>Spec Markdown can specify some tokens which do not consume any characters.</p>
 <p>The empty set, written <code>[empty]</code> appears as <span class="spec-empty">[empty]</span> can be used to define a non&#8208;terminal as matching no terminal or non&#8208;terminal tokens.</p>
 <pre><code>Example : [empty]
@@ -1981,7 +1981,7 @@ TypeThree ::: `type` `three`
 </section>
 </section>
 <section id="sec-Grammar-Semantics" secid="3.13">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Semantics">3.13</a></span>Grammar Semantics</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Semantics">3.13</a></span>Grammar Semantics</h2>
 <p>Once grammar is defined, it can be useful to define the semantics of the grammar in terms of algorithm steps. A single grammar definition followed by a list is interpretted as a grammar semantic:</p>
 <pre><code>PBJ : Bread PeanutButter Jelly Bread
 
@@ -2010,7 +2010,7 @@ TypeThree ::: `type` `three`
 </div>
 </section>
 <section id="sec-Value-Literals" secid="3.14">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Value-Literals">3.14</a></span>Value Literals</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Value-Literals">3.14</a></span>Value Literals</h2>
 <p>Value literals allow any text to refer to a value which has semantic meaning in the specification by wrapping it in <code>{ }</code> curly brace characters.</p>
 <pre><code>I can reference {foo}, {&quot;foo&quot;}, {null}, {true}.
 </code></pre>
@@ -2042,7 +2042,7 @@ TypeThree ::: `type` `three`
 </section>
 </section>
 <section id="sec-Biblio" secid="3.15">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Biblio">3.15</a></span>Biblio</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Biblio">3.15</a></span>Biblio</h2>
 <p>By supplying a <code>&quot;biblio&quot;</code> key in a metadata file, you can have Algorithm calls and Non&#8208;terminal tokens which are not defined in this spec to link to where they are defined.</p>
 <pre><code>spec-md -m metadata.json myspec.md
 </code></pre>
@@ -2081,7 +2081,7 @@ TypeThree ::: `type` `three`
 </section>
 </section>
 <section id="sec-Using-Spec-Markdown" secid="A">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Using-Spec-Markdown">A</a></span>Using Spec Markdown</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Using-Spec-Markdown">A</a></span>Using Spec Markdown</h1>
 <p>If installed globally, using <code>spec-md</code> as a shell executable is the easiest way to use Spec Markdown. The <code>spec-md</code> executable expects a filepath to a Markdown document as input and outputs HTML on stdout. Use <code>&gt;</code> to write stdout to a file.</p>
 <pre><code>npm install -g spec-md
 spec-md ./path/to/markdown.md &gt; ./path/to/output.html
@@ -2103,7 +2103,7 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <li><span class="spec-call"><span data-name="visit">visit</span>(<var data-name="ast">ast</var>, <var data-name="visitor">visitor</var>)</span> takes an <var data-name="ast">ast</var> and a <var data-name="visitor">visitor</var>. It walks over the <var data-name="ast">ast</var> in a depth&#8208;first&#8208;traversal calling the <var data-name="visitor">visitor</var> along the way.</li>
 </ul>
 <section id="sec-Print-Options" secid="A.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Print-Options">A.1</a></span>Print Options</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Print-Options">A.1</a></span>Print Options</h2>
 <p>The <span class="spec-call"><span data-name="html">html</span>(<var data-name="filePath">filePath</var>, <var data-name="options">options</var>)</span> and <span class="spec-call"><span data-name="print">print</span>(<var data-name="filePath">filePath</var>)</span> functions both take <var data-name="options">options</var> as an optional second argument. These options allow for customization control over the returned HTML, more options may be added in the future.</p>
 <ul>
 <li><strong>highlight</strong> - a function which is called when blocks of code are encountered, with the first argument as the string of code, the second argument being the language specified. This function should return well formed HTML, complete with escaped special characters.</li>
@@ -2111,7 +2111,7 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 </ul>
 </section>
 <section id="sec-Hot-rebuilding-with-nodemon" secid="A.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Hot-rebuilding-with-nodemon">A.2</a></span>Hot rebuilding with nodemon</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Hot-rebuilding-with-nodemon">A.2</a></span>Hot rebuilding with nodemon</h2>
 <p>The <code>spec-md</code> shell executable follows the <a href="http://www.faqs.org/docs/artu/ch01s06.html">Unix Philosophy</a> of doing one thing and doing it well. Try out <code>nodemon</code> to continuously rebuild the HTML output as you edit the markdown specification:</p>
 <pre><code>npm install -g nodemon
 nodemon --exec &quot;spec-md &gt; ./path/to/output.html&quot; ./path/to/markdown.md
@@ -2119,10 +2119,10 @@ nodemon --exec &quot;spec-md &gt; ./path/to/output.html&quot; ./path/to/markdown
 </section>
 </section>
 <section id="sec-Contributing-to-Spec-Markdown" secid="B">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Contributing-to-Spec-Markdown">B</a></span>Contributing to Spec Markdown</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Contributing-to-Spec-Markdown">B</a></span>Contributing to Spec Markdown</h1>
 <p>We want to make contributing to this project as easy and transparent as possible. Hopefully this document makes the process for contributing clear and answers any questions you may have. If not, feel free to open an <a href="https://github.com/leebyron/spec-md/issues">Issue</a>.</p>
 <section id="sec-Pull-Requests" secid="B.1">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Pull-Requests">B.1</a></span>Pull Requests</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Pull-Requests">B.1</a></span>Pull Requests</h2>
 <p>All active development of Spec Markdown happens on GitHub. We actively welcome your <a href="https://help.github.com/articles/creating-a-pull-request">pull requests</a>.</p>
 <ol>
 <li><a href="https://github.com/leebyron/spec-md/">Fork the repo</a> and create your branch from <code>master</code>.</li>
@@ -2133,15 +2133,15 @@ nodemon --exec &quot;spec-md &gt; ./path/to/output.html&quot; ./path/to/markdown
 </ol>
 </section>
 <section id="sec--master-is-unsafe" secid="B.2">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec--master-is-unsafe">B.2</a></span>`master` is unsafe</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec--master-is-unsafe">B.2</a></span>`master` is unsafe</h2>
 <p>We will do our best to keep <code>master</code> in good shape, with tests passing at all times. But in order to move fast, we might make API changes that your application might not be compatible with. We will do our best to communicate these changes and always <a href="http://semver.org/">version</a> appropriately so you can lock into a specific version if need be. If any of this is worrysome to you, just use <a href="https://www.npmjs.org/package/spec-md">npm</a>.</p>
 </section>
 <section id="sec-Issues" secid="B.3">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Issues">B.3</a></span>Issues</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Issues">B.3</a></span>Issues</h2>
 <p>We use GitHub issues to track public bugs and requests. Please ensure your bug description is clear and has sufficient instructions to be able to reproduce the issue. The best way is to provide a reduced test case on jsFiddle or jsBin.</p>
 </section>
 <section id="sec-Coding-Style" secid="B.4">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-Coding-Style">B.4</a></span>Coding Style</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Coding-Style">B.4</a></span>Coding Style</h2>
 <ul>
 <li>2 spaces for indentation (no tabs)</li>
 <li>80 character line length strongly preferred.</li>
@@ -2152,7 +2152,7 @@ nodemon --exec &quot;spec-md &gt; ./path/to/output.html&quot; ./path/to/markdown
 </ul>
 </section>
 <section id="sec-License" secid="B.5">
-<h3><span class="spec-secid" title="link to this section"><a href="#sec-License">B.5</a></span>License</h3>
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-License">B.5</a></span>License</h2>
 <p>By contributing to Spec Markdown, you agree that your contributions will be licensed under its MIT license. </p>
 </section>
 </section>

--- a/test/runner.js
+++ b/test/runner.js
@@ -9,6 +9,7 @@ runTests([
   ['../README.md', 'readme/ast.json', 'readme/output.html'],
   ['graphql-spec/GraphQL.md', 'graphql-spec/ast.json', 'graphql-spec/output.html'],
   ['simple-header/input.md', 'simple-header/ast.json', 'simple-header/output.html'],
+  ['sections/input.md', 'sections/ast.json', 'sections/output.html'],
   ['tables/input.md', 'tables/ast.json', 'tables/output.html'],
   ['task-lists/input.md', 'task-lists/ast.json', 'task-lists/output.html'],
   ['duplicated-notes/input.md', 'duplicated-notes/ast.json', 'duplicated-notes/output.html'],

--- a/test/sections/ast.json
+++ b/test/sections/ast.json
@@ -1,0 +1,84 @@
+{
+  "type": "Document",
+  "title": {
+    "type": "DocumentTitle",
+    "value": "Sections"
+  },
+  "contents": [
+    {
+      "type": "Paragraph",
+      "contents": [
+        {
+          "type": "Text",
+          "value": "Nested"
+        }
+      ]
+    },
+    {
+      "type": "Section",
+      "secID": null,
+      "title": "Level 1",
+      "contents": [
+        {
+          "type": "Section",
+          "secID": null,
+          "title": "Level 2",
+          "contents": [
+            {
+              "type": "Section",
+              "secID": null,
+              "title": "Level #3",
+              "contents": [
+                {
+                  "type": "Section",
+                  "secID": null,
+                  "title": "Level 4",
+                  "contents": [
+                    {
+                      "type": "Section",
+                      "secID": null,
+                      "title": "Level 5",
+                      "contents": [
+                        {
+                          "type": "Section",
+                          "secID": null,
+                          "title": "Level 6",
+                          "contents": [
+                            {
+                              "type": "Paragraph",
+                              "contents": [
+                                {
+                                  "type": "Text",
+                                  "value": "Wow"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "Subsection",
+                              "title": "Sub section",
+                              "contents": [
+                                {
+                                  "type": "Paragraph",
+                                  "contents": [
+                                    {
+                                      "type": "Text",
+                                      "value": "This is a subsection\n"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/sections/input.md
+++ b/test/sections/input.md
@@ -1,0 +1,21 @@
+# Sections
+
+Nested
+
+# Level 1
+
+## Level 2 ##
+
+### Level #3
+
+#### Level 4
+
+##### Level 5
+
+###### Level 6 ########
+
+Wow
+
+**Sub section**
+
+This is a subsection

--- a/test/sections/output.html
+++ b/test/sections/output.html
@@ -2,7 +2,7 @@
 <!-- Built with spec-md https://spec-md.com -->
 <html>
 <head><meta charset="utf-8">
-<title>Simple Header</title>
+<title>Sections</title>
 <style>body {
   color: #333333;
   font: 13pt/18pt Cambria, "Palatino Linotype", Palatino, "Liberation Serif", serif;
@@ -897,24 +897,99 @@ pre[class*="language-"] {
 </head>
 <body><article>
 <header>
-<h1>Simple Header</h1>
+<h1>Sections</h1>
 <section id="intro">
-<p>This is a simple document with only a header. </p>
+<p>Nested</p>
 </section>
 <nav class="spec-toc">
 <div class="title">Contents</div>
 <ol>
+<li><a href="#sec-Level-1"><span class="spec-secid">1</span>Level 1</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1" /><label for="_toggle_1"></label>
+<ol>
+<li><a href="#sec-Level-2"><span class="spec-secid">1.1</span>Level 2</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1" /><label for="_toggle_1.1"></label>
+<ol>
+<li><a href="#sec-Level-3"><span class="spec-secid">1.1.1</span>Level #3</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1" /><label for="_toggle_1.1.1"></label>
+<ol>
+<li><a href="#sec-Level-4"><span class="spec-secid">1.1.1.1</span>Level 4</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1.1" /><label for="_toggle_1.1.1.1"></label>
+<ol>
+<li><a href="#sec-Level-5"><span class="spec-secid">1.1.1.1.1</span>Level 5</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1.1.1" /><label for="_toggle_1.1.1.1.1"></label>
+<ol>
+<li><a href="#sec-Level-6"><span class="spec-secid">1.1.1.1.1.1</span>Level 6</a></li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
+</li>
 </ol>
 </nav>
 </header>
+<section id="sec-Level-1" secid="1">
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Level-1">1</a></span>Level 1</h1>
+<section id="sec-Level-2" secid="1.1">
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Level-2">1.1</a></span>Level 2</h2>
+<section id="sec-Level-3" secid="1.1.1">
+<h3><span class="spec-secid" title="link to this section"><a href="#sec-Level-3">1.1.1</a></span>Level #3</h3>
+<section id="sec-Level-4" secid="1.1.1.1">
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Level-4">1.1.1.1</a></span>Level 4</h4>
+<section id="sec-Level-5" secid="1.1.1.1.1">
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Level-5">1.1.1.1.1</a></span>Level 5</h5>
+<section id="sec-Level-6" secid="1.1.1.1.1.1">
+<h6><span class="spec-secid" title="link to this section"><a href="#sec-Level-6">1.1.1.1.1.1</a></span>Level 6</h6>
+<p>Wow</p>
+<section id="sec-Level-6.Sub-section" class="subsec">
+<h6><a href="#sec-Level-6.Sub-section" title="link to this subsection">Sub section</a></h6>
+<p>This is a subsection </p>
+</section>
+</section>
+</section>
+</section>
+</section>
+</section>
+</section>
 </article>
 <footer>
 Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</footer>
 <input hidden class="spec-sidebar-toggle" type="checkbox" id="spec-sidebar-toggle" aria-hidden /><label for="spec-sidebar-toggle" aria-hidden>&#x2630;</label>
 <div class="spec-sidebar" aria-hidden>
 <div class="spec-toc">
-<div class="title"><a href="#">Simple Header</a></div>
-<ol></ol>
+<div class="title"><a href="#">Sections</a></div>
+<ol><li id="_sidebar_1"><a href="#sec-Level-1"><span class="spec-secid">1</span>Level 1</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1" /><label for="_sidebar_toggle_1"></label>
+<ol>
+<li id="_sidebar_1.1"><a href="#sec-Level-2"><span class="spec-secid">1.1</span>Level 2</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1" /><label for="_sidebar_toggle_1.1"></label>
+<ol>
+<li id="_sidebar_1.1.1"><a href="#sec-Level-3"><span class="spec-secid">1.1.1</span>Level #3</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1" /><label for="_sidebar_toggle_1.1.1"></label>
+<ol>
+<li id="_sidebar_1.1.1.1"><a href="#sec-Level-4"><span class="spec-secid">1.1.1.1</span>Level 4</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1.1" /><label for="_sidebar_toggle_1.1.1.1"></label>
+<ol>
+<li id="_sidebar_1.1.1.1.1"><a href="#sec-Level-5"><span class="spec-secid">1.1.1.1.1</span>Level 5</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1.1.1" /><label for="_sidebar_toggle_1.1.1.1.1"></label>
+<ol>
+<li id="_sidebar_1.1.1.1.1.1"><a href="#sec-Level-6"><span class="spec-secid">1.1.1.1.1.1</span>Level 6</a></li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
+</li>
+</ol>
 </div>
 <script>(function(){for(var e,t=[],n=document.getElementsByTagName("section"),o=0;o<n.length;o++)n[o].getAttribute("secid")&&t.push(n[o]);var i=window.scrollY,r=!1;function c(n){for(var o,i=n+document.documentElement.clientHeight/4,r=t.length-1;r>=0;r--)if(t[r].offsetTop<i){o=t[r];break}var c=o&&o.getAttribute("secid");c!==e&&(e&&d(e,!1),c&&d(c,!0),e=c)}function d(e,t){document.getElementById("_sidebar_"+e).className=t?"viewing":"";for(var n=e.split(".");n.length;){var o=document.getElementById("_sidebar_toggle_"+n.join("."));o&&(o.checked=t),n.pop()}}window.addEventListener("scroll",(function(e){i=window.scrollY,r||(r=!0,window.requestAnimationFrame((function(){c(i),r=!1})))})),c(window.scrollY);})()</script>
 </div>

--- a/test/tables/output.html
+++ b/test/tables/output.html
@@ -96,27 +96,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 
@@ -907,7 +907,7 @@ pre[class*="language-"] {
 </nav>
 </header>
 <section id="sec-Tables" secid="1">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Tables">1</a></span>Tables</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Tables">1</a></span>Tables</h1>
 <p>Naked table</p>
 <table>
 <thead><tr>
@@ -974,7 +974,7 @@ pre[class*="language-"] {
 </table>
 </section>
 <section id="sec-Not-tables" secid="2">
-<h2><span class="spec-secid" title="link to this section"><a href="#sec-Not-tables">2</a></span>Not tables</h2>
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Not-tables">2</a></span>Not tables</h1>
 <p>Alpha ----- a </p>
 </section>
 </article>

--- a/test/task-lists/output.html
+++ b/test/task-lists/output.html
@@ -96,27 +96,27 @@ a:hover {
 
 /* Section headers */
 
-h1, h2, h3, h4, h5, h6, h7, h8 {
+h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   margin: 3em 0 1em;
   position: relative;
 }
 
-h1 {
+header > h1 {
   font-size: 1.5em;
   margin: 6em 0 3em;
 }
 
-h2 {
+h1 {
   font-size: 1.5em;
   margin-top: 5em;
 }
 
-h3, h4 {
+h2, h3 {
   font-size: 1.25em;
 }
 
-h5, h6 {
+h4, h5, h6 {
   font-size: 1em;
 }
 


### PR DESCRIPTION
Supports standard markdown headers up to H6 and uses the appropriate header tag (eg `#` to `h1`) in the rendered output. This is potentially breaking since previously `#` rendered a `h2`.