### PR TITLE
Resolve link urls from biblio

### DIFF
--- a/src/print.js
+++ b/src/print.js
@@ -486,8 +486,10 @@ function printAll(list, options) {
         case 'InlineCode':
           return '<code>' + escapeCode(node.code) + '</code>';
 
-        case 'Link':
-          return '<a href="' + encodeURI(node.url) + '">' + join(node.contents) + '</a>';
+        case 'Link': {
+          const url = resolveLinkUrl(node.url, options);
+          return '<a href="' + encodeURI(url) + '">' + join(node.contents) + '</a>';
+        }
 
         case 'Image':
           return (
@@ -772,6 +774,23 @@ function link(node, id, options, doHighlight) {
 
 function anchorize(title) {
   return title.replace(/[^A-Za-z0-9\-_]+/g, '-');
+}
+
+function resolveLinkUrl(url, options) {
+  if (url.startsWith('./') || url.startsWith('#')) {
+    const hashIdx = url.indexOf('#')
+    if (hashIdx !== -1) {
+      // Try to resolve GFM references to spec-md references.
+      const hashId = url.slice(hashIdx + 1)
+      const ref = options.biblio[hashId]
+      if (ref) return ref
+      const sectionRef = options.biblio['sec-' + hashId]
+      if (sectionRef) return sectionRef
+      const callRef = options.biblio[hashId + '()']
+      if (callRef) return callRef
+    }
+  }
+  return url
 }
 
 const ESCAPE_CODE_REGEX = /[><"'&]/g;

--- a/test/sections/ast.json
+++ b/test/sections/ast.json
@@ -29,6 +29,31 @@
               "secID": null,
               "title": "Level #3",
               "contents": [
+                [
+                  {
+                    "type": "Section",
+                    "secID": null,
+                    "title": "Imported level 1",
+                    "contents": [
+                      {
+                        "type": "Section",
+                        "secID": null,
+                        "title": "Imported level 2",
+                        "contents": [
+                          {
+                            "type": "Paragraph",
+                            "contents": [
+                              {
+                                "type": "Text",
+                                "value": "This has been imported\n"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
                 {
                   "type": "Section",
                   "secID": null,
@@ -62,7 +87,53 @@
                                   "contents": [
                                     {
                                       "type": "Text",
-                                      "value": "This is a subsection\n"
+                                      "value": "This is a subsection"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "Paragraph",
+                                  "contents": [
+                                    {
+                                      "type": "Text",
+                                      "value": "This links to "
+                                    },
+                                    {
+                                      "type": "Link",
+                                      "contents": [
+                                        {
+                                          "type": "Text",
+                                          "value": "Level 2"
+                                        }
+                                      ],
+                                      "url": "#Level-2"
+                                    },
+                                    {
+                                      "type": "Text",
+                                      "value": "."
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "Paragraph",
+                                  "contents": [
+                                    {
+                                      "type": "Text",
+                                      "value": "This links to "
+                                    },
+                                    {
+                                      "type": "Link",
+                                      "contents": [
+                                        {
+                                          "type": "Text",
+                                          "value": "Imported level 2"
+                                        }
+                                      ],
+                                      "url": "./imported.md#Imported-level-2"
+                                    },
+                                    {
+                                      "type": "Text",
+                                      "value": ".\n"
                                     }
                                   ]
                                 }

--- a/test/sections/imported.md
+++ b/test/sections/imported.md
@@ -1,0 +1,5 @@
+# Imported level 1
+
+## Imported level 2
+
+This has been imported

--- a/test/sections/input.md
+++ b/test/sections/input.md
@@ -8,6 +8,8 @@ Nested
 
 ### Level #3
 
+#### [Imported](./imported.md)
+
 #### Level 4
 
 ##### Level 5
@@ -19,3 +21,7 @@ Wow
 **Sub section**
 
 This is a subsection
+
+This links to [Level 2](#Level-2).
+
+This links to [Imported level 2](./imported.md#Imported-level-2).

--- a/test/sections/output.html
+++ b/test/sections/output.html
@@ -913,13 +913,19 @@ pre[class*="language-"] {
 <li><a href="#sec-Level-3"><span class="spec-secid">1.1.1</span>Level #3</a>
 <input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1" /><label for="_toggle_1.1.1"></label>
 <ol>
-<li><a href="#sec-Level-4"><span class="spec-secid">1.1.1.1</span>Level 4</a>
+<li><a href="#sec-Imported-level-1"><span class="spec-secid">1.1.1.1</span>Imported level 1</a>
 <input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1.1" /><label for="_toggle_1.1.1.1"></label>
 <ol>
-<li><a href="#sec-Level-5"><span class="spec-secid">1.1.1.1.1</span>Level 5</a>
-<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1.1.1" /><label for="_toggle_1.1.1.1.1"></label>
+<li><a href="#sec-Imported-level-2"><span class="spec-secid">1.1.1.1.1</span>Imported level 2</a></li>
+</ol>
+</li>
+<li><a href="#sec-Level-4"><span class="spec-secid">1.1.1.2</span>Level 4</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1.2" /><label for="_toggle_1.1.1.2"></label>
 <ol>
-<li><a href="#sec-Level-6"><span class="spec-secid">1.1.1.1.1.1</span>Level 6</a></li>
+<li><a href="#sec-Level-5"><span class="spec-secid">1.1.1.2.1</span>Level 5</a>
+<input hidden class="toggle" type="checkbox" checked id="_toggle_1.1.1.2.1" /><label for="_toggle_1.1.1.2.1"></label>
+<ol>
+<li><a href="#sec-Level-6"><span class="spec-secid">1.1.1.2.1.1</span>Level 6</a></li>
 </ol>
 </li>
 </ol>
@@ -939,16 +945,25 @@ pre[class*="language-"] {
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Level-2">1.1</a></span>Level 2</h2>
 <section id="sec-Level-3" secid="1.1.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Level-3">1.1.1</a></span>Level #3</h3>
-<section id="sec-Level-4" secid="1.1.1.1">
-<h4><span class="spec-secid" title="link to this section"><a href="#sec-Level-4">1.1.1.1</a></span>Level 4</h4>
-<section id="sec-Level-5" secid="1.1.1.1.1">
-<h5><span class="spec-secid" title="link to this section"><a href="#sec-Level-5">1.1.1.1.1</a></span>Level 5</h5>
-<section id="sec-Level-6" secid="1.1.1.1.1.1">
-<h6><span class="spec-secid" title="link to this section"><a href="#sec-Level-6">1.1.1.1.1.1</a></span>Level 6</h6>
+<section id="sec-Imported-level-1" secid="1.1.1.1">
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Imported-level-1">1.1.1.1</a></span>Imported level 1</h4>
+<section id="sec-Imported-level-2" secid="1.1.1.1.1">
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Imported-level-2">1.1.1.1.1</a></span>Imported level 2</h5>
+<p>This has been imported </p>
+</section>
+</section>
+<section id="sec-Level-4" secid="1.1.1.2">
+<h4><span class="spec-secid" title="link to this section"><a href="#sec-Level-4">1.1.1.2</a></span>Level 4</h4>
+<section id="sec-Level-5" secid="1.1.1.2.1">
+<h5><span class="spec-secid" title="link to this section"><a href="#sec-Level-5">1.1.1.2.1</a></span>Level 5</h5>
+<section id="sec-Level-6" secid="1.1.1.2.1.1">
+<h6><span class="spec-secid" title="link to this section"><a href="#sec-Level-6">1.1.1.2.1.1</a></span>Level 6</h6>
 <p>Wow</p>
 <section id="sec-Level-6.Sub-section" class="subsec">
 <h6><a href="#sec-Level-6.Sub-section" title="link to this subsection">Sub section</a></h6>
-<p>This is a subsection </p>
+<p>This is a subsection</p>
+<p>This links to <a href="#sec-Level-2">Level 2</a>.</p>
+<p>This links to <a href="#sec-Imported-level-2">Imported level 2</a>. </p>
 </section>
 </section>
 </section>
@@ -972,13 +987,19 @@ Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</foo
 <li id="_sidebar_1.1.1"><a href="#sec-Level-3"><span class="spec-secid">1.1.1</span>Level #3</a>
 <input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1" /><label for="_sidebar_toggle_1.1.1"></label>
 <ol>
-<li id="_sidebar_1.1.1.1"><a href="#sec-Level-4"><span class="spec-secid">1.1.1.1</span>Level 4</a>
+<li id="_sidebar_1.1.1.1"><a href="#sec-Imported-level-1"><span class="spec-secid">1.1.1.1</span>Imported level 1</a>
 <input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1.1" /><label for="_sidebar_toggle_1.1.1.1"></label>
 <ol>
-<li id="_sidebar_1.1.1.1.1"><a href="#sec-Level-5"><span class="spec-secid">1.1.1.1.1</span>Level 5</a>
-<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1.1.1" /><label for="_sidebar_toggle_1.1.1.1.1"></label>
+<li id="_sidebar_1.1.1.1.1"><a href="#sec-Imported-level-2"><span class="spec-secid">1.1.1.1.1</span>Imported level 2</a></li>
+</ol>
+</li>
+<li id="_sidebar_1.1.1.2"><a href="#sec-Level-4"><span class="spec-secid">1.1.1.2</span>Level 4</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1.2" /><label for="_sidebar_toggle_1.1.1.2"></label>
 <ol>
-<li id="_sidebar_1.1.1.1.1.1"><a href="#sec-Level-6"><span class="spec-secid">1.1.1.1.1.1</span>Level 6</a></li>
+<li id="_sidebar_1.1.1.2.1"><a href="#sec-Level-5"><span class="spec-secid">1.1.1.2.1</span>Level 5</a>
+<input hidden class="toggle" type="checkbox" id="_sidebar_toggle_1.1.1.2.1" /><label for="_sidebar_toggle_1.1.1.2.1"></label>
+<ol>
+<li id="_sidebar_1.1.1.2.1.1"><a href="#sec-Level-6"><span class="spec-secid">1.1.1.2.1.1</span>Level 6</a></li>
 </ol>
 </li>
 </ol>


### PR DESCRIPTION
If a markdown link has a hash reference that resolves in the biblio, then link to where biblio wants to link. Also look for `sec-` and `()` variants to properly convert from links which would resolve when viewed in Github to links that would resolve within a printed spec md html file.

Fixes #32