### PR TITLE
Allow bulleted lists in "one of" productions

### DIFF
--- a/spec/Spec Additions.md
+++ b/spec/Spec Additions.md
@@ -496,33 +496,35 @@ Produces the following:
 AssignmentOperator : one of *= `/=` %= += -= <<= >>= >>>= &= ^= |=
 
 
-"one of" can also be followed by a line break and multiple lines of tokens
+"one of" can also be followed by a line break and multiple lines of tokens.
+To improve legibility in other tools, each line may optionally begin with
+a bullet.
 
 ```
 Keyword : one of
-  break     do        in          typeof
-  case      else      instanceof  var
-  catch     export    new         void
-  class     extends   return      while
-  const     finally   super       with
-  continue  for       switch      yield
-  debugger  function  this
-  default   if        throw
-  delete    import    try
+  - break     do        in          typeof
+  - case      else      instanceof  var
+  - catch     export    new         void
+  - class     extends   return      while
+  - const     finally   super       with
+  - continue  for       switch      yield
+  - debugger  function  this
+  - default   if        throw
+  - delete    import    try
 ```
 
 Produces the following:
 
 Keyword : one of
-  break     do        in          typeof
-  case      else      instanceof  var
-  catch     export    new         void
-  class     extends   return      while
-  const     finally   super       with
-  continue  for       switch      yield
-  debugger  function  this
-  default   if        throw
-  delete    import    try
+  - break     do        in          typeof
+  - case      else      instanceof  var
+  - catch     export    new         void
+  - class     extends   return      while
+  - const     finally   super       with
+  - continue  for       switch      yield
+  - debugger  function  this
+  - default   if        throw
+  - delete    import    try
 
 
 ### Non Terminal Token

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -568,7 +568,7 @@ variable = name:localName {
 
 // Grammar productions
 
-semantic = BLOCK name:nonTerminal _ defType:(':::'/'::'/':') __ tokens:tokens steps:list {
+semantic = BLOCK name:nonTerminal _ defType:(':::'/'::'/':') __ !'one of' tokens:tokens steps:list {
   return {
     type: 'Semantic',
     name: name,
@@ -592,14 +592,14 @@ production = BLOCK token:nonTerminal _ defType:(':::'/'::'/':') rhs:productionRH
 
 productionRHS = oneOfRHS / singleRHS / listRHS
 
-oneOfRHS = !(LINE listBullet) __ 'one of' rows:(_ NL? (_ token)+)+ {
+oneOfRHS = !(LINE listBullet) __ 'one of' WB rows:(_ (NL _ listBullet?)? (_ token)+)+ {
   return {
     type: 'OneOfRHS',
     rows: rows.map(row => row[2].map(tokens => tokens[1]))
   };
 }
 
-singleRHS = !(LINE listBullet) __ condition:(condition __)? tokens:tokens {
+singleRHS = !(LINE listBullet / 'one of') __ condition:(condition __)? tokens:tokens {
   return {
     type: 'RHS',
     condition: condition ? condition[0] : null,

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -3610,7 +3610,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "\"one of\" can also be followed by a line break and multiple lines of tokens"
+                      "value": "\"one of\" can also be followed by a line break and multiple lines of tokens.\nTo improve legibility in other tools, each line may optionally begin with\na bullet."
                     }
                   ]
                 },
@@ -3620,7 +3620,7 @@
                   "lang": null,
                   "example": false,
                   "counter": false,
-                  "code": "Keyword : one of\n  break     do        in          typeof\n  case      else      instanceof  var\n  catch     export    new         void\n  class     extends   return      while\n  const     finally   super       with\n  continue  for       switch      yield\n  debugger  function  this\n  default   if        throw\n  delete    import    try\n"
+                  "code": "Keyword : one of\n  - break     do        in          typeof\n  - case      else      instanceof  var\n  - catch     export    new         void\n  - class     extends   return      while\n  - const     finally   super       with\n  - continue  for       switch      yield\n  - debugger  function  this\n  - default   if        throw\n  - delete    import    try\n"
                 },
                 {
                   "type": "Paragraph",

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1751,17 +1751,17 @@ TypeThree ::: `type` `three`
 <td class="spec-rhs"><span class="spec-t">*=</span></td><td class="spec-rhs"><span class="spec-t">/=</span></td><td class="spec-rhs"><span class="spec-t">%=</span></td><td class="spec-rhs"><span class="spec-t">+=</span></td><td class="spec-rhs"><span class="spec-t">-=</span></td><td class="spec-rhs"><span class="spec-t">&lt;&lt;=</span></td><td class="spec-rhs"><span class="spec-t">&gt;&gt;=</span></td><td class="spec-rhs"><span class="spec-t">&gt;&gt;&gt;=</span></td><td class="spec-rhs"><span class="spec-t">&amp;=</span></td><td class="spec-rhs"><span class="spec-t">^=</span></td><td class="spec-rhs"><span class="spec-t">|=</span></td></tr>
 </table></div></div>
 </div>
-<p>&ldquo;one of&rdquo; can also be followed by a line break and multiple lines of tokens</p>
+<p>&ldquo;one of&rdquo; can also be followed by a line break and multiple lines of tokens. To improve legibility in other tools, each line may optionally begin with a bullet.</p>
 <pre><code>Keyword : one of
-  break     do        in          typeof
-  case      else      instanceof  var
-  catch     export    new         void
-  class     extends   return      while
-  const     finally   super       with
-  continue  for       switch      yield
-  debugger  function  this
-  default   if        throw
-  delete    import    try
+  - break     do        in          typeof
+  - case      else      instanceof  var
+  - catch     export    new         void
+  - class     extends   return      while
+  - const     finally   super       with
+  - continue  for       switch      yield
+  - debugger  function  this
+  - default   if        throw
+  - delete    import    try
 </code></pre>
 <p>Produces the following:</p>
 <div class="spec-production" id="Keyword">


### PR DESCRIPTION
To help resolve the issue raised in https://github.com/graphql/graphql-spec/pull/726, this allows each line of a grid of "one of" tokens to start with a line bullet.

The spec-md rendered results are equivalent, however in other tools the content should be much easier to read.