### PR TITLE
Allow for escaped * in quantifiers

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -659,13 +659,13 @@ tokens = first:token rest:(__ token:token)* {
   return [first].concat(rest.map(nodes => nodes[1]));
 }
 
-token = token:unconstrainedToken quantifier:('+' / '?' / '*' / '\\*')? constraint:(__ constraint)? {
+token = token:unconstrainedToken quantifier:('\\'? ('+' / '?' / '*'))? constraint:(__ constraint)? {
   if (quantifier) {
     token = {
       type: 'Quantified',
       token: token,
-      isList: quantifier === '+' || quantifier === '*' || quantifier === '\\*',
-      isOptional: quantifier === '?' || quantifier === '*' || quantifier === '\\*'
+      isList: quantifier[1] === '+' || quantifier[1] === '*',
+      isOptional: quantifier[1] === '?' || quantifier[1] === '*'
     };
   }
   if (constraint) {

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -659,13 +659,13 @@ tokens = first:token rest:(__ token:token)* {
   return [first].concat(rest.map(nodes => nodes[1]));
 }
 
-token = token:unconstrainedToken quantifier:('+' / '?' / '*')? constraint:(__ constraint)? {
+token = token:unconstrainedToken quantifier:('+' / '?' / '*' / '\\*')? constraint:(__ constraint)? {
   if (quantifier) {
     token = {
       type: 'Quantified',
       token: token,
-      isList: quantifier === '+' || quantifier === '*',
-      isOptional: quantifier === '?' || quantifier === '*'
+      isList: quantifier === '+' || quantifier === '*' || quantifier === '\\*',
+      isOptional: quantifier === '?' || quantifier === '*' || quantifier === '\\*'
     };
   }
   if (constraint) {

--- a/test/escape-sequence/ast.json
+++ b/test/escape-sequence/ast.json
@@ -171,6 +171,56 @@
               }
             ]
           }
+        },
+        {
+          "type": "Production",
+          "token": {
+            "type": "NonTerminal",
+            "name": "EscapesInQuantifiers",
+            "params": null
+          },
+          "defType": 2,
+          "rhs": {
+            "type": "ListRHS",
+            "defs": [
+              {
+                "type": "RHS",
+                "condition": null,
+                "tokens": [
+                  {
+                    "type": "Quantified",
+                    "token": {
+                      "type": "NonTerminal",
+                      "name": "OneOrMore",
+                      "params": null
+                    },
+                    "isList": true,
+                    "isOptional": false
+                  },
+                  {
+                    "type": "Quantified",
+                    "token": {
+                      "type": "NonTerminal",
+                      "name": "ZeroOrMore",
+                      "params": null
+                    },
+                    "isList": true,
+                    "isOptional": true
+                  },
+                  {
+                    "type": "Quantified",
+                    "token": {
+                      "type": "NonTerminal",
+                      "name": "Optional",
+                      "params": null
+                    },
+                    "isList": false,
+                    "isOptional": true
+                  }
+                ]
+              }
+            ]
+          }
         }
       ]
     }

--- a/test/escape-sequence/input.md
+++ b/test/escape-sequence/input.md
@@ -18,3 +18,7 @@ LiteralBackticks:
   - `` ` ``
   - ``` `` ```
   - ` ``` `
+
+EscapesInQuantifiers ::
+
+- OneOrMore\+ ZeroOrMore\* Optional\?

--- a/test/escape-sequence/output.html
+++ b/test/escape-sequence/output.html
@@ -1053,8 +1053,11 @@ pre[class*="language-"] {
 <div class="spec-rhs"><span class="spec-t">``</span></div>
 <div class="spec-rhs"><span class="spec-t">```</span></div>
 </div>
+<div class="spec-production d2" id="EscapesInQuantifiers">
+<span class="spec-nt"><a href="#EscapesInQuantifiers" data-name="EscapesInQuantifiers">EscapesInQuantifiers</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><span data-name="OneOrMore">OneOrMore</span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-quantified"><span class="spec-nt"><span data-name="ZeroOrMore">ZeroOrMore</span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><span data-name="Optional">Optional</span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
+</div>
 </section>
-<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algorithm_Names()">Algorithm_Names</a></li><li><a href="#Grammar">Grammar</a></li><li><a href="#LiteralBackticks">LiteralBackticks</a></li></ol></section></article>
+<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algorithm_Names()">Algorithm_Names</a></li><li><a href="#EscapesInQuantifiers">EscapesInQuantifiers</a></li><li><a href="#Grammar">Grammar</a></li><li><a href="#LiteralBackticks">LiteralBackticks</a></li></ol></section></article>
 <footer>
 Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</footer>
 <input hidden class="spec-sidebar-toggle" type="checkbox" id="spec-sidebar-toggle" aria-hidden /><label for="spec-sidebar-toggle" aria-hidden><div class="spec-sidebar-button">&#x2630;</div></label>


### PR DESCRIPTION
Prettier will escape solitary `*`s; which means that for example the `Name` production in GraphQL becomes:

```
Name ::

- NameStart NameContinue\* [lookahead != NameContinue]
```

This fix ensures that the character is interpretted as it is intended.

Relates to #31 (prettier support). More PRs incoming.