### PR TITLE
Allow newline after "one of"

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -616,7 +616,7 @@ production = BLOCK token:nonTerminal _ defType:(':::'/'::'/':') rhs:productionRH
 
 productionRHS = oneOfRHS / singleRHS / listRHS
 
-oneOfRHS = !(LINE listBullet) __ 'one of' NL? WB  rows:(_ (NL _ listBullet?)? (_ token)+)+ {
+oneOfRHS = !(LINE listBullet) __ 'one of' WB rows:(__ (NL _ listBullet?)? (_ token)+)+ {
   return {
     type: 'OneOfRHS',
     rows: rows.map(row => row[2].map(tokens => tokens[1]))

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -616,10 +616,10 @@ production = BLOCK token:nonTerminal _ defType:(':::'/'::'/':') rhs:productionRH
 
 productionRHS = oneOfRHS / singleRHS / listRHS
 
-oneOfRHS = !(LINE listBullet) __ 'one of' WB NL_NO_BULLET? rows:(__ (NL _ listBullet?)? (_ token)+)+ {
+oneOfRHS = !(LINE listBullet) __ 'one of' WB rows:((LINE listBullet / __)? (_ token)+)+ {
   return {
     type: 'OneOfRHS',
-    rows: rows.map(row => row[2].map(tokens => tokens[1]))
+    rows: rows.map(row => row[1].map(tokens => tokens[1]))
   };
 }
 
@@ -807,7 +807,6 @@ DEDENT = &lineStart !{ indentStack.length === 0 } {
 NL = '\n' / '\r' / '\r\n'
 NOT_NL = [^\n\r]
 SINGLE_NL = NL !(NL / _ listBullet)
-NL_NO_BULLET = NL !(_ listBullet)
 _ = ' '*
 // Skips over whitespace including a single newline. Do not use more than once
 // in a row, otherwise multiple NL will be skipped.

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -616,7 +616,7 @@ production = BLOCK token:nonTerminal _ defType:(':::'/'::'/':') rhs:productionRH
 
 productionRHS = oneOfRHS / singleRHS / listRHS
 
-oneOfRHS = !(LINE listBullet) __ 'one of' WB rows:(_ (NL _ listBullet?)? (_ token)+)+ {
+oneOfRHS = !(LINE listBullet) __ 'one of' NL? WB  rows:(_ (NL _ listBullet?)? (_ token)+)+ {
   return {
     type: 'OneOfRHS',
     rows: rows.map(row => row[2].map(tokens => tokens[1]))

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -616,7 +616,7 @@ production = BLOCK token:nonTerminal _ defType:(':::'/'::'/':') rhs:productionRH
 
 productionRHS = oneOfRHS / singleRHS / listRHS
 
-oneOfRHS = !(LINE listBullet) __ 'one of' WB rows:(__ (NL _ listBullet?)? (_ token)+)+ {
+oneOfRHS = !(LINE listBullet) __ 'one of' WB NL_NO_BULLET? rows:(__ (NL _ listBullet?)? (_ token)+)+ {
   return {
     type: 'OneOfRHS',
     rows: rows.map(row => row[2].map(tokens => tokens[1]))
@@ -807,6 +807,7 @@ DEDENT = &lineStart !{ indentStack.length === 0 } {
 NL = '\n' / '\r' / '\r\n'
 NOT_NL = [^\n\r]
 SINGLE_NL = NL !(NL / _ listBullet)
+NL_NO_BULLET = NL !(_ listBullet)
 _ = ' '*
 // Skips over whitespace including a single newline. Do not use more than once
 // in a row, otherwise multiple NL will be skipped.

--- a/test/productions/ast.json
+++ b/test/productions/ast.json
@@ -490,6 +490,122 @@
               }
             ]
           }
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "Multiple definitions can have a newline after it"
+            }
+          ]
+        },
+        {
+          "type": "Production",
+          "token": {
+            "type": "NonTerminal",
+            "name": "PBJ",
+            "params": null
+          },
+          "defType": 1,
+          "rhs": {
+            "type": "ListRHS",
+            "defs": [
+              {
+                "type": "RHS",
+                "condition": null,
+                "tokens": [
+                  {
+                    "type": "NonTerminal",
+                    "name": "Bread",
+                    "params": null
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "PeanutButter",
+                    "params": null
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "Jelly",
+                    "params": null
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "Bread",
+                    "params": null
+                  }
+                ]
+              },
+              {
+                "type": "RHS",
+                "condition": null,
+                "tokens": [
+                  {
+                    "type": "NonTerminal",
+                    "name": "Bread",
+                    "params": null
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "PeanutButter",
+                    "params": null
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "Jelly",
+                    "params": null
+                  },
+                  {
+                    "type": "NonTerminal",
+                    "name": "Bread",
+                    "params": null
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "One of can have a newline after it"
+            }
+          ]
+        },
+        {
+          "type": "Production",
+          "token": {
+            "type": "NonTerminal",
+            "name": "Punc",
+            "params": null
+          },
+          "defType": 1,
+          "rhs": {
+            "type": "OneOfRHS",
+            "rows": [
+              [
+                {
+                  "type": "Terminal",
+                  "value": "."
+                }
+              ],
+              [
+                {
+                  "type": "Terminal",
+                  "value": "!"
+                }
+              ],
+              [
+                {
+                  "type": "Terminal",
+                  "value": "?"
+                }
+              ]
+            ]
+          }
         }
       ]
     },

--- a/test/productions/input.md
+++ b/test/productions/input.md
@@ -73,6 +73,21 @@ PBJ: Bread
   Mustard
   Bread
 
+Multiple definitions can have a newline after it
+
+PBJ:
+
+  - Bread PeanutButter Jelly Bread
+  - Bread PeanutButter Jelly Bread
+
+One of can have a newline after it
+
+Punc: one of
+
+  - `.`
+  - `!`
+  - `?`
+
 # Algorithms
 
 An algoritm can have no args

--- a/test/productions/output.html
+++ b/test/productions/output.html
@@ -1075,6 +1075,22 @@ pre[class*="language-"] {
 <div class="spec-production" id="PBJ">
 <span class="spec-nt"><a href="#PBJ" data-name="PBJ">PBJ</a></span><div class="spec-rhs"><span class="spec-nt"><span data-name="Bread">Bread</span></span><span class="spec-constrained"><span class="spec-nt"><span data-name="Condiment">Condiment</span></span><span class="spec-butnot"><span class="spec-nt"><span data-name="Ketchup">Ketchup</span></span><span class="spec-nt"><span data-name="Mustard">Mustard</span></span></span></span><span class="spec-nt"><span data-name="Bread">Bread</span></span></div>
 </div>
+<p>Multiple definitions can have a newline after it</p>
+<div class="spec-production" id="PBJ">
+<span class="spec-nt"><a href="#PBJ" data-name="PBJ">PBJ</a></span><div class="spec-rhs"><span class="spec-nt"><span data-name="Bread">Bread</span></span><span class="spec-nt"><span data-name="PeanutButter">PeanutButter</span></span><span class="spec-nt"><span data-name="Jelly">Jelly</span></span><span class="spec-nt"><span data-name="Bread">Bread</span></span></div>
+<div class="spec-rhs"><span class="spec-nt"><span data-name="Bread">Bread</span></span><span class="spec-nt"><span data-name="PeanutButter">PeanutButter</span></span><span class="spec-nt"><span data-name="Jelly">Jelly</span></span><span class="spec-nt"><span data-name="Bread">Bread</span></span></div>
+</div>
+<p>One of can have a newline after it</p>
+<div class="spec-production" id="Punc">
+<span class="spec-nt"><a href="#Punc" data-name="Punc">Punc</a></span><div class="spec-oneof"><div class="spec-oneof-grid"><table>
+<tr>
+<td class="spec-rhs"><span class="spec-t">.</span></td></tr>
+<tr>
+<td class="spec-rhs"><span class="spec-t">!</span></td></tr>
+<tr>
+<td class="spec-rhs"><span class="spec-t">?</span></td></tr>
+</table></div></div>
+</div>
 </section>
 <section id="sec-Algorithms" secid="2">
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">2</a></span>Algorithms</h1>
@@ -1103,7 +1119,7 @@ pre[class*="language-"] {
 </ol>
 </div>
 </section>
-<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algo()">Algo</a></li><li><a href="#PBJ">PBJ</a></li><li><a href="#Sandwich">Sandwich</a></li></ol></section></article>
+<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algo()">Algo</a></li><li><a href="#PBJ">PBJ</a></li><li><a href="#Punc">Punc</a></li><li><a href="#Sandwich">Sandwich</a></li></ol></section></article>
 <footer>
 Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</footer>
 <input hidden class="spec-sidebar-toggle" type="checkbox" id="spec-sidebar-toggle" aria-hidden /><label for="spec-sidebar-toggle" aria-hidden><div class="spec-sidebar-button">&#x2630;</div></label>


### PR DESCRIPTION
Prettier adds newlines around bulleted lists, which for example means that the `ExecutableDirectiveLocation` production becomes:

```
ExecutableDirectiveLocation : one of

- `QUERY`
- `MUTATION`
- `SUBSCRIPTION`
- `FIELD`
- `FRAGMENT_DEFINITION`
- `FRAGMENT_SPREAD`
- `INLINE_FRAGMENT`
- `VARIABLE_DEFINITION`
```

This PR ensures that spec-md parses this as it is intended.

Relates to #31 (prettier support). Another PR incoming.