### PR TITLE
Unescape dollars in text

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -13,7 +13,7 @@
   }
 
   function unescape(text) {
-    return text.replace(/\\([\\`*_{}[\]()#+\-.!<>|])/g, '$1');
+    return text.replace(/\\([\\`*_{}[\]()#+\-.!<>|$])/g, '$1');
   }
 
   let htmlBlockName;


### PR DESCRIPTION
Prettier automatically escapes standalone `$`s, which comes out in spec text like:

```
\${intArg} typed as {Int} cannot be used as an argument to {booleanArg}, typed
as {Boolean}.
```

This PR correctly unescapes the `$` character so that the backslash is not output into the resulting HTML.

Relates to #31 (prettier support).