### PR TITLE
Trim table cells

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -508,7 +508,8 @@ tableCell = contents:tableCellContent+ {
 tableCellContent = inlineEntity / tableCellText
 
 tableCellTextChar = escaped
-                  / [^|\n\r+\-{\x60*[!<] // \x60 = "`"
+                  / [^ |\n\r+\-{\x60*[!<] // \x60 = "`"
+                  / ' '+ ![ |\n\r] // Do not capture trailing space in a cell
                   / '++' !'}'
                   / '+' !'+}'
                   / '--' !'}'

--- a/src/print.js
+++ b/src/print.js
@@ -516,12 +516,12 @@ function printAll(list, options) {
           return (
             '<table>\n' +
               '<thead><tr>\n' +
-                join(node.headers.map(cell => '<th>' + join(cell).trim() + '</th>\n')) +
+                join(node.headers.map(cell => '<th>' + join(cell) + '</th>\n')) +
               '</tr></thead>\n' +
               '<tbody>\n' +
                 join(node.rows.map(row =>
                   '<tr>\n' +
-                    join(row.map(cell => '<td>' + join(cell).trim() + '</td>')) +
+                    join(row.map(cell => '<td>' + join(cell) + '</td>')) +
                   '</tr>\n'
                 )) +
               '</tbody>\n' +

--- a/src/print.js
+++ b/src/print.js
@@ -516,12 +516,12 @@ function printAll(list, options) {
           return (
             '<table>\n' +
               '<thead><tr>\n' +
-                join(node.headers.map(cell => '<th>' + join(cell) + '</th>\n')) +
+                join(node.headers.map(cell => '<th>' + join(cell).trim() + '</th>\n')) +
               '</tr></thead>\n' +
               '<tbody>\n' +
                 join(node.rows.map(row =>
                   '<tr>\n' +
-                    join(row.map(cell => '<td>' + join(cell) + '</td>')) +
+                    join(row.map(cell => '<td>' + join(cell).trim() + '</td>')) +
                   '</tr>\n'
                 )) +
               '</tbody>\n' +

--- a/test/graphql-spec/ast.json
+++ b/test/graphql-spec/ast.json
@@ -5671,19 +5671,19 @@
                         [
                           {
                             "type": "Text",
-                            "value": "Escaped Character "
+                            "value": "Escaped Character"
                           }
                         ],
                         [
                           {
                             "type": "Text",
-                            "value": "Code Unit Value "
+                            "value": "Code Unit Value"
                           }
                         ],
                         [
                           {
                             "type": "Text",
-                            "value": "Character Name               "
+                            "value": "Character Name"
                           }
                         ]
                       ],
@@ -5693,22 +5693,18 @@
                             {
                               "type": "InlineCode",
                               "code": "\""
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+0022          "
+                              "value": "U+0022"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "double quote                 "
+                              "value": "double quote"
                             }
                           ]
                         ],
@@ -5717,22 +5713,18 @@
                             {
                               "type": "InlineCode",
                               "code": "\\"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+005C          "
+                              "value": "U+005C"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "reverse solidus (back slash) "
+                              "value": "reverse solidus (back slash)"
                             }
                           ]
                         ],
@@ -5741,22 +5733,18 @@
                             {
                               "type": "InlineCode",
                               "code": "/"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+002F          "
+                              "value": "U+002F"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "solidus (forward slash)      "
+                              "value": "solidus (forward slash)"
                             }
                           ]
                         ],
@@ -5765,22 +5753,18 @@
                             {
                               "type": "InlineCode",
                               "code": "b"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+0008          "
+                              "value": "U+0008"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "backspace                    "
+                              "value": "backspace"
                             }
                           ]
                         ],
@@ -5789,22 +5773,18 @@
                             {
                               "type": "InlineCode",
                               "code": "f"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+000C          "
+                              "value": "U+000C"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "form feed                    "
+                              "value": "form feed"
                             }
                           ]
                         ],
@@ -5813,22 +5793,18 @@
                             {
                               "type": "InlineCode",
                               "code": "n"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+000A          "
+                              "value": "U+000A"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "line feed (new line)         "
+                              "value": "line feed (new line)"
                             }
                           ]
                         ],
@@ -5837,22 +5813,18 @@
                             {
                               "type": "InlineCode",
                               "code": "r"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+000D          "
+                              "value": "U+000D"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "carriage return              "
+                              "value": "carriage return"
                             }
                           ]
                         ],
@@ -5861,22 +5833,18 @@
                             {
                               "type": "InlineCode",
                               "code": "t"
-                            },
-                            {
-                              "type": "Text",
-                              "value": "               "
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "U+0009          "
+                              "value": "U+0009"
                             }
                           ],
                           [
                             {
                               "type": "Text",
-                              "value": "horizontal tab               "
+                              "value": "horizontal tab"
                             }
                           ]
                         ]
@@ -15780,13 +15748,13 @@
                     [
                       {
                         "type": "Text",
-                        "value": "Literal Value            "
+                        "value": "Literal Value"
                       }
                     ],
                     [
                       {
                         "type": "Text",
-                        "value": "Variables               "
+                        "value": "Variables"
                       }
                     ],
                     [
@@ -15802,20 +15770,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: \"abc\", b: 123 }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -15830,20 +15790,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: null, b: 123 }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "    "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -15858,20 +15810,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ b: 123 }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "             "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -15886,20 +15830,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: $var, b: 123 }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "    "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{ var: null }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "         "
                         }
                       ],
                       [
@@ -15914,20 +15850,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: $var, b: 123 }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "    "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -15942,20 +15870,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ b: $var }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "            "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{ var: 123 }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "          "
                         }
                       ],
                       [
@@ -15970,20 +15890,12 @@
                         {
                           "type": "InlineCode",
                           "code": "$var"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                   "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{ var: { b: 123 } }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
@@ -15998,20 +15910,12 @@
                         {
                           "type": "InlineCode",
                           "code": "\"abc123\""
-                        },
-                        {
-                          "type": "Text",
-                          "value": "               "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -16026,20 +15930,12 @@
                         {
                           "type": "InlineCode",
                           "code": "$var"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                   "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{ var: \"abc123\" }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
@@ -16054,20 +15950,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: \"abc\", b: \"123\" }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": " "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -16086,20 +15974,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: \"abc\" }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -16118,20 +15998,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ b: $var }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "            "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -16154,20 +16026,12 @@
                         {
                           "type": "InlineCode",
                           "code": "$var"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                   "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{ var: { a: \"abc\" } }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": " "
                         }
                       ],
                       [
@@ -16186,20 +16050,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ a: \"abc\", b: null }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "  "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -16222,20 +16078,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ b: $var }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "            "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{ var: null }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "         "
                         }
                       ],
                       [
@@ -16258,20 +16106,12 @@
                         {
                           "type": "InlineCode",
                           "code": "{ b: 123, c: \"xyz\" }"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "{}"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "                    "
                         }
                       ],
                       [
@@ -16703,13 +16543,13 @@
                     [
                       {
                         "type": "Text",
-                        "value": "Expected Type "
+                        "value": "Expected Type"
                       }
                     ],
                     [
                       {
                         "type": "Text",
-                        "value": "Provided Value   "
+                        "value": "Provided Value"
                       }
                     ],
                     [
@@ -16725,20 +16565,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, 3]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
@@ -16753,20 +16585,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, \"b\", true]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": " "
                         }
                       ],
                       [
@@ -16781,20 +16605,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "1"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "              "
                         }
                       ],
                       [
@@ -16809,20 +16625,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
@@ -16837,20 +16645,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[[Int]]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[[1], [2, 3]]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "  "
                         }
                       ],
                       [
@@ -16865,20 +16665,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[[Int]]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, 3]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
@@ -16893,20 +16685,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[[Int]]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "1"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "              "
                         }
                       ],
                       [
@@ -16921,20 +16705,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[[Int]]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
@@ -17296,13 +17072,13 @@
                     [
                       {
                         "type": "Text",
-                        "value": "Expected Type "
+                        "value": "Expected Type"
                       }
                     ],
                     [
                       {
                         "type": "Text",
-                        "value": "Internal Value   "
+                        "value": "Internal Value"
                       }
                     ],
                     [
@@ -17318,20 +17094,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, 3]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
@@ -17346,20 +17114,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
@@ -17374,20 +17134,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, null]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
@@ -17402,20 +17154,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "       "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, Error]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "  "
                         }
                       ],
                       [
@@ -17434,20 +17178,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, 3]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
@@ -17462,20 +17198,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
@@ -17490,20 +17218,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, null]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
@@ -17518,20 +17238,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, Error]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "  "
                         }
                       ],
                       [
@@ -17550,20 +17262,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, 3]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
@@ -17578,20 +17282,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
@@ -17606,20 +17302,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, null]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
@@ -17638,20 +17326,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, Error]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "  "
                         }
                       ],
                       [
@@ -17670,20 +17350,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, 3]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "      "
                         }
                       ],
                       [
@@ -17698,20 +17370,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "           "
                         }
                       ],
                       [
@@ -17726,20 +17390,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, null]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "   "
                         }
                       ],
                       [
@@ -17754,20 +17410,12 @@
                         {
                           "type": "InlineCode",
                           "code": "[Int!]!"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "     "
                         }
                       ],
                       [
                         {
                           "type": "InlineCode",
                           "code": "[1, 2, Error]"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "  "
                         }
                       ],
                       [
@@ -37522,13 +37170,13 @@
                     [
                       {
                         "type": "Text",
-                        "value": "GraphQL Value "
+                        "value": "GraphQL Value"
                       }
                     ],
                     [
                       {
                         "type": "Text",
-                        "value": "JSON Value        "
+                        "value": "JSON Value"
                       }
                     ]
                   ],
@@ -37537,13 +37185,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "Map           "
+                          "value": "Map"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "Object            "
+                          "value": "Object"
                         }
                       ]
                     ],
@@ -37551,13 +37199,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "List          "
+                          "value": "List"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "Array             "
+                          "value": "Array"
                         }
                       ]
                     ],
@@ -37565,17 +37213,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "Null          "
+                          "value": "Null"
                         }
                       ],
                       [
                         {
                           "type": "Keyword",
                           "value": "null"
-                        },
-                        {
-                          "type": "Text",
-                          "value": "            "
                         }
                       ]
                     ],
@@ -37583,13 +37227,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "String        "
+                          "value": "String"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "String            "
+                          "value": "String"
                         }
                       ]
                     ],
@@ -37597,7 +37241,7 @@
                       [
                         {
                           "type": "Text",
-                          "value": "Boolean       "
+                          "value": "Boolean"
                         }
                       ],
                       [
@@ -37612,10 +37256,6 @@
                         {
                           "type": "Keyword",
                           "value": "false"
-                        },
-                        {
-                          "type": "Text",
-                          "value": " "
                         }
                       ]
                     ],
@@ -37623,13 +37263,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "Int           "
+                          "value": "Int"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "Number            "
+                          "value": "Number"
                         }
                       ]
                     ],
@@ -37637,13 +37277,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "Float         "
+                          "value": "Float"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "Number            "
+                          "value": "Number"
                         }
                       ]
                     ],
@@ -37651,13 +37291,13 @@
                       [
                         {
                           "type": "Text",
-                          "value": "Enum Value    "
+                          "value": "Enum Value"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "String            "
+                          "value": "String"
                         }
                       ]
                     ]

--- a/test/graphql-spec/output.html
+++ b/test/graphql-spec/output.html
@@ -2051,27 +2051,27 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
 </div>
 <table>
 <thead><tr>
-<th>Escaped Character </th>
-<th>Code Unit Value </th>
-<th>Character Name </th>
+<th>Escaped Character</th>
+<th>Code Unit Value</th>
+<th>Character Name</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><code>&quot;</code> </td><td>U+0022 </td><td>double quote </td></tr>
+<td><code>&quot;</code></td><td>U+0022</td><td>double quote</td></tr>
 <tr>
-<td><code>\</code> </td><td>U+005C </td><td>reverse solidus (back slash) </td></tr>
+<td><code>\</code></td><td>U+005C</td><td>reverse solidus (back slash)</td></tr>
 <tr>
-<td><code>/</code> </td><td>U+002F </td><td>solidus (forward slash) </td></tr>
+<td><code>/</code></td><td>U+002F</td><td>solidus (forward slash)</td></tr>
 <tr>
-<td><code>b</code> </td><td>U+0008 </td><td>backspace </td></tr>
+<td><code>b</code></td><td>U+0008</td><td>backspace</td></tr>
 <tr>
-<td><code>f</code> </td><td>U+000C </td><td>form feed </td></tr>
+<td><code>f</code></td><td>U+000C</td><td>form feed</td></tr>
 <tr>
-<td><code>n</code> </td><td>U+000A </td><td>line feed (new line) </td></tr>
+<td><code>n</code></td><td>U+000A</td><td>line feed (new line)</td></tr>
 <tr>
-<td><code>r</code> </td><td>U+000D </td><td>carriage return </td></tr>
+<td><code>r</code></td><td>U+000D</td><td>carriage return</td></tr>
 <tr>
-<td><code>t</code> </td><td>U+0009 </td><td>horizontal tab </td></tr>
+<td><code>t</code></td><td>U+0009</td><td>horizontal tab</td></tr>
 </tbody>
 </table>
 <div class="spec-semantic d2">
@@ -3350,43 +3350,43 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 </code></pre>
 <table>
 <thead><tr>
-<th>Literal Value </th>
-<th>Variables </th>
+<th>Literal Value</th>
+<th>Variables</th>
 <th>Coerced Value</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><code>{ a: &quot;abc&quot;, b: 123 }</code> </td><td><code>{}</code> </td><td><code>{ a: &quot;abc&quot;, b: 123 }</code></td></tr>
+<td><code>{ a: &quot;abc&quot;, b: 123 }</code></td><td><code>{}</code></td><td><code>{ a: &quot;abc&quot;, b: 123 }</code></td></tr>
 <tr>
-<td><code>{ a: null, b: 123 }</code> </td><td><code>{}</code> </td><td><code>{ a: null, b: 123 }</code></td></tr>
+<td><code>{ a: null, b: 123 }</code></td><td><code>{}</code></td><td><code>{ a: null, b: 123 }</code></td></tr>
 <tr>
-<td><code>{ b: 123 }</code> </td><td><code>{}</code> </td><td><code>{ b: 123 }</code></td></tr>
+<td><code>{ b: 123 }</code></td><td><code>{}</code></td><td><code>{ b: 123 }</code></td></tr>
 <tr>
-<td><code>{ a: $var, b: 123 }</code> </td><td><code>{ var: null }</code> </td><td><code>{ a: null, b: 123 }</code></td></tr>
+<td><code>{ a: $var, b: 123 }</code></td><td><code>{ var: null }</code></td><td><code>{ a: null, b: 123 }</code></td></tr>
 <tr>
-<td><code>{ a: $var, b: 123 }</code> </td><td><code>{}</code> </td><td><code>{ b: 123 }</code></td></tr>
+<td><code>{ a: $var, b: 123 }</code></td><td><code>{}</code></td><td><code>{ b: 123 }</code></td></tr>
 <tr>
-<td><code>{ b: $var }</code> </td><td><code>{ var: 123 }</code> </td><td><code>{ b: 123 }</code></td></tr>
+<td><code>{ b: $var }</code></td><td><code>{ var: 123 }</code></td><td><code>{ b: 123 }</code></td></tr>
 <tr>
-<td><code>$var</code> </td><td><code>{ var: { b: 123 } }</code> </td><td><code>{ b: 123 }</code></td></tr>
+<td><code>$var</code></td><td><code>{ var: { b: 123 } }</code></td><td><code>{ b: 123 }</code></td></tr>
 <tr>
-<td><code>&quot;abc123&quot;</code> </td><td><code>{}</code> </td><td>Error: Incorrect value</td></tr>
+<td><code>&quot;abc123&quot;</code></td><td><code>{}</code></td><td>Error: Incorrect value</td></tr>
 <tr>
-<td><code>$var</code> </td><td><code>{ var: &quot;abc123&quot; }</code> </td><td>Error: Incorrect value</td></tr>
+<td><code>$var</code></td><td><code>{ var: &quot;abc123&quot; }</code></td><td>Error: Incorrect value</td></tr>
 <tr>
-<td><code>{ a: &quot;abc&quot;, b: &quot;123&quot; }</code> </td><td><code>{}</code> </td><td>Error: Incorrect value for field <var data-name="b">b</var></td></tr>
+<td><code>{ a: &quot;abc&quot;, b: &quot;123&quot; }</code></td><td><code>{}</code></td><td>Error: Incorrect value for field <var data-name="b">b</var></td></tr>
 <tr>
-<td><code>{ a: &quot;abc&quot; }</code> </td><td><code>{}</code> </td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
+<td><code>{ a: &quot;abc&quot; }</code></td><td><code>{}</code></td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
 <tr>
-<td><code>{ b: $var }</code> </td><td><code>{}</code> </td><td>Error: Missing required field <var data-name="b">b</var>.</td></tr>
+<td><code>{ b: $var }</code></td><td><code>{}</code></td><td>Error: Missing required field <var data-name="b">b</var>.</td></tr>
 <tr>
-<td><code>$var</code> </td><td><code>{ var: { a: &quot;abc&quot; } }</code> </td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
+<td><code>$var</code></td><td><code>{ var: { a: &quot;abc&quot; } }</code></td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
 <tr>
-<td><code>{ a: &quot;abc&quot;, b: null }</code> </td><td><code>{}</code> </td><td>Error: <var data-name="b">b</var> must be non&#8208;null.</td></tr>
+<td><code>{ a: &quot;abc&quot;, b: null }</code></td><td><code>{}</code></td><td>Error: <var data-name="b">b</var> must be non&#8208;null.</td></tr>
 <tr>
-<td><code>{ b: $var }</code> </td><td><code>{ var: null }</code> </td><td>Error: <var data-name="b">b</var> must be non&#8208;null.</td></tr>
+<td><code>{ b: $var }</code></td><td><code>{ var: null }</code></td><td>Error: <var data-name="b">b</var> must be non&#8208;null.</td></tr>
 <tr>
-<td><code>{ b: 123, c: &quot;xyz&quot; }</code> </td><td><code>{}</code> </td><td>Error: Unexpected field <var data-name="c">c</var></td></tr>
+<td><code>{ b: 123, c: &quot;xyz&quot; }</code></td><td><code>{}</code></td><td>Error: Unexpected field <var data-name="c">c</var></td></tr>
 </tbody>
 </table>
 </section>
@@ -3441,27 +3441,27 @@ For more information on the error handling process, see &ldquo;Errors and Non&#8
 <p>Following are examples of input coercion with various list types and values:</p>
 <table>
 <thead><tr>
-<th>Expected Type </th>
-<th>Provided Value </th>
+<th>Expected Type</th>
+<th>Provided Value</th>
 <th>Coerced Value</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><code>[Int]</code> </td><td><code>[1, 2, 3]</code> </td><td><code>[1, 2, 3]</code></td></tr>
+<td><code>[Int]</code></td><td><code>[1, 2, 3]</code></td><td><code>[1, 2, 3]</code></td></tr>
 <tr>
-<td><code>[Int]</code> </td><td><code>[1, &quot;b&quot;, true]</code> </td><td>Error: Incorrect item value</td></tr>
+<td><code>[Int]</code></td><td><code>[1, &quot;b&quot;, true]</code></td><td>Error: Incorrect item value</td></tr>
 <tr>
-<td><code>[Int]</code> </td><td><code>1</code> </td><td><code>[1]</code></td></tr>
+<td><code>[Int]</code></td><td><code>1</code></td><td><code>[1]</code></td></tr>
 <tr>
-<td><code>[Int]</code> </td><td><code>null</code> </td><td><code>null</code></td></tr>
+<td><code>[Int]</code></td><td><code>null</code></td><td><code>null</code></td></tr>
 <tr>
-<td><code>[[Int]]</code> </td><td><code>[[1], [2, 3]]</code> </td><td><code>[[1], [2, 3]]</code></td></tr>
+<td><code>[[Int]]</code></td><td><code>[[1], [2, 3]]</code></td><td><code>[[1], [2, 3]]</code></td></tr>
 <tr>
-<td><code>[[Int]]</code> </td><td><code>[1, 2, 3]</code> </td><td>Error: Incorrect item value</td></tr>
+<td><code>[[Int]]</code></td><td><code>[1, 2, 3]</code></td><td>Error: Incorrect item value</td></tr>
 <tr>
-<td><code>[[Int]]</code> </td><td><code>1</code> </td><td><code>[[1]]</code></td></tr>
+<td><code>[[Int]]</code></td><td><code>1</code></td><td><code>[[1]]</code></td></tr>
 <tr>
-<td><code>[[Int]]</code> </td><td><code>null</code> </td><td><code>null</code></td></tr>
+<td><code>[[Int]]</code></td><td><code>null</code></td><td><code>null</code></td></tr>
 </tbody>
 </table>
 </section>
@@ -3517,43 +3517,43 @@ The Validation section defines providing a nullable variable type to a non&#8208
 <p>Following are examples of result coercion with various types and values:</p>
 <table>
 <thead><tr>
-<th>Expected Type </th>
-<th>Internal Value </th>
+<th>Expected Type</th>
+<th>Internal Value</th>
 <th>Coerced Result</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><code>[Int]</code> </td><td><code>[1, 2, 3]</code> </td><td><code>[1, 2, 3]</code></td></tr>
+<td><code>[Int]</code></td><td><code>[1, 2, 3]</code></td><td><code>[1, 2, 3]</code></td></tr>
 <tr>
-<td><code>[Int]</code> </td><td><code>null</code> </td><td><code>null</code></td></tr>
+<td><code>[Int]</code></td><td><code>null</code></td><td><code>null</code></td></tr>
 <tr>
-<td><code>[Int]</code> </td><td><code>[1, 2, null]</code> </td><td><code>[1, 2, null]</code></td></tr>
+<td><code>[Int]</code></td><td><code>[1, 2, null]</code></td><td><code>[1, 2, null]</code></td></tr>
 <tr>
-<td><code>[Int]</code> </td><td><code>[1, 2, Error]</code> </td><td><code>[1, 2, null]</code> (With logged error)</td></tr>
+<td><code>[Int]</code></td><td><code>[1, 2, Error]</code></td><td><code>[1, 2, null]</code> (With logged error)</td></tr>
 <tr>
-<td><code>[Int]!</code> </td><td><code>[1, 2, 3]</code> </td><td><code>[1, 2, 3]</code></td></tr>
+<td><code>[Int]!</code></td><td><code>[1, 2, 3]</code></td><td><code>[1, 2, 3]</code></td></tr>
 <tr>
-<td><code>[Int]!</code> </td><td><code>null</code> </td><td>Error: Value cannot be null</td></tr>
+<td><code>[Int]!</code></td><td><code>null</code></td><td>Error: Value cannot be null</td></tr>
 <tr>
-<td><code>[Int]!</code> </td><td><code>[1, 2, null]</code> </td><td><code>[1, 2, null]</code></td></tr>
+<td><code>[Int]!</code></td><td><code>[1, 2, null]</code></td><td><code>[1, 2, null]</code></td></tr>
 <tr>
-<td><code>[Int]!</code> </td><td><code>[1, 2, Error]</code> </td><td><code>[1, 2, null]</code> (With logged error)</td></tr>
+<td><code>[Int]!</code></td><td><code>[1, 2, Error]</code></td><td><code>[1, 2, null]</code> (With logged error)</td></tr>
 <tr>
-<td><code>[Int!]</code> </td><td><code>[1, 2, 3]</code> </td><td><code>[1, 2, 3]</code></td></tr>
+<td><code>[Int!]</code></td><td><code>[1, 2, 3]</code></td><td><code>[1, 2, 3]</code></td></tr>
 <tr>
-<td><code>[Int!]</code> </td><td><code>null</code> </td><td><code>null</code></td></tr>
+<td><code>[Int!]</code></td><td><code>null</code></td><td><code>null</code></td></tr>
 <tr>
-<td><code>[Int!]</code> </td><td><code>[1, 2, null]</code> </td><td><code>null</code> (With logged coercion error)</td></tr>
+<td><code>[Int!]</code></td><td><code>[1, 2, null]</code></td><td><code>null</code> (With logged coercion error)</td></tr>
 <tr>
-<td><code>[Int!]</code> </td><td><code>[1, 2, Error]</code> </td><td><code>null</code> (With logged error)</td></tr>
+<td><code>[Int!]</code></td><td><code>[1, 2, Error]</code></td><td><code>null</code> (With logged error)</td></tr>
 <tr>
-<td><code>[Int!]!</code> </td><td><code>[1, 2, 3]</code> </td><td><code>[1, 2, 3]</code></td></tr>
+<td><code>[Int!]!</code></td><td><code>[1, 2, 3]</code></td><td><code>[1, 2, 3]</code></td></tr>
 <tr>
-<td><code>[Int!]!</code> </td><td><code>null</code> </td><td>Error: Value cannot be null</td></tr>
+<td><code>[Int!]!</code></td><td><code>null</code></td><td>Error: Value cannot be null</td></tr>
 <tr>
-<td><code>[Int!]!</code> </td><td><code>[1, 2, null]</code> </td><td>Error: Item cannot be null</td></tr>
+<td><code>[Int!]!</code></td><td><code>[1, 2, null]</code></td><td>Error: Item cannot be null</td></tr>
 <tr>
-<td><code>[Int!]!</code> </td><td><code>[1, 2, Error]</code> </td><td>Error: Error occurred in item</td></tr>
+<td><code>[Int!]!</code></td><td><code>[1, 2, Error]</code></td><td>Error: Error occurred in item</td></tr>
 </tbody>
 </table>
 </section>
@@ -6496,26 +6496,26 @@ Previous versions of this spec did not describe the <code>extensions</code> entr
 <p>When using JSON as a serialization of GraphQL responses, the following JSON values should be used to encode the related GraphQL values:</p>
 <table>
 <thead><tr>
-<th>GraphQL Value </th>
-<th>JSON Value </th>
+<th>GraphQL Value</th>
+<th>JSON Value</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>Map </td><td>Object </td></tr>
+<td>Map</td><td>Object</td></tr>
 <tr>
-<td>List </td><td>Array </td></tr>
+<td>List</td><td>Array</td></tr>
 <tr>
-<td>Null </td><td><span class="spec-keyword">null</span> </td></tr>
+<td>Null</td><td><span class="spec-keyword">null</span></td></tr>
 <tr>
-<td>String </td><td>String </td></tr>
+<td>String</td><td>String</td></tr>
 <tr>
-<td>Boolean </td><td><span class="spec-keyword">true</span> or <span class="spec-keyword">false</span> </td></tr>
+<td>Boolean</td><td><span class="spec-keyword">true</span> or <span class="spec-keyword">false</span></td></tr>
 <tr>
-<td>Int </td><td>Number </td></tr>
+<td>Int</td><td>Number</td></tr>
 <tr>
-<td>Float </td><td>Number </td></tr>
+<td>Float</td><td>Number</td></tr>
 <tr>
-<td>Enum Value </td><td>String </td></tr>
+<td>Enum Value</td><td>String</td></tr>
 </tbody>
 </table>
 <div id="note-786e2" class="spec-note">

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -2207,19 +2207,19 @@
                     [
                       {
                         "type": "Text",
-                        "value": "This "
+                        "value": "This"
                       }
                     ],
                     [
                       {
                         "type": "Text",
-                        "value": "is a "
+                        "value": "is a"
                       }
                     ],
                     [
                       {
                         "type": "Text",
-                        "value": "table "
+                        "value": "table"
                       }
                     ]
                   ],
@@ -2228,19 +2228,19 @@
                       [
                         {
                           "type": "Text",
-                          "value": "key  "
+                          "value": "key"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "val  "
+                          "value": "val"
                         }
                       ],
                       [
                         {
                           "type": "Text",
-                          "value": "etc   "
+                          "value": "etc"
                         }
                       ]
                     ]

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1515,13 +1515,13 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 <p>Produces the following:</p>
 <table>
 <thead><tr>
-<th>This </th>
-<th>is a </th>
-<th>table </th>
+<th>This</th>
+<th>is a</th>
+<th>table</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>key </td><td>val </td><td>etc </td></tr>
+<td>key</td><td>val</td><td>etc</td></tr>
 </tbody>
 </table>
 <p>Table cells can contain any content that a paragraph can contain.</p>

--- a/test/tables/ast.json
+++ b/test/tables/ast.json
@@ -25,7 +25,7 @@
             [
               {
                 "type": "Text",
-                "value": "Alpha "
+                "value": "Alpha"
               }
             ],
             [
@@ -40,7 +40,7 @@
               [
                 {
                   "type": "Text",
-                  "value": "a     "
+                  "value": "a"
                 }
               ],
               [
@@ -67,13 +67,13 @@
             [
               {
                 "type": "Text",
-                "value": "Alpha "
+                "value": "Alpha"
               }
             ],
             [
               {
                 "type": "Text",
-                "value": "Beta "
+                "value": "Beta"
               }
             ]
           ],
@@ -82,13 +82,13 @@
               [
                 {
                   "type": "Text",
-                  "value": "a     "
+                  "value": "a"
                 }
               ],
               [
                 {
                   "type": "Text",
-                  "value": "b    "
+                  "value": "b"
                 }
               ]
             ]
@@ -109,13 +109,13 @@
             [
               {
                 "type": "Text",
-                "value": "Alpha "
+                "value": "Alpha"
               }
             ],
             [
               {
                 "type": "Text",
-                "value": "Beta "
+                "value": "Beta"
               }
             ]
           ],
@@ -124,13 +124,13 @@
               [
                 {
                   "type": "Text",
-                  "value": "a     "
+                  "value": "a"
                 }
               ],
               [
                 {
                   "type": "Text",
-                  "value": "b    "
+                  "value": "b"
                 }
               ]
             ]
@@ -151,7 +151,7 @@
             [
               {
                 "type": "Text",
-                "value": "Alpha "
+                "value": "Alpha"
               }
             ],
             [
@@ -166,7 +166,7 @@
               [
                 {
                   "type": "Text",
-                  "value": "a     "
+                  "value": "a"
                 }
               ],
               [
@@ -193,7 +193,7 @@
             [
               {
                 "type": "Text",
-                "value": "Alpha "
+                "value": "Alpha"
               }
             ]
           ],
@@ -202,7 +202,7 @@
               [
                 {
                   "type": "Text",
-                  "value": "a     "
+                  "value": "a"
                 }
               ]
             ]

--- a/test/tables/output.html
+++ b/test/tables/output.html
@@ -1039,55 +1039,55 @@ pre[class*="language-"] {
 <p>Naked table</p>
 <table>
 <thead><tr>
-<th>Alpha </th>
+<th>Alpha</th>
 <th>Beta</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>a </td><td>b</td></tr>
+<td>a</td><td>b</td></tr>
 </tbody>
 </table>
 <p>Wrapped table</p>
 <table>
 <thead><tr>
-<th>Alpha </th>
-<th>Beta </th>
+<th>Alpha</th>
+<th>Beta</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>a </td><td>b </td></tr>
+<td>a</td><td>b</td></tr>
 </tbody>
 </table>
 <p>Right wrapped</p>
 <table>
 <thead><tr>
-<th>Alpha </th>
-<th>Beta </th>
+<th>Alpha</th>
+<th>Beta</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>a </td><td>b </td></tr>
+<td>a</td><td>b</td></tr>
 </tbody>
 </table>
 <p>Left wrapped</p>
 <table>
 <thead><tr>
-<th>Alpha </th>
+<th>Alpha</th>
 <th>Beta</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>a </td><td>b</td></tr>
+<td>a</td><td>b</td></tr>
 </tbody>
 </table>
 <p>Wrapped solo</p>
 <table>
 <thead><tr>
-<th>Alpha </th>
+<th>Alpha</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>a </td></tr>
+<td>a</td></tr>
 </tbody>
 </table>
 <p>Left wrapped solo</p>


### PR DESCRIPTION
This is not required for prettier support, but it does bring consistency to the printer. In Markdown you can write a table like:

```
a | b | c
--- | --- | ---
1 | 2 | 3
```

a | b | c
--- | --- | ---
1 | 2 | 3


or like:

```
| a   | b   | c   |
| --- | --- | --- |
| 1   | 2   | 3   |
```

| a   | b   | c   |
| --- | --- | --- |
| 1   | 2   | 3   |

The visual output of these is equivalent, but in spec-md the trailing spaces inside the `<th>` and `<td>` elements are included in the output HTML, leaving an output difference between the two forms.

Adopting this PR would cause whitespace-only churn now, but would lead to fewer table-related diffs in future.