### PR TITLE
Allow escaping any ASCII punctuation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "build-peg": "pegjs --allowed-start-rules initialDocument,importedDocument src/grammar.pegjs src/generated/grammar.js",
     "build-js": "cd src/client; for file in *.js; do terser -cm --toplevel \"$file\" > \"../generated/$file\"; done",
     "generate": "mkdir -p out && ./bin/spec-md -m spec/metadata.json README.md > out/index.html",
-    "test": "node ./test/runner.js",
-    "watch": "nodemon -e css,js,json,pegjs,md --ignore src/generated --exec 'npm run build && npm test'"
+    "test": "npm run build && node ./test/runner.js",
+    "record-test": "RECORD=1 npm test",
+    "watch": "nodemon -e css,js,json,pegjs,md --ignore src/generated --exec 'npm test'"
   },
   "dependencies": {
     "prismjs": "^1.23.0"

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -26,26 +26,15 @@ You can type \*literal asterisks\* instead of emphasis by typing
 
 Escaping does not apply within code.
 
-Spec Markdown provides backslash escapes for the following characters:
+Spec Markdown allows backslash escapes for any ASCII punctuation character.
 
 ```
-\   backslash
-`   backtick
-*   asterisk
-_   underscore
-{}  curly braces
-[]  square brackets
-()  parentheses
-#   hash mark
-+   plus sign
--   minus sign (hyphen)
-.   dot
-!   exclamation mark
-<   less-than    <-- added in Spec Markdown
->   greater-than <-- added in Spec Markdown
-|   pipe         <-- added in Spec Markdown
+\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
 ```
 
+Produces the following:
+
+\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
 
 ## Inline formatting
 

--- a/test/escape-sequence/ast.json
+++ b/test/escape-sequence/ast.json
@@ -109,10 +109,63 @@
                         "value": "\"string _ \\\" literal\""
                       }
                     ]
-                  },
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "Plain "
+            },
+            {
+              "type": "InlineCode",
+              "code": "code literals don't allow \\\" escapes\\"
+            }
+          ]
+        },
+        {
+          "type": "Production",
+          "token": {
+            "type": "NonTerminal",
+            "name": "LiteralBackticks",
+            "params": null
+          },
+          "defType": 1,
+          "rhs": {
+            "type": "ListRHS",
+            "defs": [
+              {
+                "type": "RHS",
+                "condition": null,
+                "tokens": [
                   {
-                    "type": "Text",
-                    "value": "\n"
+                    "type": "Terminal",
+                    "value": "`"
+                  }
+                ]
+              },
+              {
+                "type": "RHS",
+                "condition": null,
+                "tokens": [
+                  {
+                    "type": "Terminal",
+                    "value": "``"
+                  }
+                ]
+              },
+              {
+                "type": "RHS",
+                "condition": null,
+                "tokens": [
+                  {
+                    "type": "Terminal",
+                    "value": "```"
                   }
                 ]
               }

--- a/test/escape-sequence/input.md
+++ b/test/escape-sequence/input.md
@@ -11,3 +11,10 @@ Grammar: \< rules \> "and \_ prose"
 Algorithm\_Names(and\_param, \_names):
   * And \* steps
   * And {Call\_with("string \_ \" literal")}
+
+Plain `code literals don't allow \" escapes\`
+
+LiteralBackticks:
+  - `` ` ``
+  - ``` `` ```
+  - ` ``` `

--- a/test/escape-sequence/output.html
+++ b/test/escape-sequence/output.html
@@ -1044,11 +1044,17 @@ pre[class*="language-"] {
 <div class="spec-algo" id="Algorithm_Names()">
 <span class="spec-call"><a href="#Algorithm_Names()" data-name="Algorithm_Names">Algorithm_Names</a>(<var data-name="and_param">and_param</var>, <var data-name="_names">_names</var>)</span><ol>
 <li>And * steps</li>
-<li>And <span class="spec-call"><span data-name="Call_with">Call_with</span>(<span class="spec-string">"string _ \" literal"</span>)</span> </li>
+<li>And <span class="spec-call"><span data-name="Call_with">Call_with</span>(<span class="spec-string">"string _ \" literal"</span>)</span></li>
 </ol>
 </div>
+<p>Plain <code>code literals don&#x27;t allow \&quot; escapes\</code></p>
+<div class="spec-production" id="LiteralBackticks">
+<span class="spec-nt"><a href="#LiteralBackticks" data-name="LiteralBackticks">LiteralBackticks</a></span><div class="spec-rhs"><span class="spec-t">`</span></div>
+<div class="spec-rhs"><span class="spec-t">``</span></div>
+<div class="spec-rhs"><span class="spec-t">```</span></div>
+</div>
 </section>
-<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algorithm_Names()">Algorithm_Names</a></li><li><a href="#Grammar">Grammar</a></li></ol></section></article>
+<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algorithm_Names()">Algorithm_Names</a></li><li><a href="#Grammar">Grammar</a></li><li><a href="#LiteralBackticks">LiteralBackticks</a></li></ol></section></article>
 <footer>
 Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</footer>
 <input hidden class="spec-sidebar-toggle" type="checkbox" id="spec-sidebar-toggle" aria-hidden /><label for="spec-sidebar-toggle" aria-hidden><div class="spec-sidebar-button">&#x2630;</div></label>

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -318,7 +318,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Spec Markdown provides backslash escapes for the following characters:"
+                      "value": "Spec Markdown allows backslash escapes for any ASCII punctuation character."
                     }
                   ]
                 },
@@ -328,7 +328,25 @@
                   "lang": null,
                   "example": false,
                   "counter": false,
-                  "code": "\\   backslash\n`   backtick\n*   asterisk\n_   underscore\n{}  curly braces\n[]  square brackets\n()  parentheses\n#   hash mark\n+   plus sign\n-   minus sign (hyphen)\n.   dot\n!   exclamation mark\n<   less-than    <-- added in Spec Markdown\n>   greater-than <-- added in Spec Markdown\n|   pipe         <-- added in Spec Markdown\n"
+                  "code": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n"
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Produces the following:"
+                    }
+                  ]
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+                    }
+                  ]
                 }
               ]
             }

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1171,23 +1171,11 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <p>Markdown makes use of certain characters to format text, in order to render one explicitly, place a backslash before it.</p>
 <p>You can type *literal asterisks* instead of emphasis by typing <code>\*literal asterisks\*</code>.</p>
 <p>Escaping does not apply within code.</p>
-<p>Spec Markdown provides backslash escapes for the following characters:</p>
-<pre><code>\   backslash
-`   backtick
-*   asterisk
-_   underscore
-{}  curly braces
-[]  square brackets
-()  parentheses
-#   hash mark
-+   plus sign
--   minus sign (hyphen)
-.   dot
-!   exclamation mark
-&lt;   less-than    &lt;-- added in Spec Markdown
-&gt;   greater-than &lt;-- added in Spec Markdown
-|   pipe         &lt;-- added in Spec Markdown
+<p>Spec Markdown allows backslash escapes for any ASCII punctuation character.</p>
+<pre><code>\!\&quot;\#\$\%\&amp;\&#x27;\(\)\*\+\,\-\.\/\:\;\&lt;\=\&gt;\?\@\[\\\]\^\_\`\{\|\}\~
 </code></pre>
+<p>Produces the following:</p>
+<p>!&rdquo;#$%&&rsquo;()*+,-./:;&hArr;?@[\]^_`{|}~</p>
 </section>
 </section>
 <section id="sec-Inline-formatting" secid="2.2">


### PR DESCRIPTION
As I learned from #55, an extended set of punctuation from the original core set may be escaped. Commonmark defines all ascii punctuation as escapeable https://spec.commonmark.org/0.29/#backslash-escapes

This change extends the `escaped` grammar and `unescape()` function to include all ASCII punct ranges, and fixes some bugs uncovered by that change within quoted strings and grammar terminals.

A critical bug was another gap from commonmark for [code spans](https://spec.commonmark.org/0.29/#code-spans). This diff also includes multi backquote and space removal as defined. This removes a specmd-only quirk for quoted inline code as terminals.