### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         node-version: [10.x, 12.x, 14.x, 15.x]
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
   },
   "main": "./src/index.js",
   "scripts": {
-    "build": "mkdir -p src/generated && npm run build-peg && npm run build-js",
-    "build-peg": "pegjs --allowed-start-rules initialDocument,importedDocument --output src/generated/grammar.js src/grammar.pegjs",
-    "build-js": "cd src/client; for file in *.js; do terser -cm --toplevel \"$file\" > \"../generated/$file\"; done",
+    "build": "node scripts/build.js",
     "generate": "mkdir -p out && ./bin/spec-md -m spec/metadata.json README.md > out/index.html",
-    "test": "npm run build && node ./test/runner.js",
+    "test": "npm run build && node ./scripts/test.js",
     "record-test": "RECORD=1 npm test",
     "watch": "nodemon -e css,js,json,pegjs,md --ignore src/generated --exec 'npm test'"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,23 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const { join, extname } = require('path');
+
+const clientPath = join('src','client')
+const generatedPath = join('src', 'generated');
+
+function exec(cmd) {
+  console.log('> ' + cmd)
+  execSync(cmd)
+}
+
+if (!fs.existsSync(generatedPath)) {
+  fs.mkdirSync(generatedPath);
+}
+
+exec(`pegjs --allowed-start-rules initialDocument,importedDocument --output ${join(generatedPath, 'grammar.js')} ${join('src','grammar.pegjs')}`)
+
+for (const file of fs.readdirSync(clientPath)) {
+  if (extname(file) === '.js') {
+    exec(`terser -cm --toplevel ${join(clientPath, file)} > ${join(generatedPath, file)}`)
+  }
+}

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -334,7 +334,7 @@ reference = '{' !('++'/'--') _ ref:(call / value / token)? _ close:'}'? {
 
 inlineCode = code:(inlineCode1 / inlineCode2 / inlineCode3) {
   // https://spec.commonmark.org/0.29/#code-spans
-  code = code.replace(/\r\n|\r|\n/g, ' ')
+  code = code.replace(/\r\n|\n|\r/g, ' ')
   if (code.startsWith(' ') && code.endsWith(' ') && !code.match(/^\s+$/)) {
     code = code.slice(1, -1)
   }
@@ -759,7 +759,7 @@ butNot = 'but' WB __ 'not' WB __ ('one' WB __ 'of' WB __)? first:token rest:(__ 
   };
 }
 
-regexp = '/' value:$(([^/\n] / '\\/')+)? closer:'/'? {
+regexp = '/' value:$(([^/\n\r] / '\\/')+)? closer:'/'? {
   if (value === null || closer === null) {
     error('Malformed regular expression.');
   }
@@ -776,7 +776,7 @@ quotedTerminal = inlineCode:inlineCode {
   };
 }
 
-terminal = value:$([^ \n"/`] [^ \n"\`,\]\}]*) {
+terminal = value:$([^ \n\r"/`] [^ \n\r"\`,\]\}]*) {
   return {
     type: 'Terminal',
     value: unescape(value)
@@ -808,8 +808,8 @@ DEDENT = &lineStart !{ indentStack.length === 0 } {
   indent = indentStack.pop();
 }
 
-NL = '\n' / '\r' / '\r\n'
-NOT_NL = [^\n\r]
+NL = '\r\n' / '\n' / '\r'
+NOT_NL = !NL .
 SINGLE_NL = NL !(NL / _ listBullet)
 _ = ' '*
 // Skips over whitespace including a single newline. Do not use more than once

--- a/src/parse.js
+++ b/src/parse.js
@@ -15,7 +15,8 @@ async function parse(filepath) {
 function readFile(filepath) {
   return new Promise((resolve, reject) => {
     fs.readFile(filepath, { encoding: 'utf8' }, (err, result) =>
-      err ? reject(err) : resolve(result)
+      // Normalize line endings
+      err ? reject(err) : resolve(result.replace(/\r\n|\n|\r/g, '\n'))
     );
   });
 }
@@ -44,7 +45,7 @@ function parseSpecMD(filepath, source, startRule) {
     if (error && error.location) {
       error.filepath = filepath;
       error.source = source;
-      const lines = source.split(/\r\n|\n|\r/g);
+      const lines = source.split('\n');
       const start = error.location.start;
       let location = filepath + ':' + start.line + ':' + start.column + '\n';
       let lineChars = String(start.line + 1).length

--- a/src/print.js
+++ b/src/print.js
@@ -863,15 +863,21 @@ function execStaticJS(filename) {
 }
 
 function readStatic(filename) {
-  return fs.readFileSync(path.join(__dirname, filename), 'utf8');
+  return readFile(path.join(__dirname, filename));
 }
 
 function readPrismCSS() {
-  const filename = path.join(
-    path.dirname(require.resolve('prismjs')),
-    'themes/prism.css'
+  return readFile(
+    path.join(
+      path.dirname(require.resolve('prismjs')),
+      'themes/prism.css'
+    )
   );
-  return fs.readFileSync(filename, 'utf8');
+}
+
+function readFile(filename) {
+  // Normalize line endings
+  return fs.readFileSync(filename, 'utf8').replace(/\r\n|\n|\r/g, '\n');
 }
 
 function stableCodeHash(code) {


### PR DESCRIPTION
Adds Windows support by supporting CRLF line endings in the grammar and normalizing line endings during test runs.

Fixes #26 
