### PR TITLE
Overhaul smart typography

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -5,16 +5,21 @@ const specMarkdown = require('../');
 
 const shouldRecord = Boolean(process.env.RECORD);
 
+function testSource(dir, input) {
+  return [input || `test/${dir}/input.md`, `test/${dir}/ast.json`, `test/${dir}/output.html`];
+}
+
 runTests([
-  ['README.md', 'test/readme/ast.json', 'test/readme/output.html'],
-  ['test/graphql-spec/GraphQL.md', 'test/graphql-spec/ast.json', 'test/graphql-spec/output.html'],
-  ['test/simple-header/input.md', 'test/simple-header/ast.json', 'test/simple-header/output.html'],
-  ['test/sections/input.md', 'test/sections/ast.json', 'test/sections/output.html'],
-  ['test/tables/input.md', 'test/tables/ast.json', 'test/tables/output.html'],
-  ['test/task-lists/input.md', 'test/task-lists/ast.json', 'test/task-lists/output.html'],
-  ['test/escape-sequence/input.md', 'test/escape-sequence/ast.json', 'test/escape-sequence/output.html'],
-  ['test/duplicated-notes/input.md', 'test/duplicated-notes/ast.json', 'test/duplicated-notes/output.html'],
-  ['test/productions/input.md', 'test/productions/ast.json', 'test/productions/output.html'],
+  testSource('duplicated-notes'),
+  testSource('escape-sequence'),
+  testSource('graphql-spec', 'test/graphql-spec/GraphQL.md'),
+  testSource('productions'),
+  testSource('readme', 'README.md'),
+  testSource('sections'),
+  testSource('simple-header'),
+  testSource('smart-quotes'),
+  testSource('tables'),
+  testSource('task-lists'),
 ]);
 
 async function runTests(tests) {

--- a/spec/Spec Additions.md
+++ b/spec/Spec Additions.md
@@ -143,17 +143,21 @@ Will render as:
 
 "She told me that 'he isn't here right *now*' - so I left."
 
+Escaped `\"quotes \'and single\-quotes\'\"` becomes: \"quotes \'and single\-quotes\'\".
 
 ### Math
 
 Math operators like >=, <=, and ~= can be written as `>=`, `<=`, and `~=`.
 
+Escaped `\>= \<= \~=` becomes: \>= \<= \~=.
 
 ### Arrows
 
 Smart arrows -> and <- and <-> can be written as `->`, `<-` and `<->`.
 
 Fat smart arrows => and <== and <=> can be written as `=>`, `<==` and `<=>`.
+
+Escaped `\-> \<- \<-> \=> \<== \<=>` becomes: \-> \<- \<-> \=> \<== \<=>.
 
 
 ### Tables

--- a/src/print.js
+++ b/src/print.js
@@ -310,7 +310,7 @@ function printTOC(ast, options) {
         const secID = join(node.secID, '.');
         return (
           '<li>' +
-            '<a href="' + options.biblio[node.id] + '">' +
+            '<a href="' + encodeURI(options.biblio[node.id]) + '">' +
               '<span class="spec-secid">' + secID + '</span>' +
               escape(node.title) +
             '</a>' +
@@ -346,14 +346,14 @@ function printSidebar(ast, options) {
         const subSections = join(node.contents);
         const secID = join(node.secID, '.');
         return (
-          '<li id="_sidebar_' + secID + '">' +
-            '<a href="' + options.biblio[node.id] + '">' +
-              '<span class="spec-secid">' + join(node.secID, '.') + '</span>' +
+          '<li id="' + escapeAttr('_sidebar_' + secID) + '">' +
+            '<a href="' + encodeURI(options.biblio[node.id]) + '">' +
+              '<span class="spec-secid">' + escape(join(node.secID, '.')) + '</span>' +
               escape(node.title) +
             '</a>' +
             (subSections &&
-              '\n<input hidden class="toggle" type="checkbox" id="_toggle_' + secID + '" />' +
-              '<label for="_toggle_' + secID + '"></label>\n' +
+              '\n<input hidden class="toggle" type="checkbox" id="' + escapeAttr('_toggle_' + secID) + '" />' +
+              '<label for="' + escapeAttr('_toggle_' + secID) + '"></label>\n' +
               '<ol>\n' + subSections + '</ol>\n') +
           '</li>\n'
         );
@@ -403,10 +403,10 @@ function printAll(list, options) {
           const level = Math.min(node.secID.length, 6);
           const secID = join(node.secID, '.');
           return (
-            '<section id="' + node.id + '" secid="' + secID + '">\n' +
+            '<section id="' + escapeAttr(node.id) + '" secid="' + escapeAttr(secID) + '">\n' +
               '<h' + level + '>' +
               '<span class="spec-secid" title="link to this section">' +
-                '<a href="' + options.biblio[node.id] + '">' + secID + '</a>' +
+                '<a href="' + encodeURI(options.biblio[node.id]) + '">' + escape(secID) + '</a>' +
               '</span>' +
               escape(node.title) +
               '</h' + level + '>\n' +
@@ -417,9 +417,9 @@ function printAll(list, options) {
 
         case 'Subsection':
           return (
-            '<section id="' + node.id + '" class="subsec">\n' +
+            '<section id="' + escapeAttr(node.id) + '" class="subsec">\n' +
               '<h6>' +
-                '<a href="' + options.biblio[node.id] + '" title="link to this subsection">' +
+                '<a href="' + encodeURI(options.biblio[node.id]) + '" title="link to this subsection">' +
                   escape(node.title) +
                 '</a>' +
               '</h6>\n' +
@@ -437,7 +437,7 @@ function printAll(list, options) {
           return '<p>' + join(node.contents) + '</p>\n';
 
         case 'Text':
-          return formatText(node.value);
+          return escape(node.value);
 
         case 'Bold':
           return '<strong>' + join(node.contents) + '</strong>';
@@ -447,8 +447,8 @@ function printAll(list, options) {
 
         case 'Note':
           return (
-            '<div id="' + node.id + '" class="spec-note">\n' +
-              '<a href="#' + node.id + '">Note</a>\n' +
+            '<div id="' + escapeAttr(node.id) + '" class="spec-note">\n' +
+              '<a href="' + encodeURI('#' + node.id) + '">Note</a>\n' +
               join(node.contents) +
             '</div>\n'
           );
@@ -471,9 +471,9 @@ function printAll(list, options) {
         case 'Code':
           return (
             '<pre' +
-              (node.id ? ' id="' + node.id + '"' : '') +
+              (node.id ? ' id="' + escapeAttr(node.id) + '"' : '') +
               (node.counter ? ' class="spec-counter-example"' : node.example ? ' class="spec-example"' : '') +
-              (node.lang ? ' data-language="' + node.lang + '"' : '') +
+              (node.lang ? ' data-language="' + escapeAttr(node.lang) + '"' : '') +
             '>' +
             (node.example ? link({name: (node.counter ? 'Counter Example № ' : 'Example № ') + node.number}, node.id, options) : '') +
             '<code>' +
@@ -492,7 +492,7 @@ function printAll(list, options) {
         case 'Image':
           return (
             '<img src="' + encodeURI(node.url) + '"' +
-              (node.alt ? ' alt="' + escape(node.alt) + '"' : '') +
+              (node.alt ? ' alt="' + escapeAttr(node.alt) + '"' : '') +
             '/>'
           );
 
@@ -530,7 +530,7 @@ function printAll(list, options) {
 
         case 'Algorithm':
           return (
-            '<div class="spec-algo" id="' + node.id + '">\n' +
+            '<div class="spec-algo" id="' + escapeAttr(node.id) + '">\n' +
               node.call +
               node.steps +
             '</div>\n'
@@ -764,7 +764,7 @@ function link(node, id, options, doHighlight) {
     return content;
   }
   return (
-    '<a href="' + href + '"' +
+    '<a href="' + encodeURI(href) + '"' +
       (doHighlight ? ' data-name="' + anchorize(node.name) + '"' : '') +
       (href[0] !== '#' ? ' target="_blank"' : '') + '>' +
       content +
@@ -793,16 +793,14 @@ function resolveLinkUrl(url, options) {
   return url
 }
 
-const ESCAPE_CODE_REGEX = /[><"'&]/g;
-const ESCAPE_REGEX = /\u2010|\u2013|\u2014|\u2018|\u2019|\u201C|\u201D|\u2190|\u2192|\u2194|\u21D0|\u21D2|\u21D4|\u2245|\u2264|\u2265|[><"']|(?:&(?!\S{1,10};))/g;
+const ESCAPE_CODE_REGEX = /[><&]/g;
+const ESCAPE_REGEX = /\u2013|\u2014|\u2018|\u2019|\u201C|\u201D|\u2190|\u2192|\u2194|\u21D0|\u21D2|\u21D4|\u2248|\u2264|\u2265|[><]|(?:&(?!#?[\w]{1,10};))/g;
 
 const ESCAPE_LOOKUP = {
   '&': '&amp;',
   '>': '&gt;',
   '<': '&lt;',
   '"': '&quot;',
-  '\'': '&#x27;',
-  '\u2010': '&#8208;',
   '\u2013': '&ndash;',
   '\u2014': '&mdash;',
   '\u2018': '&lsquo;',
@@ -815,7 +813,7 @@ const ESCAPE_LOOKUP = {
   '\u21D0': '&lArr;',
   '\u21D2': '&rArr;',
   '\u21D4': '&hArr;',
-  '\u2245': '&cong;',
+  '\u2248': '&asymp;',
   '\u2264': '&le;',
   '\u2265': '&ge;',
 };
@@ -828,33 +826,12 @@ function escapeCode(text) {
   return text.replace(ESCAPE_CODE_REGEX, escaper);
 }
 
-function escape(text) {
-  return text.replace(ESCAPE_REGEX, escaper);
+function escapeAttr(text) {
+  return escape(text).replace('"', '&quot;');
 }
 
-function formatText(text) {
-  return escape(text
-    .replace(/[ \n\r]+/g, ' ')
-    .replace(/<-+>/g, '\u2194')
-    .replace(/<-+/g, '\u2190')
-    .replace(/-+>/g, '\u2192')
-    .replace(/<=+>/g, '\u21D4')
-    .replace(/<==+/g, '\u21D0')
-    .replace(/=+>/g, '\u21D2')
-    .replace(/~=/g, '\u2245')
-    .replace(/<=/g, '\u2264')
-    .replace(/>=/g, '\u2265')
-    .replace(/(\w)--(?=\w)/g, '$1\u2014')
-    .replace(/(\w)-(?=\w)/g, '$1\u2010')
-    .replace(/(\S\s)-(?=\s\S)/g, '$1\u2013')
-    .replace(/(\s)"/g, '$1\u201C')
-    .replace(/"(?=\w)/g, '\u201C')
-    .replace(/"/g, '\u201D')
-    .replace(/(\w)'(?=\w)/g, '$1\u2019')
-    .replace(/(\s)'/g, '\u2018')
-    .replace(/'(?=\w)/g, '\u2018')
-    .replace(/'/g, '\u2019')
-  );
+function escape(text) {
+  return text.replace(ESCAPE_REGEX, escaper);
 }
 
 function execStaticJS(filename) {

--- a/test/duplicated-notes/ast.json
+++ b/test/duplicated-notes/ast.json
@@ -667,7 +667,7 @@
       "contents": [
         {
           "type": "Text",
-          "value": "Note\n"
+          "value": "Note "
         }
       ]
     }

--- a/test/graphql-spec/ast.json
+++ b/test/graphql-spec/ast.json
@@ -28,7 +28,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "This is the specification for GraphQL, a query language and execution engine\noriginally created at Facebook in 2012 for describing the capabilities and\nrequirements of data models for client-server applications. The development of\nthis open standard started in 2015. This specification was licensed under OWFa\n1.0 in 2017. Copyright and trademark was transferred to the GraphQL Foundation\nin 2019."
+              "value": "This is the specification for GraphQL, a query language and execution engine originally created at Facebook in 2012 for describing the capabilities and requirements of data models for client-server applications. The development of this open standard started in 2015. This specification was licensed under OWFa 1.0 in 2017. Copyright and trademark was transferred to the GraphQL Foundation in 2019."
             }
           ]
         },
@@ -37,7 +37,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "GraphQL has evolved and may continue to evolve in future editions of this\nspecification. Previous editions of the GraphQL specification can be found at\npermalinks that match their "
+              "value": "GraphQL has evolved and may continue to evolve in future editions of this specification. Previous editions of the GraphQL specification can be found at permalinks that match their "
             },
             {
               "type": "Link",
@@ -51,7 +51,7 @@
             },
             {
               "type": "Text",
-              "value": ".\nThe latest working draft release can be found at "
+              "value": ". The latest working draft release can be found at "
             },
             {
               "type": "Link",
@@ -98,7 +98,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "As of September 26, 2017, the following persons or entities have made this\nSpecification available under the Open Web Foundation Final Specification\nAgreement (OWFa 1.0), which is available at "
+              "value": "As of September 26, 2017, the following persons or entities have made this Specification available under the Open Web Foundation Final Specification Agreement (OWFa 1.0), which is available at "
             },
             {
               "type": "Link",
@@ -136,7 +136,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "You can review the signed copies of the Open Web Foundation Final Specification\nAgreement Version 1.0 for this specification at "
+              "value": "You can review the signed copies of the Open Web Foundation Final Specification Agreement Version 1.0 for this specification at "
             },
             {
               "type": "Link",
@@ -150,7 +150,7 @@
             },
             {
               "type": "Text",
-              "value": ",\nwhich may also include additional parties to those listed above."
+              "value": ", which may also include additional parties to those listed above."
             }
           ]
         },
@@ -159,7 +159,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Your use of this Specification may be subject to other third party rights.\nTHIS SPECIFICATION IS PROVIDED “AS IS.” The contributors expressly disclaim any\nwarranties (express, implied, or otherwise), including implied warranties of\nmerchantability, non-infringement, fitness for a particular purpose, or title,\nrelated to the Specification. The entire risk as to implementing or otherwise\nusing the Specification is assumed by the Specification implementer and user.\nIN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY\nFORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER\nFROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS SPECIFICATION OR ITS\nGOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING\nNEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED\nOF THE POSSIBILITY OF SUCH DAMAGE."
+              "value": "Your use of this Specification may be subject to other third party rights. THIS SPECIFICATION IS PROVIDED “AS IS.” The contributors expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the Specification. The entire risk as to implementing or otherwise using the Specification is assumed by the Specification implementer and user. IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS SPECIFICATION OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
             }
           ]
         }
@@ -174,7 +174,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "A conforming implementation of GraphQL must fulfill all normative requirements.\nConformance requirements are described in this document via both\ndescriptive assertions and key words with clearly defined meanings."
+              "value": "A conforming implementation of GraphQL must fulfill all normative requirements. Conformance requirements are described in this document via both descriptive assertions and key words with clearly defined meanings."
             }
           ]
         },
@@ -183,7 +183,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "The key words \"MUST\", \"MUST NOT\", \"REQUIRED\", \"SHALL\", \"SHALL NOT\", \"SHOULD\",\n\"SHOULD NOT\", \"RECOMMENDED\", \"MAY\", and \"OPTIONAL\" in the normative portions of\nthis document are to be interpreted as described in "
+              "value": "The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative portions of this document are to be interpreted as described in "
             },
             {
               "type": "Link",
@@ -197,7 +197,7 @@
             },
             {
               "type": "Text",
-              "value": ".\nThese key words may appear in lowercase and still retain their meaning unless\nexplicitly declared as non-normative."
+              "value": ". These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative."
             }
           ]
         },
@@ -206,7 +206,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "A conforming implementation of GraphQL may provide additional functionality,\nbut must not where explicitly disallowed or would otherwise result\nin non-conformance."
+              "value": "A conforming implementation of GraphQL may provide additional functionality, but must not where explicitly disallowed or would otherwise result in non-conformance."
             }
           ]
         }
@@ -221,7 +221,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Algorithm steps phrased in imperative grammar (e.g. \"Return the result of\ncalling resolver\") are to be interpreted with the same level of requirement as\nthe algorithm it is contained within. Any algorithm referenced within an\nalgorithm step (e.g. \"Let completedResult be the result of calling\nCompleteValue()\") is to be interpreted as having at least the same level of\nrequirement as the algorithm containing that step."
+              "value": "Algorithm steps phrased in imperative grammar (e.g. “Return the result of calling resolver”) are to be interpreted with the same level of requirement as the algorithm it is contained within. Any algorithm referenced within an algorithm step (e.g. “Let completedResult be the result of calling CompleteValue()”) is to be interpreted as having at least the same level of requirement as the algorithm containing that step."
             }
           ]
         },
@@ -230,7 +230,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Conformance requirements expressed as algorithms can be fulfilled by an\nimplementation of this specification in any way as long as the perceived result\nis equivalent. Algorithms described in this document are written to be easy to\nunderstand. Implementers are encouraged to include equivalent but\noptimized implementations."
+              "value": "Conformance requirements expressed as algorithms can be fulfilled by an implementation of this specification in any way as long as the perceived result is equivalent. Algorithms described in this document are written to be easy to understand. Implementers are encouraged to include equivalent but optimized implementations."
             }
           ]
         },
@@ -253,7 +253,7 @@
             },
             {
               "type": "Text",
-              "value": " for more details\nabout the definition of algorithms and other notational conventions used in this\ndocument."
+              "value": " for more details about the definition of algorithms and other notational conventions used in this document."
             }
           ]
         }
@@ -268,7 +268,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "All contents of this document are normative except portions explicitly\ndeclared as non-normative."
+              "value": "All contents of this document are normative except portions explicitly declared as non-normative."
             }
           ]
         },
@@ -277,7 +277,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Examples in this document are non-normative, and are presented to aid\nunderstanding of introduced concepts and the behavior of normative portions of\nthe specification. Examples are either introduced explicitly in prose\n(e.g. \"for example\") or are set apart in example or counter-example blocks,\nlike this:"
+              "value": "Examples in this document are non-normative, and are presented to aid understanding of introduced concepts and the behavior of normative portions of the specification. Examples are either introduced explicitly in prose (e.g. “for example”) or are set apart in example or counter-example blocks, like this:"
             }
           ]
         },
@@ -302,7 +302,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Notes in this document are non-normative, and are presented to clarify intent,\ndraw attention to potential edge-cases and pit-falls, and answer common\nquestions that arise during implementation. Notes are either introduced\nexplicitly in prose (e.g. \"Note: \") or are set apart in a note block, like this:"
+              "value": "Notes in this document are non-normative, and are presented to clarify intent, draw attention to potential edge-cases and pit-falls, and answer common questions that arise during implementation. Notes are either introduced explicitly in prose (e.g. “Note: “) or are set apart in a note block, like this:"
             }
           ]
         },
@@ -327,7 +327,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "GraphQL is a query language designed to build client applications by providing\nan intuitive and flexible syntax and system for describing their data\nrequirements and interactions."
+              "value": "GraphQL is a query language designed to build client applications by providing an intuitive and flexible syntax and system for describing their data requirements and interactions."
             }
           ]
         },
@@ -336,7 +336,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "For example, this GraphQL request will receive the name of the user with id 4\nfrom the Facebook implementation of GraphQL."
+              "value": "For example, this GraphQL request will receive the name of the user with id 4 from the Facebook implementation of GraphQL."
             }
           ]
         },
@@ -370,7 +370,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "GraphQL is not a programming language capable of arbitrary computation, but is\ninstead a language used to query application services that have\ncapabilities defined in this specification. GraphQL does not mandate a\nparticular programming language or storage system for application services that\nimplement it. Instead, application services take their capabilities and map them\nto a uniform language, type system, and philosophy that GraphQL encodes.\nThis provides a unified interface friendly to product development and a powerful\nplatform for tool-building."
+              "value": "GraphQL is not a programming language capable of arbitrary computation, but is instead a language used to query application services that have capabilities defined in this specification. GraphQL does not mandate a particular programming language or storage system for application services that implement it. Instead, application services take their capabilities and map them to a uniform language, type system, and philosophy that GraphQL encodes. This provides a unified interface friendly to product development and a powerful platform for tool-building."
             }
           ]
         },
@@ -401,7 +401,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ": Most product development today involves the creation and\n   manipulation of view hierarchies. To achieve congruence with the structure\n   of these applications, a GraphQL query itself is structured hierarchically.\n   The query is shaped just like the data it returns. It is a natural\n   way for clients to describe data requirements."
+                  "value": ": Most product development today involves the creation and manipulation of view hierarchies. To achieve congruence with the structure of these applications, a GraphQL query itself is structured hierarchically. The query is shaped just like the data it returns. It is a natural way for clients to describe data requirements."
                 }
               ]
             },
@@ -419,7 +419,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ": GraphQL is unapologetically driven by the requirements\n   of views and the front-end engineers that write them. GraphQL starts with\n   their way of thinking and requirements and builds the language and runtime\n   necessary to enable that."
+                  "value": ": GraphQL is unapologetically driven by the requirements of views and the front-end engineers that write them. GraphQL starts with their way of thinking and requirements and builds the language and runtime necessary to enable that."
                 }
               ]
             },
@@ -437,7 +437,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ": Every GraphQL service defines an application-specific\n   type system. Queries are executed within the context of that type system.\n   Given a query, tools can ensure that the query is both syntactically\n   correct and valid within the GraphQL type system before execution, i.e. at\n   development time, and the service can make certain guarantees about the shape\n   and nature of the response."
+                  "value": ": Every GraphQL service defines an application-specific type system. Queries are executed within the context of that type system. Given a query, tools can ensure that the query is both syntactically correct and valid within the GraphQL type system before execution, i.e. at development time, and the service can make certain guarantees about the shape and nature of the response."
                 }
               ]
             },
@@ -455,7 +455,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ": Through its type system, a GraphQL service\n   publishes the capabilities that its clients are allowed to consume. It is\n   the client that is responsible for specifying exactly how it will consume\n   those published capabilities. These queries are specified at field-level\n   granularity. In the majority of client-server applications written\n   without GraphQL, the service determines the data returned in its various\n   scripted endpoints. A GraphQL query, on the other hand, returns exactly what\n   a client asks for and no more."
+                  "value": ": Through its type system, a GraphQL service publishes the capabilities that its clients are allowed to consume. It is the client that is responsible for specifying exactly how it will consume those published capabilities. These queries are specified at field-level granularity. In the majority of client-server applications written without GraphQL, the service determines the data returned in its various scripted endpoints. A GraphQL query, on the other hand, returns exactly what a client asks for and no more."
                 }
               ]
             },
@@ -473,7 +473,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ": GraphQL is introspective. A GraphQL service's type system\n   must be queryable by the GraphQL language itself, as will be described in this\n   specification. GraphQL introspection serves as a powerful platform for\n   building common tools and client software libraries."
+                  "value": ": GraphQL is introspective. A GraphQL service’s type system must be queryable by the GraphQL language itself, as will be described in this specification. GraphQL introspection serves as a powerful platform for building common tools and client software libraries."
                 }
               ]
             }
@@ -484,7 +484,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Because of these principles, GraphQL is a powerful and productive environment\nfor building client applications. Product developers and designers building\napplications against working GraphQL services—supported with quality tools—can\nquickly become productive without reading extensive documentation and with\nlittle or no formal training. To enable that experience, there must be those\nthat build those services and tools."
+              "value": "Because of these principles, GraphQL is a powerful and productive environment for building client applications. Product developers and designers building applications against working GraphQL services—supported with quality tools—can quickly become productive without reading extensive documentation and with little or no formal training. To enable that experience, there must be those that build those services and tools."
             }
           ]
         },
@@ -493,7 +493,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "The following formal specification serves as a reference for those builders.\nIt describes the language and its grammar, the type system and the\nintrospection system used to query it, and the execution and validation engines\nwith the algorithms to power them. The goal of this specification is to provide\na foundation and framework for an ecosystem of GraphQL tools, client libraries,\nand service implementations—spanning both organizations and platforms—that\nhas yet to be built. We look forward to working with the community\nin order to do that.\n"
+              "value": "The following formal specification serves as a reference for those builders. It describes the language and its grammar, the type system and the introspection system used to query it, and the execution and validation engines with the algorithms to power them. The goal of this specification is to provide a foundation and framework for an ecosystem of GraphQL tools, client libraries, and service implementations—spanning both organizations and platforms—that has yet to be built. We look forward to working with the community in order to do that. "
             }
           ]
         }
@@ -509,7 +509,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Clients use the GraphQL query language to make requests to a GraphQL service.\nWe refer to these request sources as documents. A document may contain\noperations (queries, mutations, and subscriptions) as well as fragments, a\ncommon unit of composition allowing for query reuse."
+              "value": "Clients use the GraphQL query language to make requests to a GraphQL service. We refer to these request sources as documents. A document may contain operations (queries, mutations, and subscriptions) as well as fragments, a common unit of composition allowing for query reuse."
             }
           ]
         },
@@ -518,7 +518,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "A GraphQL document is defined as a syntactic grammar where terminal symbols are\ntokens (indivisible lexical units). These tokens are defined in a lexical\ngrammar which matches patterns of source characters. In this document, syntactic\ngrammar productions are distinguished with a colon "
+              "value": "A GraphQL document is defined as a syntactic grammar where terminal symbols are tokens (indivisible lexical units). These tokens are defined in a lexical grammar which matches patterns of source characters. In this document, syntactic grammar productions are distinguished with a colon "
             },
             {
               "type": "InlineCode",
@@ -526,7 +526,7 @@
             },
             {
               "type": "Text",
-              "value": " while lexical grammar\nproductions are distinguished with a double-colon "
+              "value": " while lexical grammar productions are distinguished with a double-colon "
             },
             {
               "type": "InlineCode",
@@ -552,7 +552,7 @@
             },
             {
               "type": "Text",
-              "value": ".\nThe character sequence must be described by a sequence of "
+              "value": ". The character sequence must be described by a sequence of "
             },
             {
               "type": "NonTerminal",
@@ -570,7 +570,7 @@
             },
             {
               "type": "Text",
-              "value": "\nlexical grammars. The lexical token sequence, omitting "
+              "value": " lexical grammars. The lexical token sequence, omitting "
             },
             {
               "type": "NonTerminal",
@@ -579,7 +579,7 @@
             },
             {
               "type": "Text",
-              "value": ", must be\ndescribed by a single "
+              "value": ", must be described by a single "
             },
             {
               "type": "NonTerminal",
@@ -611,7 +611,7 @@
             },
             {
               "type": "Text",
-              "value": " for more information\nabout the lexical and syntactic grammar and other notational conventions used\nthroughout this document."
+              "value": " for more information about the lexical and syntactic grammar and other notational conventions used throughout this document."
             }
           ]
         },
@@ -624,7 +624,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "The source text of a GraphQL document is first converted into a sequence of\nlexical tokens, "
+                  "value": "The source text of a GraphQL document is first converted into a sequence of lexical tokens, "
                 },
                 {
                   "type": "NonTerminal",
@@ -642,7 +642,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". The source text is\nscanned from left to right, repeatedly taking the next possible sequence of\ncode-points allowed by the lexical grammar productions as the next token. This\nsequence of lexical tokens are then scanned from left to right to produce an\nabstract syntax tree (AST) according to the "
+                  "value": ". The source text is scanned from left to right, repeatedly taking the next possible sequence of code-points allowed by the lexical grammar productions as the next token. This sequence of lexical tokens are then scanned from left to right to produce an abstract syntax tree (AST) according to the "
                 },
                 {
                   "type": "NonTerminal",
@@ -673,7 +673,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " to\nremove ambiguity and ensure a single valid lexical analysis. A lexical token is\nonly valid if not followed by a character in its lookahead restriction."
+                  "value": " to remove ambiguity and ensure a single valid lexical analysis. A lexical token is only valid if not followed by a character in its lookahead restriction."
                 }
               ]
             },
@@ -707,7 +707,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ", so cannot\nbe followed by a "
+                  "value": ", so cannot be followed by a "
                 },
                 {
                   "type": "NonTerminal",
@@ -724,7 +724,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " cannot represent\nthe tokens ("
+                  "value": " cannot represent the tokens ("
                 },
                 {
                   "type": "Terminal",
@@ -765,7 +765,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " and\nso must only represent a single token. Use "
+                  "value": " and so must only represent a single token. Use "
                 },
                 {
                   "type": "NonTerminal",
@@ -783,7 +783,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\nbetween characters to represent multiple tokens."
+                  "value": " between characters to represent multiple tokens."
                 }
               ]
             },
@@ -792,7 +792,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "This typically has the same behavior as a\n\""
+                  "value": "This typically has the same behavior as a “"
                 },
                 {
                   "type": "Link",
@@ -806,7 +806,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\" longest possible\nmatch, however some lookahead restrictions include additional constraints."
+                  "value": "” longest possible match, however some lookahead restrictions include additional constraints."
                 }
               ]
             }
@@ -876,7 +876,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL documents are expressed as a sequence of\n"
+                  "value": "GraphQL documents are expressed as a sequence of "
                 },
                 {
                   "type": "Link",
@@ -890,7 +890,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " characters. However, with\nfew exceptions, most of GraphQL is expressed only in the original non-control\nASCII range so as to be as widely compatible with as many existing tools,\nlanguages, and serialization formats as possible and avoid display issues in\ntext editors and source control."
+                  "value": " characters. However, with few exceptions, most of GraphQL is expressed only in the original non-control ASCII range so as to be as widely compatible with as many existing tools, languages, and serialization formats as possible and avoid display issues in text editors and source control."
                 }
               ]
             },
@@ -932,7 +932,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and\n"
+                      "value": " and "
                     },
                     {
                       "type": "NonTerminal",
@@ -950,7 +950,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The \"Byte Order Mark\" is a special Unicode character which\nmay appear at the beginning of a file containing Unicode which programs may use\nto determine the fact that the text stream is Unicode, what endianness the text\nstream is in, and which of several Unicode encodings to interpret."
+                      "value": "The “Byte Order Mark” is a special Unicode character which may appear at the beginning of a file containing Unicode which programs may use to determine the fact that the text stream is Unicode, what endianness the text stream is in, and which of several Unicode encodings to interpret."
                     }
                   ]
                 }
@@ -1000,7 +1000,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "White space is used to improve legibility of source text and act as separation\nbetween tokens, and any amount of white space may appear before or after any\ntoken. White space between tokens is not significant to the semantic meaning of\na GraphQL Document, however white space characters may appear within a\n"
+                      "value": "White space is used to improve legibility of source text and act as separation between tokens, and any amount of white space may appear before or after any token. White space between tokens is not significant to the semantic meaning of a GraphQL Document, however white space characters may appear within a "
                     },
                     {
                       "type": "NonTerminal",
@@ -1027,7 +1027,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL intentionally does not consider Unicode \"Zs\" category characters\nas white-space, avoiding misinterpretation by text editors and source\ncontrol tools."
+                      "value": "GraphQL intentionally does not consider Unicode “Zs” category characters as white-space, avoiding misinterpretation by text editors and source control tools."
                     }
                   ]
                 }
@@ -1102,7 +1102,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Like white space, line terminators are used to improve the legibility of source\ntext, any amount may appear before or after any other token and have no\nsignificance to the semantic meaning of a GraphQL Document. Line\nterminators are not found within any other token."
+                      "value": "Like white space, line terminators are used to improve the legibility of source text, any amount may appear before or after any other token and have no significance to the semantic meaning of a GraphQL Document. Line terminators are not found within any other token."
                     }
                   ]
                 },
@@ -1111,7 +1111,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Any error reporting which provides the line number in the source of the\noffending syntax should use the preceding amount of "
+                      "value": "Any error reporting which provides the line number in the source of the offending syntax should use the preceding amount of "
                     },
                     {
                       "type": "NonTerminal",
@@ -1120,7 +1120,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " to produce\nthe line number."
+                      "value": " to produce the line number."
                     }
                   ]
                 }
@@ -1210,7 +1210,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL source documents may contain single-line comments, starting with the\n"
+                      "value": "GraphQL source documents may contain single-line comments, starting with the "
                     },
                     {
                       "type": "Terminal",
@@ -1236,7 +1236,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " except\n"
+                      "value": " except "
                     },
                     {
                       "type": "NonTerminal",
@@ -1245,7 +1245,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " so a comment always consists of all code points starting with\nthe "
+                      "value": " so a comment always consists of all code points starting with the "
                     },
                     {
                       "type": "Terminal",
@@ -1262,7 +1262,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " (or end of\nthe source)."
+                      "value": " (or end of the source)."
                     }
                   ]
                 },
@@ -1280,7 +1280,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " like white space and may appear after any token, or\nbefore a "
+                      "value": " like white space and may appear after any token, or before a "
                     },
                     {
                       "type": "NonTerminal",
@@ -1289,7 +1289,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", and have no significance to the semantic meaning of a\nGraphQL Document."
+                      "value": ", and have no significance to the semantic meaning of a GraphQL Document."
                     }
                   ]
                 }
@@ -1332,7 +1332,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ") are used to improve\nthe legibility of source text and separate lexical tokens but are otherwise\nsyntactically and semantically insignificant within GraphQL Documents."
+                      "value": ") are used to improve the legibility of source text and separate lexical tokens but are otherwise syntactically and semantically insignificant within GraphQL Documents."
                     }
                   ]
                 },
@@ -1341,7 +1341,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Non-significant comma characters ensure that the absence or presence of a comma\ndoes not meaningfully alter the interpreted syntax of the document, as this can\nbe a common user-error in other languages. It also allows for the stylistic use\nof either trailing commas or line-terminators as list delimiters which are both\noften desired for legibility and maintainability of source code."
+                      "value": "Non-significant comma characters ensure that the absence or presence of a comma does not meaningfully alter the interpreted syntax of the document, as this can be a common user-error in other languages. It also allows for the stylistic use of either trailing commas or line-terminators as list delimiters which are both often desired for legibility and maintainability of source code."
                     }
                   ]
                 }
@@ -1426,7 +1426,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A GraphQL document is comprised of several kinds of indivisible lexical tokens\ndefined here in a lexical grammar by patterns of source Unicode characters."
+                      "value": "A GraphQL document is comprised of several kinds of indivisible lexical tokens defined here in a lexical grammar by patterns of source Unicode characters."
                     }
                   ]
                 },
@@ -1525,7 +1525,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " tokens are used to improve readability and provide separation between\n"
+                      "value": " tokens are used to improve readability and provide separation between "
                     },
                     {
                       "type": "NonTerminal",
@@ -1534,7 +1534,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", but are otherwise insignificant and not referenced in syntactical\ngrammar productions."
+                      "value": ", but are otherwise insignificant and not referenced in syntactical grammar productions."
                     }
                   ]
                 },
@@ -1552,7 +1552,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " may appear before and after every lexical token. No\nignored regions of a source document are significant, however "
+                      "value": " may appear before and after every lexical token. No ignored regions of a source document are significant, however "
                     },
                     {
                       "type": "NonTerminal",
@@ -1561,7 +1561,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nwhich appear in "
+                      "value": " which appear in "
                     },
                     {
                       "type": "NonTerminal",
@@ -1579,7 +1579,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " in a\nsignificant way, for example a "
+                      "value": " in a significant way, for example a "
                     },
                     {
                       "type": "NonTerminal",
@@ -1588,7 +1588,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " may contain white space characters.\nNo "
+                      "value": " may contain white space characters. No "
                     },
                     {
                       "type": "NonTerminal",
@@ -1619,7 +1619,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", for example no white space\ncharacters are permitted between the characters defining a "
+                      "value": ", for example no white space characters are permitted between the characters defining a "
                     },
                     {
                       "type": "NonTerminal",
@@ -1716,7 +1716,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL documents include punctuation in order to describe structure. GraphQL\nis a data description language and not a programming language, therefore GraphQL\nlacks the punctuation often used to describe mathematical expressions."
+                      "value": "GraphQL documents include punctuation in order to describe structure. GraphQL is a data description language and not a programming language, therefore GraphQL lacks the punctuation often used to describe mathematical expressions."
                     }
                   ]
                 }
@@ -2146,7 +2146,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL Documents are full of named things: operations, fields, arguments,\ntypes, directives, fragments, and variables. All names must follow the same\ngrammatical form."
+                      "value": "GraphQL Documents are full of named things: operations, fields, arguments, types, directives, fragments, and variables. All names must follow the same grammatical form."
                     }
                   ]
                 },
@@ -2179,7 +2179,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nall refer to different names. Underscores are significant, which means\n"
+                      "value": " all refer to different names. Underscores are significant, which means "
                     },
                     {
                       "type": "InlineCode",
@@ -2231,7 +2231,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ntoken is always the longest possible valid sequence. The source characters\n"
+                      "value": " token is always the longest possible valid sequence. The source characters "
                     },
                     {
                       "type": "Terminal",
@@ -2289,7 +2289,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " subset\nof "
+                      "value": " subset of "
                     },
                     {
                       "type": "NonTerminal",
@@ -2298,7 +2298,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " in order to support interoperation with as many other\nsystems as possible."
+                      "value": " in order to support interoperation with as many other systems as possible."
                     }
                   ]
                 }
@@ -2424,7 +2424,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL Document describes a complete file or request string operated on\nby a GraphQL service or client. A document contains multiple definitions, either\nexecutable or representative of a GraphQL type system."
+                  "value": "A GraphQL Document describes a complete file or request string operated on by a GraphQL service or client. A document contains multiple definitions, either executable or representative of a GraphQL type system."
                 }
               ]
             },
@@ -2433,7 +2433,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Documents are only executable by a GraphQL service if they contain an\n"
+                  "value": "Documents are only executable by a GraphQL service if they contain an "
                 },
                 {
                   "type": "NonTerminal",
@@ -2451,7 +2451,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ".\nHowever documents which do not contain "
+                  "value": ". However documents which do not contain "
                 },
                 {
                   "type": "NonTerminal",
@@ -2460,7 +2460,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " or do contain\n"
+                  "value": " or do contain "
                 },
                 {
                   "type": "NonTerminal",
@@ -2478,7 +2478,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " may still be parsed\nand validated to allow client tools to represent many GraphQL uses which may\nappear across many individual files."
+                  "value": " may still be parsed and validated to allow client tools to represent many GraphQL uses which may appear across many individual files."
                 }
               ]
             },
@@ -2487,7 +2487,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "If a Document contains only one operation, that operation may be unnamed or\nrepresented in the shorthand form, which omits both the query keyword and\noperation name. Otherwise, if a GraphQL Document contains multiple\noperations, each operation must be named. When submitting a Document with\nmultiple operations to a GraphQL service, the name of the desired operation to\nbe executed must also be provided."
+                  "value": "If a Document contains only one operation, that operation may be unnamed or represented in the shorthand form, which omits both the query keyword and operation name. Otherwise, if a GraphQL Document contains multiple operations, each operation must be named. When submitting a Document with multiple operations to a GraphQL service, the name of the desired operation to be executed must also be provided."
                 }
               ]
             },
@@ -2496,7 +2496,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL services which only seek to provide GraphQL query execution may choose\nto only include "
+                  "value": "GraphQL services which only seek to provide GraphQL query execution may choose to only include "
                 },
                 {
                   "type": "NonTerminal",
@@ -2514,7 +2514,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " and\n"
+                  "value": " and "
                 },
                 {
                   "type": "NonTerminal",
@@ -2660,7 +2660,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "query - a read-only fetch."
+                      "value": "query – a read-only fetch."
                     }
                   ]
                 },
@@ -2669,7 +2669,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "mutation - a write followed by a fetch."
+                      "value": "mutation – a write followed by a fetch."
                     }
                   ]
                 },
@@ -2678,7 +2678,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "subscription - a long-lived request that fetches data in response to source\n    events."
+                      "value": "subscription – a long-lived request that fetches data in response to source events."
                     }
                   ]
                 }
@@ -2698,7 +2698,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "For example, this mutation operation might \"like\" a story and then retrieve the\nnew number of likes:"
+                  "value": "For example, this mutation operation might “like” a story and then retrieve the new number of likes:"
                 }
               ]
             },
@@ -2719,7 +2719,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If a document contains only one query operation, and that query defines no\nvariables and contains no directives, that operation may be represented in a\nshort-hand form which omits the query keyword and query name."
+                      "value": "If a document contains only one query operation, and that query defines no variables and contains no directives, that operation may be represented in a short-hand form which omits the query keyword and query name."
                     }
                   ]
                 },
@@ -2843,7 +2843,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "An operation selects the set of information it needs, and will receive exactly\nthat information and nothing more, avoiding over-fetching and\nunder-fetching data."
+                  "value": "An operation selects the set of information it needs, and will receive exactly that information and nothing more, avoiding over-fetching and under-fetching data."
                 }
               ]
             },
@@ -2884,7 +2884,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " fields form a selection\nset. Selection sets may also contain fragment references."
+                  "value": " fields form a selection set. Selection sets may also contain fragment references."
                 }
               ]
             }
@@ -2960,7 +2960,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A selection set is primarily composed of fields. A field describes one discrete\npiece of information available to request within a selection set."
+                  "value": "A selection set is primarily composed of fields. A field describes one discrete piece of information available to request within a selection set."
                 }
               ]
             },
@@ -2969,7 +2969,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Some fields describe complex data or relationships to other data. In order to\nfurther explore this data, a field may itself contain a selection set, allowing\nfor deeply nested requests. All GraphQL operations must specify their selections\ndown to fields which return scalar values to ensure an unambiguously\nshaped response."
+                  "value": "Some fields describe complex data or relationships to other data. In order to further explore this data, a field may itself contain a selection set, allowing for deeply nested requests. All GraphQL operations must specify their selections down to fields which return scalar values to ensure an unambiguously shaped response."
                 }
               ]
             },
@@ -2978,7 +2978,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "For example, this operation selects fields of complex data and relationships\ndown to scalar values."
+                  "value": "For example, this operation selects fields of complex data and relationships down to scalar values."
                 }
               ]
             },
@@ -2995,7 +2995,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Fields in the top-level selection set of an operation often represent some\ninformation that is globally accessible to your application and its current\nviewer. Some typical examples of these top fields include references to a\ncurrent logged-in viewer, or accessing certain types of data referenced by a\nunique identifier."
+                  "value": "Fields in the top-level selection set of an operation often represent some information that is globally accessible to your application and its current viewer. Some typical examples of these top fields include references to a current logged-in viewer, or accessing certain types of data referenced by a unique identifier."
                 }
               ]
             },
@@ -3109,7 +3109,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Fields are conceptually functions which return values, and occasionally accept\narguments which alter their behavior. These arguments often map directly to\nfunction arguments within a GraphQL service's implementation."
+                  "value": "Fields are conceptually functions which return values, and occasionally accept arguments which alter their behavior. These arguments often map directly to function arguments within a GraphQL service’s implementation."
                 }
               ]
             },
@@ -3126,7 +3126,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\nargument) and their profile picture of a specific "
+                  "value": " argument) and their profile picture of a specific "
                 },
                 {
                   "type": "InlineCode",
@@ -3172,7 +3172,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Arguments may be provided in any syntactic order and maintain identical\nsemantic meaning."
+                      "value": "Arguments may be provided in any syntactic order and maintain identical semantic meaning."
                     }
                   ]
                 },
@@ -3239,7 +3239,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "By default, the key in the response object will use the field name\nqueried. However, you can define a different name by specifying an alias."
+                  "value": "By default, the key in the response object will use the field name queried. However, you can define a different name by specifying an alias."
                 }
               ]
             },
@@ -3248,7 +3248,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "In this example, we can fetch two profile pictures of different sizes and ensure\nthe resulting object will not have duplicate keys:"
+                  "value": "In this example, we can fetch two profile pictures of different sizes and ensure the resulting object will not have duplicate keys:"
                 }
               ]
             },
@@ -3316,7 +3316,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A field's response key is its alias if an alias is provided, and it is\notherwise the field's name."
+                  "value": "A field’s response key is its alias if an alias is provided, and it is otherwise the field’s name."
                 }
               ]
             }
@@ -3451,7 +3451,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Fragments allow for the reuse of common repeated selections of fields, reducing\nduplicated text in the document. Inline Fragments can be used directly within a\nselection to condition upon a type condition when querying against an interface\nor union."
+                  "value": "Fragments allow for the reuse of common repeated selections of fields, reducing duplicated text in the document. Inline Fragments can be used directly within a selection to condition upon a type condition when querying against an interface or union."
                 }
               ]
             },
@@ -3460,7 +3460,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "For example, if we wanted to fetch some common information about mutual friends\nas well as friends of some user:"
+                  "value": "For example, if we wanted to fetch some common information about mutual friends as well as friends of some user:"
                 }
               ]
             },
@@ -3477,7 +3477,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "The repeated fields could be extracted into a fragment and composed by\na parent fragment or query."
+                  "value": "The repeated fields could be extracted into a fragment and composed by a parent fragment or query."
                 }
               ]
             },
@@ -3502,7 +3502,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "). All fields selected\nby the fragment will be added to the query field selection at the same level\nas the fragment invocation. This happens through multiple levels of fragment\nspreads."
+                  "value": "). All fields selected by the fragment will be added to the query field selection at the same level as the fragment invocation. This happens through multiple levels of fragment spreads."
                 }
               ]
             },
@@ -3552,7 +3552,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " all\nproduce the same response object."
+                  "value": " all produce the same response object."
                 }
               ]
             },
@@ -3598,7 +3598,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ncan be used in the context of querying a "
+                      "value": " can be used in the context of querying a "
                     },
                     {
                       "type": "InlineCode",
@@ -3615,7 +3615,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Fragments cannot be specified on any input value (scalar, enumeration, or input\nobject)."
+                      "value": "Fragments cannot be specified on any input value (scalar, enumeration, or input object)."
                     }
                   ]
                 },
@@ -3633,7 +3633,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Selections within fragments only return values when the concrete type of the object\nit is operating on matches the type of the fragment."
+                      "value": "Selections within fragments only return values when the concrete type of the object it is operating on matches the type of the fragment."
                     }
                   ]
                 },
@@ -3675,7 +3675,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " or a\n"
+                      "value": " or a "
                     },
                     {
                       "type": "InlineCode",
@@ -3707,7 +3707,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " will be\npresent and "
+                      "value": " will be present and "
                     },
                     {
                       "type": "InlineCode",
@@ -3731,7 +3731,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nwill be present and "
+                      "value": " will be present and "
                     },
                     {
                       "type": "InlineCode",
@@ -3807,7 +3807,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Fragments can be defined inline within a selection set. This is done to\nconditionally include fields based on their runtime type. This feature of\nstandard fragment inclusion was demonstrated in the "
+                      "value": "Fragments can be defined inline within a selection set. This is done to conditionally include fields based on their runtime type. This feature of standard fragment inclusion was demonstrated in the "
                     },
                     {
                       "type": "InlineCode",
@@ -3815,7 +3815,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nexample. We could accomplish the same thing using inline fragments."
+                      "value": " example. We could accomplish the same thing using inline fragments."
                     }
                   ]
                 },
@@ -3832,7 +3832,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Inline fragments may also be used to apply a directive to a group of fields.\nIf the TypeCondition is omitted, an inline fragment is considered to be of the\nsame type as the enclosing context."
+                      "value": "Inline fragments may also be used to apply a directive to a group of fields. If the TypeCondition is omitted, an inline fragment is considered to be of the same type as the enclosing context."
                     }
                   ]
                 },
@@ -3996,7 +3996,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Field and directive arguments accept input values of various literal primitives;\ninput values can be scalars, enumeration values, lists, or input objects."
+                  "value": "Field and directive arguments accept input values of various literal primitives; input values can be scalars, enumeration values, lists, or input objects."
                 }
               ]
             },
@@ -4014,7 +4014,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "), input values can be\nspecified as a variable. List and inputs objects may also contain variables (unless defined to be constant)."
+                  "value": "), input values can be specified as a variable. List and inputs objects may also contain variables (unless defined to be constant)."
                 }
               ]
             },
@@ -4194,7 +4194,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " is specified without a decimal point or exponent but may be\nnegative (ex. "
+                      "value": " is specified without a decimal point or exponent but may be negative (ex. "
                     },
                     {
                       "type": "Terminal",
@@ -4246,7 +4246,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ntoken is always the longest possible valid sequence. The source characters\n"
+                      "value": " token is always the longest possible valid sequence. The source characters "
                     },
                     {
                       "type": "Terminal",
@@ -4271,7 +4271,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\n"
+                      "value": " "
                     },
                     {
                       "type": "Terminal",
@@ -4287,7 +4287,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " is invalid since it can neither be\ninterpreted as a single token nor two "
+                      "value": " is invalid since it can neither be interpreted as a single token nor two "
                     },
                     {
                       "type": "Terminal",
@@ -4338,7 +4338,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " or\n"
+                      "value": " or "
                     },
                     {
                       "type": "NonTerminal",
@@ -4347,7 +4347,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " follows then the token must only be interpreted as a\npossible "
+                      "value": " follows then the token must only be interpreted as a possible "
                     },
                     {
                       "type": "NonTerminal",
@@ -4365,7 +4365,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " character can follow. For example\nthe sequences "
+                      "value": " character can follow. For example the sequences "
                     },
                     {
                       "type": "InlineCode",
@@ -4661,7 +4661,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ") or an exponent\n(ex. "
+                      "value": ") or an exponent (ex. "
                     },
                     {
                       "type": "Terminal",
@@ -4686,7 +4686,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ",\nit also must not have any leading "
+                      "value": ", it also must not have any leading "
                     },
                     {
                       "type": "Terminal",
@@ -4730,7 +4730,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ntoken is always the longest possible valid sequence. The source characters\n"
+                      "value": " token is always the longest possible valid sequence. The source characters "
                     },
                     {
                       "type": "Terminal",
@@ -4746,7 +4746,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " is followed by the\n"
+                      "value": " is followed by the "
                     },
                     {
                       "type": "NonTerminal",
@@ -4797,7 +4797,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ncannot be interpreted as two tokens ("
+                      "value": " cannot be interpreted as two tokens ("
                     },
                     {
                       "type": "Terminal",
@@ -4840,7 +4840,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". For example the sequence\n"
+                      "value": ". For example the sequence "
                     },
                     {
                       "type": "InlineCode",
@@ -4875,7 +4875,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " both restrict being\nimmediately followed by a letter (or other "
+                      "value": " both restrict being immediately followed by a letter (or other "
                     },
                     {
                       "type": "NonTerminal",
@@ -4884,7 +4884,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ") to reduce confusion\nor unexpected behavior since GraphQL only supports decimal numbers."
+                      "value": ") to reduce confusion or unexpected behavior since GraphQL only supports decimal numbers."
                     }
                   ]
                 }
@@ -5233,7 +5233,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Strings are sequences of characters wrapped in quotation marks (U+0022).\n(ex. "
+                      "value": "Strings are sequences of characters wrapped in quotation marks (U+0022). (ex. "
                     },
                     {
                       "type": "Terminal",
@@ -5241,7 +5241,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "). White space and other otherwise-ignored characters are\nsignificant within a string value."
+                      "value": "). White space and other otherwise-ignored characters are significant within a string value."
                     }
                   ]
                 },
@@ -5266,7 +5266,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " otherwise it would\nbe interpreted as the beginning of a block string. As an example, the source\n"
+                      "value": " otherwise it would be interpreted as the beginning of a block string. As an example, the source "
                     },
                     {
                       "type": "Terminal",
@@ -5274,7 +5274,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " can only be interpreted as a single empty block string and not three\nempty strings."
+                      "value": " can only be interpreted as a single empty block string and not three empty strings."
                     }
                   ]
                 },
@@ -5283,7 +5283,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Unicode characters are allowed within String value literals, however\n"
+                      "value": "Unicode characters are allowed within String value literals, however "
                     },
                     {
                       "type": "NonTerminal",
@@ -5292,7 +5292,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " must not contain some ASCII control characters so escape\nsequences must be used to represent these characters."
+                      "value": " must not contain some ASCII control characters so escape sequences must be used to represent these characters."
                     }
                   ]
                 },
@@ -5313,7 +5313,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ").\nWhite space, line terminators, quote, and backslash characters may all be\nused unescaped to enable verbatim text. Characters must all be valid\n"
+                          "value": "). White space, line terminators, quote, and backslash characters may all be used unescaped to enable verbatim text. Characters must all be valid "
                         },
                         {
                           "type": "NonTerminal",
@@ -5331,7 +5331,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Since block strings represent freeform text often used in indented\npositions, the string value semantics of a block string excludes uniform\nindentation and blank initial and trailing lines via "
+                          "value": "Since block strings represent freeform text often used in indented positions, the string value semantics of a block string excludes uniform indentation and blank initial and trailing lines via "
                         },
                         {
                           "type": "Call",
@@ -5383,7 +5383,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Since block string values strip leading and trailing empty lines, there is no\nsingle canonical printed block string for a given value. Because block strings\ntypically represent freeform text, it is considered easier to read if they begin\nand end with an empty line."
+                          "value": "Since block string values strip leading and trailing empty lines, there is no single canonical printed block string for a given value. Because block strings typically represent freeform text, it is considered easier to read if they begin and end with an empty line."
                         }
                       ]
                     },
@@ -5408,7 +5408,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If non-printable ASCII characters are needed in a string value, a standard\nquoted string with appropriate escape sequences must be used instead of a\nblock string."
+                          "value": "If non-printable ASCII characters are needed in a string value, a standard quoted string with appropriate escape sequences must be used instead of a block string."
                         }
                       ]
                     }
@@ -5500,7 +5500,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": "\n    Unicode character values."
+                                "value": " Unicode character values."
                               }
                             ]
                           }
@@ -5602,7 +5602,7 @@
                             "contents": [
                               {
                                 "type": "Text",
-                                "value": "Return the character whose code unit value in the Unicode Basic Multilingual\n    Plane is the 16-bit hexadecimal value "
+                                "value": "Return the character whose code unit value in the Unicode Basic Multilingual Plane is the 16-bit hexadecimal value "
                               },
                               {
                                 "type": "NonTerminal",
@@ -5898,7 +5898,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " be the Unicode character sequence of all\n    "
+                                "value": " be the Unicode character sequence of all "
                               },
                               {
                                 "type": "NonTerminal",
@@ -5907,7 +5907,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " Unicode character values (which may be an empty\n    sequence)."
+                                "value": " Unicode character values (which may be an empty sequence)."
                               }
                             ]
                           },
@@ -6211,7 +6211,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " characters\n      in "
+                                        "value": " characters in "
                                       },
                                       {
                                         "type": "Variable",
@@ -6853,7 +6853,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " to the argument \"arg\", while the second\nhas implicitly not provided a value to the argument \"arg\". These two forms may\nbe interpreted differently. For example, a mutation representing deleting a\nfield vs not altering a field, respectively. Neither form may be used for an\ninput expecting a Non-Null type."
+                      "value": " to the argument “arg”, while the second has implicitly not provided a value to the argument “arg”. These two forms may be interpreted differently. For example, a mutation representing deleting a field vs not altering a field, respectively. Neither form may be used for an input expecting a Non-Null type."
                     }
                   ]
                 },
@@ -6862,7 +6862,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The same two methods of representing the lack of a value are possible via\nvariables by either providing the variable value as "
+                      "value": "The same two methods of representing the lack of a value are possible via variables by either providing the variable value as "
                     },
                     {
                       "type": "Keyword",
@@ -6870,7 +6870,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " or not providing\na variable value at all."
+                      "value": " or not providing a variable value at all."
                     }
                   ]
                 }
@@ -6934,7 +6934,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "). It is\nrecommended that Enum values be \"all caps\". Enum values are only used in\ncontexts where the precise enumeration type is known. Therefore it's not\nnecessary to supply an enumeration type name in the literal."
+                      "value": "). It is recommended that Enum values be “all caps”. Enum values are only used in contexts where the precise enumeration type is known. Therefore it’s not necessary to supply an enumeration type name in the literal."
                     }
                   ]
                 }
@@ -7024,7 +7024,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". The\nvalues of a List literal may be any value literal or variable (ex. "
+                      "value": ". The values of a List literal may be any value literal or variable (ex. "
                     },
                     {
                       "type": "InlineCode",
@@ -7041,7 +7041,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Commas are optional throughout GraphQL so trailing commas are allowed and repeated\ncommas do not represent missing values."
+                      "value": "Commas are optional throughout GraphQL so trailing commas are allowed and repeated commas do not represent missing values."
                     }
                   ]
                 },
@@ -7353,7 +7353,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Input object literal values are unordered lists of keyed input values wrapped in\ncurly-braces "
+                      "value": "Input object literal values are unordered lists of keyed input values wrapped in curly-braces "
                     },
                     {
                       "type": "InlineCode",
@@ -7361,7 +7361,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". The values of an object literal may be any input value\nliteral or variable (ex. "
+                      "value": ". The values of an object literal may be any input value literal or variable (ex. "
                     },
                     {
                       "type": "InlineCode",
@@ -7369,7 +7369,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "). We refer to\nliteral representation of input objects as \"object literals.\""
+                      "value": "). We refer to literal representation of input objects as “object literals.”"
                     }
                   ]
                 },
@@ -7382,7 +7382,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Input object fields may be provided in any syntactic order and maintain\nidentical semantic meaning."
+                          "value": "Input object fields may be provided in any syntactic order and maintain identical semantic meaning."
                         }
                       ]
                     },
@@ -7816,7 +7816,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL operation can be parameterized with variables, maximizing reuse,\nand avoiding costly string building in clients at runtime."
+                  "value": "A GraphQL operation can be parameterized with variables, maximizing reuse, and avoiding costly string building in clients at runtime."
                 }
               ]
             },
@@ -7843,7 +7843,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " can be\nsupplied for an input value."
+                  "value": " can be supplied for an input value."
                 }
               ]
             },
@@ -7852,7 +7852,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Variables must be defined at the top of an operation and are in scope\nthroughout the execution of that operation."
+                  "value": "Variables must be defined at the top of an operation and are in scope throughout the execution of that operation."
                 }
               ]
             },
@@ -7861,7 +7861,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "In this example, we want to fetch a profile picture size based on the size\nof a particular device:"
+                  "value": "In this example, we want to fetch a profile picture size based on the size of a particular device:"
                 }
               ]
             },
@@ -7878,7 +7878,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Values for those variables are provided to a GraphQL service along with a\nrequest so they may be substituted during execution. If providing JSON for the\nvariables' values, we could run this query and request profilePic of\nsize "
+                  "value": "Values for those variables are provided to a GraphQL service along with a request so they may be substituted during execution. If providing JSON for the variables’ values, we could run this query and request profilePic of size "
                 },
                 {
                   "type": "InlineCode",
@@ -7907,7 +7907,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Query variables can be used within fragments. Query variables have global scope\nwith a given operation, so a variable used within a fragment must be declared\nin any top-level operation that transitively consumes that fragment. If\na variable is referenced in a fragment and is included by an operation that does\nnot define that variable, the operation cannot be executed."
+                      "value": "Query variables can be used within fragments. Query variables have global scope with a given operation, so a variable used within a fragment must be declared in any top-level operation that transitively consumes that fragment. If a variable is referenced in a fragment and is included by an operation that does not define that variable, the operation cannot be executed."
                     }
                   ]
                 }
@@ -8064,7 +8064,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL describes the types of data expected by query variables. Input types\nmay be lists of another input type, or a non-null variant of any other\ninput type."
+                  "value": "GraphQL describes the types of data expected by query variables. Input types may be lists of another input type, or a non-null variant of any other input type."
                 }
               ]
             },
@@ -8453,7 +8453,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Directives provide a way to describe alternate runtime execution and type\nvalidation behavior in a GraphQL document."
+                  "value": "Directives provide a way to describe alternate runtime execution and type validation behavior in a GraphQL document."
                 }
               ]
             },
@@ -8462,7 +8462,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "In some cases, you need to provide options to alter GraphQL's execution\nbehavior in ways field arguments will not suffice, such as conditionally\nincluding or skipping a field. Directives provide this by describing additional information to the executor."
+                  "value": "In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor."
                 }
               ]
             },
@@ -8471,7 +8471,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Directives have a name along with a list of arguments which may accept values\nof any input type."
+                  "value": "Directives have a name along with a list of arguments which may accept values of any input type."
                 }
               ]
             },
@@ -8480,7 +8480,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Directives can be used to describe additional information for types, fields, fragments\nand operations."
+                  "value": "Directives can be used to describe additional information for types, fields, fragments and operations."
                 }
               ]
             },
@@ -8489,7 +8489,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "As future versions of GraphQL adopt new configurable execution capabilities,\nthey may be exposed via directives. GraphQL services and tools may also provide\nadditional "
+                  "value": "As future versions of GraphQL adopt new configurable execution capabilities, they may be exposed via directives. GraphQL services and tools may also provide additional "
                 },
                 {
                   "type": "Link",
@@ -8503,7 +8503,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\nbeyond those described here."
+                  "value": " beyond those described here."
                 }
               ]
             },
@@ -8561,7 +8561,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "The GraphQL Type system describes the capabilities of a GraphQL service and is\nused to determine if a query is valid. The type system also describes the\ninput types of query variables to determine if values provided at runtime\nare valid."
+              "value": "The GraphQL Type system describes the capabilities of a GraphQL service and is used to determine if a query is valid. The type system also describes the input types of query variables to determine if values provided at runtime are valid."
             }
           ]
         },
@@ -8617,7 +8617,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "The GraphQL language includes an\n"
+              "value": "The GraphQL language includes an "
             },
             {
               "type": "Link",
@@ -8631,7 +8631,7 @@
             },
             {
               "type": "Text",
-              "value": " used to\ndescribe a GraphQL service's type system. Tools may use this definition language\nto provide utilities such as client code generation or service boot-strapping."
+              "value": " used to describe a GraphQL service’s type system. Tools may use this definition language to provide utilities such as client code generation or service boot-strapping."
             }
           ]
         },
@@ -8640,7 +8640,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "GraphQL tools which only seek to provide GraphQL query execution may choose not\nto parse "
+              "value": "GraphQL tools which only seek to provide GraphQL query execution may choose not to parse "
             },
             {
               "type": "NonTerminal",
@@ -8667,7 +8667,7 @@
             },
             {
               "type": "Text",
-              "value": " must not be executed;\nGraphQL execution services which receive a GraphQL Document containing type\nsystem definitions should return a descriptive error."
+              "value": " must not be executed; GraphQL execution services which receive a GraphQL Document containing type system definitions should return a descriptive error."
             }
           ]
         },
@@ -8676,7 +8676,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "The type system definition language is used throughout the remainder of\nthis specification document when illustrating example type systems."
+              "value": "The type system definition language is used throughout the remainder of this specification document when illustrating example type systems."
             }
           ]
         },
@@ -8726,7 +8726,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Type system extensions are used to represent a GraphQL type system which has been\nextended from some original type system. For example, this might be used by a\nlocal service to represent data a GraphQL client only accesses locally, or by a\nGraphQL service which is itself an extension of another GraphQL service."
+                  "value": "Type system extensions are used to represent a GraphQL type system which has been extended from some original type system. For example, this might be used by a local service to represent data a GraphQL client only accesses locally, or by a GraphQL service which is itself an extension of another GraphQL service."
                 }
               ]
             }
@@ -8762,7 +8762,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Documentation is a first-class feature of GraphQL type systems. To ensure\nthe documentation of a GraphQL service remains consistent with its capabilities,\ndescriptions of GraphQL definitions are provided alongside their definitions and\nmade available via introspection."
+                  "value": "Documentation is a first-class feature of GraphQL type systems. To ensure the documentation of a GraphQL service remains consistent with its capabilities, descriptions of GraphQL definitions are provided alongside their definitions and made available via introspection."
                 }
               ]
             },
@@ -8771,7 +8771,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "To allow GraphQL service designers to easily publish documentation alongside the\ncapabilities of a GraphQL service, GraphQL descriptions are defined using the\nMarkdown syntax (as specified by "
+                  "value": "To allow GraphQL service designers to easily publish documentation alongside the capabilities of a GraphQL service, GraphQL descriptions are defined using the Markdown syntax (as specified by "
                 },
                 {
                   "type": "Link",
@@ -8785,7 +8785,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "). In the\ntype system definition language, these description strings (often "
+                  "value": "). In the type system definition language, these description strings (often "
                 },
                 {
                   "type": "NonTerminal",
@@ -8794,7 +8794,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ")\noccur immediately before the definition they describe."
+                  "value": ") occur immediately before the definition they describe."
                 }
               ]
             },
@@ -8803,7 +8803,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.)\nwhich can be described should provide a "
+                  "value": "GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.) which can be described should provide a "
                 },
                 {
                   "type": "NonTerminal",
@@ -8812,7 +8812,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " unless they are considered\nself descriptive."
+                  "value": " unless they are considered self descriptive."
                 }
               ]
             },
@@ -8938,7 +8938,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL service's collective type system capabilities are referred to as that\nservice's \"schema\". A schema is defined in terms of the types and directives it\nsupports as well as the root operation types for each kind of operation:\nquery, mutation, and subscription; this determines the place in the type system\nwhere those operations begin."
+                  "value": "A GraphQL service’s collective type system capabilities are referred to as that service’s “schema”. A schema is defined in terms of the types and directives it supports as well as the root operation types for each kind of operation: query, mutation, and subscription; this determines the place in the type system where those operations begin."
                 }
               ]
             },
@@ -8947,7 +8947,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL schema must itself be internally valid. This section describes\nthe rules for this validation process where relevant."
+                  "value": "A GraphQL schema must itself be internally valid. This section describes the rules for this validation process where relevant."
                 }
               ]
             },
@@ -8956,7 +8956,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "All types within a GraphQL schema must have unique names. No two provided types\nmay have the same name. No provided type may have a name which conflicts with\nany built in types (including Scalar and Introspection types)."
+                  "value": "All types within a GraphQL schema must have unique names. No two provided types may have the same name. No provided type may have a name which conflicts with any built in types (including Scalar and Introspection types)."
                 }
               ]
             },
@@ -8974,7 +8974,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "All types and directives defined within a schema must not have a name which\nbegins with "
+                  "value": "All types and directives defined within a schema must not have a name which begins with "
                 },
                 {
                   "type": "StringLiteral",
@@ -8982,7 +8982,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " (two underscores), as this is used exclusively by GraphQL's\nintrospection system."
+                  "value": " (two underscores), as this is used exclusively by GraphQL’s introspection system."
                 }
               ]
             },
@@ -8996,7 +8996,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A schema defines the initial root operation type for each kind of operation it\nsupports: query, mutation, and subscription; this determines the place in the\ntype system where those operations begin."
+                      "value": "A schema defines the initial root operation type for each kind of operation it supports: query, mutation, and subscription; this determines the place in the type system where those operations begin."
                     }
                   ]
                 },
@@ -9030,7 +9030,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " root operation type is optional; if it is not provided, the\nservice does not support mutations. If it is provided, it must be an\nObject type."
+                      "value": " root operation type is optional; if it is not provided, the service does not support mutations. If it is provided, it must be an Object type."
                     }
                   ]
                 },
@@ -9047,7 +9047,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " root operation type is also optional; if it is not\nprovided, the service does not support subscriptions. If it is provided, it must\nbe an Object type."
+                      "value": " root operation type is also optional; if it is not provided, the service does not support subscriptions. If it is provided, it must be an Object type."
                     }
                   ]
                 },
@@ -9064,7 +9064,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " root operation type indicate what fields are available\nat the top level of a GraphQL query. For example, a basic GraphQL query like:"
+                      "value": " root operation type indicate what fields are available at the top level of a GraphQL query. For example, a basic GraphQL query like:"
                     }
                   ]
                 },
@@ -9089,7 +9089,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " root operation type has a field named \"myName\"."
+                      "value": " root operation type has a field named “myName”."
                     }
                   ]
                 },
@@ -9114,7 +9114,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " root operation type\nhas a field named \"setName\". Note that the "
+                      "value": " root operation type has a field named “setName”. Note that the "
                     },
                     {
                       "type": "InlineCode",
@@ -9130,7 +9130,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " root types\nmust be different types."
+                      "value": " root types must be different types."
                     }
                   ]
                 },
@@ -9147,7 +9147,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When using the type system definition language, a document must include at most\none "
+                      "value": "When using the type system definition language, a document must include at most one "
                     },
                     {
                       "type": "InlineCode",
@@ -9164,7 +9164,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "In this example, a GraphQL schema is defined with both query and mutation\nroot types:"
+                      "value": "In this example, a GraphQL schema is defined with both query and mutation root types:"
                     }
                   ]
                 },
@@ -9185,7 +9185,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "While any type can be the root operation type for a GraphQL operation, the type\nsystem definition language can omit the schema definition when the "
+                          "value": "While any type can be the root operation type for a GraphQL operation, the type system definition language can omit the schema definition when the "
                         },
                         {
                           "type": "InlineCode",
@@ -9193,7 +9193,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ",\n"
+                          "value": ", "
                         },
                         {
                           "type": "InlineCode",
@@ -9225,7 +9225,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ", and\n"
+                          "value": ", and "
                         },
                         {
                           "type": "InlineCode",
@@ -9242,7 +9242,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Likewise, when representing a GraphQL schema using the type system definition\nlanguage, a schema definition should be omitted if it only uses the default root\noperation type names."
+                          "value": "Likewise, when representing a GraphQL schema using the type system definition language, a schema definition should be omitted if it only uses the default root operation type names."
                         }
                       ]
                     },
@@ -9251,7 +9251,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "This example describes a valid complete GraphQL schema, despite not explicitly\nincluding a "
+                          "value": "This example describes a valid complete GraphQL schema, despite not explicitly including a "
                         },
                         {
                           "type": "InlineCode",
@@ -9275,7 +9275,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\nroot operation type of the schema."
+                          "value": " root operation type of the schema."
                         }
                       ]
                     },
@@ -9390,7 +9390,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Schema extensions are used to represent a schema which has been extended from\nan original schema. For example, this might be used by a GraphQL service which\nadds additional operation types, or additional directives to an existing schema."
+                      "value": "Schema extensions are used to represent a schema which has been extended from an original schema. For example, this might be used by a GraphQL service which adds additional operation types, or additional directives to an existing schema."
                     }
                   ]
                 },
@@ -9425,7 +9425,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Schema."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Schema."
                             }
                           ]
                         }
@@ -9527,7 +9527,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "The fundamental unit of any GraphQL Schema is the type. There are six kinds\nof named type definitions in GraphQL, and two wrapping types."
+                  "value": "The fundamental unit of any GraphQL Schema is the type. There are six kinds of named type definitions in GraphQL, and two wrapping types."
                 }
               ]
             },
@@ -9544,7 +9544,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". A scalar represents a primitive value, like\na string or an integer. Oftentimes, the possible responses for a scalar field\nare enumerable. GraphQL offers an "
+                  "value": ". A scalar represents a primitive value, like a string or an integer. Oftentimes, the possible responses for a scalar field are enumerable. GraphQL offers an "
                 },
                 {
                   "type": "InlineCode",
@@ -9552,7 +9552,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " type in those cases, where the type\nspecifies the space of valid responses."
+                  "value": " type in those cases, where the type specifies the space of valid responses."
                 }
               ]
             },
@@ -9561,7 +9561,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Scalars and Enums form the leaves in response trees; the intermediate levels are\n"
+                  "value": "Scalars and Enums form the leaves in response trees; the intermediate levels are "
                 },
                 {
                   "type": "InlineCode",
@@ -9569,7 +9569,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " types, which define a set of fields, where each field is another\ntype in the system, allowing the definition of arbitrary type hierarchies."
+                  "value": " types, which define a set of fields, where each field is another type in the system, allowing the definition of arbitrary type hierarchies."
                 }
               ]
             },
@@ -9603,7 +9603,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " types and other Interface\ntypes which implement this Interface are guaranteed to implement those fields.\nWhenever a field claims it will return an Interface type, it will return a\nvalid implementing Object type during execution."
+                  "value": " types and other Interface types which implement this Interface are guaranteed to implement those fields. Whenever a field claims it will return an Interface type, it will return a valid implementing Object type during execution."
                 }
               ]
             },
@@ -9620,7 +9620,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " defines a list of possible types; similar to interfaces, whenever the\ntype system claims a union will be returned, one of the possible types will be\nreturned."
+                  "value": " defines a list of possible types; similar to interfaces, whenever the type system claims a union will be returned, one of the possible types will be returned."
                 }
               ]
             },
@@ -9629,7 +9629,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Finally, oftentimes it is useful to provide complex structs as inputs to\nGraphQL field arguments or variables; the "
+                  "value": "Finally, oftentimes it is useful to provide complex structs as inputs to GraphQL field arguments or variables; the "
                 },
                 {
                   "type": "InlineCode",
@@ -9637,7 +9637,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " type allows the schema\nto define exactly what data is expected."
+                  "value": " type allows the schema to define exactly what data is expected."
                 }
               ]
             },
@@ -9651,7 +9651,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "All of the types so far are assumed to be both nullable and singular: e.g. a\nscalar string returns either null or a singular string."
+                      "value": "All of the types so far are assumed to be both nullable and singular: e.g. a scalar string returns either null or a singular string."
                     }
                   ]
                 },
@@ -9660,7 +9660,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A GraphQL schema may describe that a field represents a list of another type;\nthe "
+                      "value": "A GraphQL schema may describe that a field represents a list of another type; the "
                     },
                     {
                       "type": "InlineCode",
@@ -9685,7 +9685,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type wraps another type, and denotes that the\nresulting value will never be "
+                      "value": " type wraps another type, and denotes that the resulting value will never be "
                     },
                     {
                       "type": "Keyword",
@@ -9693,7 +9693,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " (and that an error cannot result in a\n"
+                      "value": " (and that an error cannot result in a "
                     },
                     {
                       "type": "Keyword",
@@ -9710,7 +9710,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "These two types are referred to as \"wrapping types\"; non-wrapping types are\nreferred to as \"named types\". A wrapping type has an underlying named type,\nfound by continually unwrapping the type until a named type is found."
+                      "value": "These two types are referred to as “wrapping types”; non-wrapping types are referred to as “named types”. A wrapping type has an underlying named type, found by continually unwrapping the type until a named type is found."
                     }
                   ]
                 }
@@ -9726,7 +9726,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Types are used throughout GraphQL to describe both the values accepted as input\nto arguments and variables as well as the values output by fields. These two\nuses categorize types as "
+                      "value": "Types are used throughout GraphQL to describe both the values accepted as input to arguments and variables as well as the values output by fields. These two uses categorize types as "
                     },
                     {
                       "type": "Italic",
@@ -9752,7 +9752,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". Some kinds of types,\nlike Scalar and Enum types, can be used as both input types and output types;\nother kinds of types can only be used in one or the other. Input Object types can\nonly be used as input types. Object, Interface, and Union types can only be used\nas output types. Lists and Non-Null types may be used as input types or output\ntypes depending on how the wrapped type may be used."
+                      "value": ". Some kinds of types, like Scalar and Enum types, can be used as both input types and output types; other kinds of types can only be used in one or the other. Input Object types can only be used as input types. Object, Interface, and Union types can only be used as output types. Lists and Non-Null types may be used as input types or output types depending on how the wrapped type may be used."
                     }
                   ]
                 },
@@ -10114,7 +10114,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Type extensions are used to represent a GraphQL type which has been extended\nfrom some original type. For example, this might be used by a local service to\nrepresent additional fields a GraphQL client only accesses locally."
+                      "value": "Type extensions are used to represent a GraphQL type which has been extended from some original type. For example, this might be used by a local service to represent additional fields a GraphQL client only accesses locally."
                     }
                   ]
                 }
@@ -10183,7 +10183,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Scalar types represent primitive leaf values in a GraphQL type system. GraphQL\nresponses take the form of a hierarchical tree; the leaves of this tree are\ntypically GraphQL Scalar types (but may also be Enum types or "
+                  "value": "Scalar types represent primitive leaf values in a GraphQL type system. GraphQL responses take the form of a hierarchical tree; the leaves of this tree are typically GraphQL Scalar types (but may also be Enum types or "
                 },
                 {
                   "type": "Keyword",
@@ -10200,7 +10200,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL provides a number of built-in scalars (see below), but type systems can\nadd additional scalars with semantic meaning. For example, a GraphQL system\ncould define a scalar called "
+                  "value": "GraphQL provides a number of built-in scalars (see below), but type systems can add additional scalars with semantic meaning. For example, a GraphQL system could define a scalar called "
                 },
                 {
                   "type": "InlineCode",
@@ -10208,7 +10208,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " which, while serialized as a string,\npromises to conform to ISO-8601. When querying a field of type "
+                  "value": " which, while serialized as a string, promises to conform to ISO-8601. When querying a field of type "
                 },
                 {
                   "type": "InlineCode",
@@ -10216,7 +10216,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ", you can\nthen rely on the ability to parse the result with an ISO-8601 parser and use a\nclient-specific primitive for time. Another example of a potentially useful\ncustom scalar is "
+                  "value": ", you can then rely on the ability to parse the result with an ISO-8601 parser and use a client-specific primitive for time. Another example of a potentially useful custom scalar is "
                 },
                 {
                   "type": "InlineCode",
@@ -10224,7 +10224,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ", which serializes as a string, but is guaranteed by\nthe service to be a valid URL."
+                  "value": ", which serializes as a string, but is guaranteed by the service to be a valid URL."
                 }
               ]
             },
@@ -10263,7 +10263,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ",\n"
+                      "value": ", "
                     },
                     {
                       "type": "NonTerminal",
@@ -10290,7 +10290,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". A GraphQL framework should support all of these\ntypes, and a GraphQL service which provides a type by these names must adhere to\nthe behavior described for them in this document. As an example, a service must\nnot include a type called "
+                      "value": ". A GraphQL framework should support all of these types, and a GraphQL service which provides a type by these names must adhere to the behavior described for them in this document. As an example, a service must not include a type called "
                     },
                     {
                       "type": "NonTerminal",
@@ -10299,7 +10299,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and use it to represent 64-bit numbers,\ninternationalization information, or anything other than what is defined in\nthis document."
+                      "value": " and use it to represent 64-bit numbers, internationalization information, or anything other than what is defined in this document."
                     }
                   ]
                 },
@@ -10316,7 +10316,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " introspection type, all\nreferenced built-in scalars must be included. If a built-in scalar type is not\nreferenced anywhere in a schema (there is no field, argument, or input field of\nthat type) then it must not be included."
+                      "value": " introspection type, all referenced built-in scalars must be included. If a built-in scalar type is not referenced anywhere in a schema (there is no field, argument, or input field of that type) then it must not be included."
                     }
                   ]
                 },
@@ -10325,7 +10325,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When representing a GraphQL schema using the type system definition language,\nall built-in scalars must be omitted for brevity."
+                      "value": "When representing a GraphQL schema using the type system definition language, all built-in scalars must be omitted for brevity."
                     }
                   ]
                 }
@@ -10340,7 +10340,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A GraphQL service, when preparing a field of a given scalar type, must uphold the\ncontract the scalar type describes, either by coercing the value or producing a\nfield error if a value cannot be coerced or if coercion may result in data loss."
+                      "value": "A GraphQL service, when preparing a field of a given scalar type, must uphold the contract the scalar type describes, either by coercing the value or producing a field error if a value cannot be coerced or if coercion may result in data loss."
                     }
                   ]
                 },
@@ -10349,7 +10349,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A GraphQL service may decide to allow coercing different internal types to the\nexpected return type. For example when coercing a field of type "
+                      "value": "A GraphQL service may decide to allow coercing different internal types to the expected return type. For example when coercing a field of type "
                     },
                     {
                       "type": "NonTerminal",
@@ -10358,7 +10358,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " a boolean\n"
+                      "value": " a boolean "
                     },
                     {
                       "type": "Keyword",
@@ -10382,7 +10382,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " may be parsed as base-10\n"
+                      "value": " may be parsed as base-10 "
                     },
                     {
                       "type": "Terminal",
@@ -10390,7 +10390,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". However if internal type coercion cannot be reasonably performed without\nlosing information, then it must raise a field error."
+                      "value": ". However if internal type coercion cannot be reasonably performed without losing information, then it must raise a field error."
                     }
                   ]
                 },
@@ -10399,7 +10399,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Since this coercion behavior is not observable to clients of the GraphQL service,\nthe precise rules of coercion are left to the implementation. The only\nrequirement is that the service must yield values which adhere to the expected\nScalar type."
+                      "value": "Since this coercion behavior is not observable to clients of the GraphQL service, the precise rules of coercion are left to the implementation. The only requirement is that the service must yield values which adhere to the expected Scalar type."
                     }
                   ]
                 },
@@ -10408,7 +10408,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL scalars are serialized according to the serialization format being used.\nThere may be a most appropriate serialized primitive for each given scalar type,\nand the service should produce each primitive where appropriate."
+                      "value": "GraphQL scalars are serialized according to the serialization format being used. There may be a most appropriate serialized primitive for each given scalar type, and the service should produce each primitive where appropriate."
                     }
                   ]
                 },
@@ -10431,7 +10431,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " for more detailed\ninformation on the serialization of scalars in common JSON and other formats."
+                      "value": " for more detailed information on the serialization of scalars in common JSON and other formats."
                     }
                   ]
                 }
@@ -10446,7 +10446,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If a GraphQL service expects a scalar type as input to an argument, coercion\nis observable and the rules must be well defined. If an input value does not\nmatch a coercion rule, a query error must be raised."
+                      "value": "If a GraphQL service expects a scalar type as input to an argument, coercion is observable and the rules must be well defined. If an input value does not match a coercion rule, a query error must be raised."
                     }
                   ]
                 },
@@ -10455,7 +10455,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL has different constant literals to represent integer and floating-point\ninput values, and coercion rules may apply differently depending on which type\nof input value is encountered. GraphQL may be parameterized by query variables,\nthe values of which are often serialized when sent over a transport like HTTP. Since\nsome common serializations (ex. JSON) do not discriminate between integer\nand floating-point values, they are interpreted as an integer input value if\nthey have an empty fractional part (ex. "
+                      "value": "GraphQL has different constant literals to represent integer and floating-point input values, and coercion rules may apply differently depending on which type of input value is encountered. GraphQL may be parameterized by query variables, the values of which are often serialized when sent over a transport like HTTP. Since some common serializations (ex. JSON) do not discriminate between integer and floating-point values, they are interpreted as an integer input value if they have an empty fractional part (ex. "
                     },
                     {
                       "type": "InlineCode",
@@ -10463,7 +10463,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ") and otherwise as floating-point\ninput value."
+                      "value": ") and otherwise as floating-point input value."
                     }
                   ]
                 },
@@ -10472,7 +10472,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "For all types below, with the exception of Non-Null, if the explicit value\n"
+                      "value": "For all types below, with the exception of Non-Null, if the explicit value "
                     },
                     {
                       "type": "Keyword",
@@ -10504,7 +10504,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The Int scalar type represents a signed 32-bit numeric non-fractional value.\nResponse formats that support a 32-bit integer or a number type should use\nthat type to represent this scalar."
+                      "value": "The Int scalar type represents a signed 32-bit numeric non-fractional value. Response formats that support a 32-bit integer or a number type should use that type to represent this scalar."
                     }
                   ]
                 },
@@ -10526,7 +10526,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " expect to encounter 32-bit integer\ninternal values."
+                          "value": " expect to encounter 32-bit integer internal values."
                         }
                       ]
                     },
@@ -10535,7 +10535,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL services may coerce non-integer internal values to integers when\nreasonable without losing information, otherwise they must raise a field error.\nExamples of this may include returning "
+                          "value": "GraphQL services may coerce non-integer internal values to integers when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning "
                         },
                         {
                           "type": "InlineCode",
@@ -10551,7 +10551,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ",\nor returning "
+                          "value": ", or returning "
                         },
                         {
                           "type": "InlineCode",
@@ -10567,7 +10567,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ". In scenarios where coercion may lose\ndata, raising a field error is more appropriate. For example, a floating-point\nnumber "
+                          "value": ". In scenarios where coercion may lose data, raising a field error is more appropriate. For example, a floating-point number "
                         },
                         {
                           "type": "InlineCode",
@@ -10608,7 +10608,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " or\ngreater than or equal to 2"
+                          "value": " or greater than or equal to 2"
                         },
                         {
                           "type": "HTMLTag",
@@ -10639,7 +10639,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "When expected as an input type, only integer input values are accepted. All\nother input values, including strings with numeric content, must raise a query\nerror indicating an incorrect type. If the integer input value represents a\nvalue less than -2"
+                          "value": "When expected as an input type, only integer input values are accepted. All other input values, including strings with numeric content, must raise a query error indicating an incorrect type. If the integer input value represents a value less than -2"
                         },
                         {
                           "type": "HTMLTag",
@@ -10671,7 +10671,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ", a\nquery error should be raised."
+                          "value": ", a query error should be raised."
                         }
                       ]
                     },
@@ -10680,7 +10680,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Numeric integer values larger than 32-bit should either use String or a\ncustom-defined Scalar type, as not all platforms and transports support\nencoding integer numbers larger than 32-bit."
+                          "value": "Numeric integer values larger than 32-bit should either use String or a custom-defined Scalar type, as not all platforms and transports support encoding integer numbers larger than 32-bit."
                         }
                       ]
                     }
@@ -10698,7 +10698,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The Float scalar type represents signed double-precision fractional values\nas specified by "
+                      "value": "The Float scalar type represents signed double-precision fractional values as specified by "
                     },
                     {
                       "type": "Link",
@@ -10712,7 +10712,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ".\nResponse formats that support an appropriate double-precision number type\nshould use that type to represent this scalar."
+                      "value": ". Response formats that support an appropriate double-precision number type should use that type to represent this scalar."
                     }
                   ]
                 },
@@ -10734,7 +10734,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " expect to encounter double-precision\nfloating-point internal values."
+                          "value": " expect to encounter double-precision floating-point internal values."
                         }
                       ]
                     },
@@ -10752,7 +10752,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " when\nreasonable without losing information, otherwise they must raise a field error.\nExamples of this may include returning "
+                          "value": " when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning "
                         },
                         {
                           "type": "InlineCode",
@@ -10768,7 +10768,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ", or\n"
+                          "value": ", or "
                         },
                         {
                           "type": "InlineCode",
@@ -10799,7 +10799,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "When expected as an input type, both integer and float input values are\naccepted. Integer input values are coerced to Float by adding an empty\nfractional part, for example "
+                          "value": "When expected as an input type, both integer and float input values are accepted. Integer input values are coerced to Float by adding an empty fractional part, for example "
                         },
                         {
                           "type": "InlineCode",
@@ -10815,7 +10815,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ". All\nother input values, including strings with numeric content, must raise a query\nerror indicating an incorrect type. If the integer input value represents a\nvalue not representable by IEEE 754, a query error should be raised."
+                          "value": ". All other input values, including strings with numeric content, must raise a query error indicating an incorrect type. If the integer input value represents a value not representable by IEEE 754, a query error should be raised."
                         }
                       ]
                     }
@@ -10833,7 +10833,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The String scalar type represents textual data, represented as UTF-8 character\nsequences. The String type is most often used by GraphQL to represent free-form\nhuman-readable text. All response formats must support string representations,\nand that representation must be used here."
+                      "value": "The String scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text. All response formats must support string representations, and that representation must be used here."
                     }
                   ]
                 },
@@ -10873,7 +10873,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " when reasonable\nwithout losing information, otherwise they must raise a field error. Examples of\nthis may include returning the string "
+                          "value": " when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning the string "
                         },
                         {
                           "type": "InlineCode",
@@ -10881,7 +10881,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " for a boolean true value, or the\nstring "
+                          "value": " for a boolean true value, or the string "
                         },
                         {
                           "type": "InlineCode",
@@ -10912,7 +10912,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "When expected as an input type, only valid UTF-8 string input values are\naccepted. All other input values must raise a query error indicating an\nincorrect type."
+                          "value": "When expected as an input type, only valid UTF-8 string input values are accepted. All other input values must raise a query error indicating an incorrect type."
                         }
                       ]
                     }
@@ -10946,7 +10946,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". Response formats should\nuse a built-in boolean type if supported; otherwise, they should use their\nrepresentation of the integers "
+                      "value": ". Response formats should use a built-in boolean type if supported; otherwise, they should use their representation of the integers "
                     },
                     {
                       "type": "InlineCode",
@@ -11002,7 +11002,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " when reasonable\nwithout losing information, otherwise they must raise a field error. Examples of\nthis may include returning "
+                          "value": " when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning "
                         },
                         {
                           "type": "InlineCode",
@@ -11025,7 +11025,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "When expected as an input type, only boolean input values are accepted. All\nother input values must raise a query error indicating an incorrect type."
+                          "value": "When expected as an input type, only boolean input values are accepted. All other input values must raise a query error indicating an incorrect type."
                         }
                       ]
                     }
@@ -11043,7 +11043,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The ID scalar type represents a unique identifier, often used to refetch an\nobject or as the key for a cache. The ID type is serialized in the same way as\na "
+                      "value": "The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a "
                     },
                     {
                       "type": "NonTerminal",
@@ -11052,7 +11052,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "; however, it is not intended to be human-readable. While it is\noften numeric, it should always serialize as a "
+                      "value": "; however, it is not intended to be human-readable. While it is often numeric, it should always serialize as a "
                     },
                     {
                       "type": "NonTerminal",
@@ -11074,7 +11074,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL is agnostic to ID format, and serializes to string to ensure consistency\nacross many formats ID could represent, from small auto-increment numbers, to\nlarge 128-bit random numbers, to base64 encoded values, or string values of a\nformat like "
+                          "value": "GraphQL is agnostic to ID format, and serializes to string to ensure consistency across many formats ID could represent, from small auto-increment numbers, to large 128-bit random numbers, to base64 encoded values, or string values of a format like "
                         },
                         {
                           "type": "Link",
@@ -11097,7 +11097,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL services should coerce as appropriate given the ID formats they expect.\nWhen coercion is not possible they must raise a field error."
+                          "value": "GraphQL services should coerce as appropriate given the ID formats they expect. When coercion is not possible they must raise a field error."
                         }
                       ]
                     }
@@ -11120,7 +11120,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ") or integer (such as\n"
+                          "value": ") or integer (such as "
                         },
                         {
                           "type": "InlineCode",
@@ -11136,7 +11136,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ") input value should be coerced to ID as appropriate for the ID\nformats a given GraphQL service expects. Any other input value, including float\ninput values (such as "
+                          "value": ") input value should be coerced to ID as appropriate for the ID formats a given GraphQL service expects. Any other input value, including float input values (such as "
                         },
                         {
                           "type": "InlineCode",
@@ -11144,7 +11144,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "), must raise a query error indicating an incorrect\ntype."
+                          "value": "), must raise a query error indicating an incorrect type."
                         }
                       ]
                     }
@@ -11207,7 +11207,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Scalar type extensions are used to represent a scalar type which has been\nextended from some original scalar type. For example, this might be used by a\nGraphQL tool or service which adds directives to an existing scalar."
+                      "value": "Scalar type extensions are used to represent a scalar type which has been extended from some original scalar type. For example, this might be used by a GraphQL tool or service which adds directives to an existing scalar."
                     }
                   ]
                 },
@@ -11242,7 +11242,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Scalar type."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Scalar type."
                             }
                           ]
                         }
@@ -11492,7 +11492,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL queries are hierarchical and composed, describing a tree of information.\nWhile Scalar types describe the leaf values of these hierarchical queries, Objects\ndescribe the intermediate levels."
+                  "value": "GraphQL queries are hierarchical and composed, describing a tree of information. While Scalar types describe the leaf values of these hierarchical queries, Objects describe the intermediate levels."
                 }
               ]
             },
@@ -11501,7 +11501,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL Objects represent a list of named fields, each of which yield a value of\na specific type. Object values should be serialized as ordered maps, where the\nqueried field names (or aliases) are the keys and the result of evaluating\nthe field is the value, ordered by the order in which they appear in the query."
+                  "value": "GraphQL Objects represent a list of named fields, each of which yield a value of a specific type. Object values should be serialized as ordered maps, where the queried field names (or aliases) are the keys and the result of evaluating the field is the value, ordered by the order in which they appear in the query."
                 }
               ]
             },
@@ -11510,7 +11510,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "All fields defined within an Object type must not have a name which begins with\n"
+                  "value": "All fields defined within an Object type must not have a name which begins with "
                 },
                 {
                   "type": "StringLiteral",
@@ -11518,7 +11518,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " (two underscores), as this is used exclusively by GraphQL's\nintrospection system."
+                  "value": " (two underscores), as this is used exclusively by GraphQL’s introspection system."
                 }
               ]
             },
@@ -11577,7 +11577,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is a field\nthat will yield an "
+                  "value": " is a field that will yield an "
                 },
                 {
                   "type": "NonTerminal",
@@ -11594,7 +11594,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is a field that will yield a\n"
+                  "value": " is a field that will yield a "
                 },
                 {
                   "type": "InlineCode",
@@ -11611,7 +11611,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A query of an object value must select at least one field. This selection of\nfields will yield an ordered map containing exactly the subset of the object\nqueried, which should be represented in the order in which they were queried.\nOnly fields that are declared on the object type may validly be queried on\nthat object."
+                  "value": "A query of an object value must select at least one field. This selection of fields will yield an ordered map containing exactly the subset of the object queried, which should be represented in the order in which they were queried. Only fields that are declared on the object type may validly be queried on that object."
                 }
               ]
             },
@@ -11696,7 +11696,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A field of an Object type may be a Scalar, Enum, another Object type,\nan Interface, or a Union. Additionally, it may be any wrapping type whose\nunderlying base type is one of those five."
+                  "value": "A field of an Object type may be a Scalar, Enum, another Object type, an Interface, or a Union. Additionally, it may be any wrapping type whose underlying base type is one of those five."
                 }
               ]
             },
@@ -11738,7 +11738,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Valid queries must supply a nested field set for a field that returns\nan object, so this query is not valid:"
+                  "value": "Valid queries must supply a nested field set for a field that returns an object, so this query is not valid:"
                 }
               ]
             },
@@ -11793,7 +11793,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When querying an Object, the resulting mapping of fields are conceptually\nordered in the same order in which they were encountered during query execution,\nexcluding fragments for which the type does not apply and fields or\nfragments that are skipped via "
+                      "value": "When querying an Object, the resulting mapping of fields are conceptually ordered in the same order in which they were encountered during query execution, excluding fragments for which the type does not apply and fields or fragments that are skipped via "
                     },
                     {
                       "type": "InlineCode",
@@ -11809,7 +11809,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " directives. This ordering\nis correctly produced when using the "
+                      "value": " directives. This ordering is correctly produced when using the "
                     },
                     {
                       "type": "Call",
@@ -11827,7 +11827,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Response serialization formats capable of representing ordered maps should\nmaintain this ordering. Serialization formats which can only represent unordered\nmaps (such as JSON) should retain this order textually. That is, if two fields\n"
+                      "value": "Response serialization formats capable of representing ordered maps should maintain this ordering. Serialization formats which can only represent unordered maps (such as JSON) should retain this order textually. That is, if two fields "
                     },
                     {
                       "type": "InlineCode",
@@ -11835,7 +11835,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " were queried in that order, the resulting JSON serialization\nshould contain "
+                      "value": " were queried in that order, the resulting JSON serialization should contain "
                     },
                     {
                       "type": "InlineCode",
@@ -11852,7 +11852,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Producing a response where fields are represented in the same order in which\nthey appear in the request improves human readability during debugging and\nenables more efficient parsing of responses if the order of properties can\nbe anticipated."
+                      "value": "Producing a response where fields are represented in the same order in which they appear in the request improves human readability during debugging and enables more efficient parsing of responses if the order of properties can be anticipated."
                     }
                   ]
                 },
@@ -11861,7 +11861,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If a fragment is spread before other fields, the fields that fragment specifies\noccur in the response before the following fields."
+                      "value": "If a fragment is spread before other fields, the fields that fragment specifies occur in the response before the following fields."
                     }
                   ]
                 },
@@ -11895,7 +11895,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If a field is queried multiple times in a selection, it is ordered by the first\ntime it is encountered. However fragments for which the type does not apply does\nnot affect ordering."
+                      "value": "If a field is queried multiple times in a selection, it is ordered by the first time it is encountered. However fragments for which the type does not apply does not affect ordering."
                     }
                   ]
                 },
@@ -11929,7 +11929,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Also, if directives result in fields being excluded, they are not considered in\nthe ordering of fields."
+                      "value": "Also, if directives result in fields being excluded, they are not considered in the ordering of fields."
                     }
                   ]
                 },
@@ -11969,7 +11969,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Determining the result of coercing an object is the heart of the GraphQL\nexecutor, so this is covered in that section of the spec."
+                      "value": "Determining the result of coercing an object is the heart of the GraphQL executor, so this is covered in that section of the spec."
                     }
                   ]
                 }
@@ -11999,7 +11999,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Object types have the potential to be invalid if incorrectly defined. This set\nof rules must be adhered to by every Object type in a GraphQL schema."
+                      "value": "Object types have the potential to be invalid if incorrectly defined. This set of rules must be adhered to by every Object type in a GraphQL schema."
                     }
                   ]
                 },
@@ -12032,7 +12032,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The field must have a unique name within that Object type;\n      no two fields may share the same name."
+                                  "value": "The field must have a unique name within that Object type; no two fields may share the same name."
                                 }
                               ]
                             },
@@ -12041,7 +12041,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The field must not have a name which begins with the\n      characters "
+                                  "value": "The field must not have a name which begins with the characters "
                                 },
                                 {
                                   "type": "StringLiteral",
@@ -12100,7 +12100,7 @@
                                       "contents": [
                                         {
                                           "type": "Text",
-                                          "value": "The argument must not have a name which begins with the\n         characters "
+                                          "value": "The argument must not have a name which begins with the characters "
                                         },
                                         {
                                           "type": "StringLiteral",
@@ -12131,7 +12131,7 @@
                                         },
                                         {
                                           "type": "Text",
-                                          "value": "\n         returns "
+                                          "value": " returns "
                                         },
                                         {
                                           "type": "Keyword",
@@ -12201,7 +12201,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": ",\n      "
+                                  "value": ", "
                                 },
                                 {
                                   "type": "Call",
@@ -12270,7 +12270,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " declares it implements any interfaces,\n      "
+                            "value": " declares it implements any interfaces, "
                           },
                           {
                             "type": "Variable",
@@ -12291,7 +12291,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " must include a field of the same name for every field\n      defined in "
+                            "value": " must include a field of the same name for every field defined in "
                           },
                           {
                             "type": "Variable",
@@ -12364,7 +12364,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " must include an argument of the same name for every argument\n         defined in "
+                                    "value": " must include an argument of the same name for every argument defined in "
                                   },
                                   {
                                     "type": "Variable",
@@ -12391,7 +12391,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " must accept the same type\n            (invariant) as that named argument on "
+                                            "value": " must accept the same type (invariant) as that named argument on "
                                           },
                                           {
                                             "type": "Variable",
@@ -12416,7 +12416,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " may include additional arguments not defined in\n         "
+                                    "value": " may include additional arguments not defined in "
                                   },
                                   {
                                     "type": "Variable",
@@ -12424,7 +12424,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": ", but any additional argument must not be required,\n         e.g. must not be of a non-nullable type."
+                                    "value": ", but any additional argument must not be required, e.g. must not be of a non-nullable type."
                                   }
                                 ]
                               },
@@ -12437,7 +12437,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " must return a type which is equal to or a sub-type of\n         (covariant) the return type of "
+                                    "value": " must return a type which is equal to or a sub-type of (covariant) the return type of "
                                   },
                                   {
                                     "type": "Variable",
@@ -12445,7 +12445,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " field's return type:"
+                                    "value": " field’s return type:"
                                   },
                                   {
                                     "type": "List",
@@ -12520,7 +12520,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": "\n            must be "
+                                            "value": " must be "
                                           },
                                           {
                                             "type": "Keyword",
@@ -12620,7 +12620,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " be the unwrapped nullable type\n        of "
+                                    "value": " be the unwrapped nullable type of "
                                   },
                                   {
                                     "type": "Variable",
@@ -12628,7 +12628,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " if it is a Non-Null type, otherwise let it be\n        "
+                                    "value": " if it is a Non-Null type, otherwise let it be "
                                   },
                                   {
                                     "type": "Variable",
@@ -12736,7 +12736,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " be the unwrapped item type\n        of "
+                                    "value": " be the unwrapped item type of "
                                   },
                                   {
                                     "type": "Variable",
@@ -12833,7 +12833,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " is\n     a Union type and "
+                            "value": " is a Union type and "
                           },
                           {
                             "type": "Variable",
@@ -12849,7 +12849,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": "\n     then return "
+                            "value": " then return "
                           },
                           {
                             "type": "Keyword",
@@ -12882,7 +12882,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": "\n     is an Interface type and "
+                            "value": " is an Interface type and "
                           },
                           {
                             "type": "Variable",
@@ -12890,7 +12890,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " declares it implements\n     "
+                            "value": " declares it implements "
                           },
                           {
                             "type": "Variable",
@@ -13041,7 +13041,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Object fields are conceptually functions which yield values. Occasionally object\nfields can accept arguments to further specify the return value. Object field\narguments are defined as a list of all possible argument names and their\nexpected input types."
+                      "value": "Object fields are conceptually functions which yield values. Occasionally object fields can accept arguments to further specify the return value. Object field arguments are defined as a list of all possible argument names and their expected input types."
                     }
                   ]
                 },
@@ -13050,7 +13050,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "All arguments defined within a field must not have a name which begins with\n"
+                      "value": "All arguments defined within a field must not have a name which begins with "
                     },
                     {
                       "type": "StringLiteral",
@@ -13058,7 +13058,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " (two underscores), as this is used exclusively by GraphQL's\nintrospection system."
+                      "value": " (two underscores), as this is used exclusively by GraphQL’s introspection system."
                     }
                   ]
                 },
@@ -13083,7 +13083,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " field could accept an argument to\ndetermine what size of an image to return."
+                      "value": " field could accept an argument to determine what size of an image to return."
                     }
                   ]
                 },
@@ -13100,7 +13100,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL queries can optionally specify arguments to their fields to provide\nthese arguments."
+                      "value": "GraphQL queries can optionally specify arguments to their fields to provide these arguments."
                     }
                   ]
                 },
@@ -13143,7 +13143,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The type of an object field argument must be an input type (any type except an\nObject, Interface, or Union type)."
+                      "value": "The type of an object field argument must be an input type (any type except an Object, Interface, or Union type)."
                     }
                   ]
                 }
@@ -13159,7 +13159,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Fields in an object may be marked as deprecated as deemed necessary by the\napplication. It is still legal to query for these fields (to ensure existing\nclients are not broken by the change), but the fields should be appropriately\ntreated in documentation and tooling."
+                      "value": "Fields in an object may be marked as deprecated as deemed necessary by the application. It is still legal to query for these fields (to ensure existing clients are not broken by the change), but the fields should be appropriately treated in documentation and tooling."
                     }
                   ]
                 },
@@ -13176,7 +13176,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " directives are\nused to indicate that a field is deprecated:"
+                      "value": " directives are used to indicate that a field is deprecated:"
                     }
                   ]
                 },
@@ -13330,7 +13330,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Object type extensions are used to represent a type which has been extended from\nsome original type. For example, this might be used to represent local data, or\nby a GraphQL service which is itself an extension of another GraphQL service."
+                      "value": "Object type extensions are used to represent a type which has been extended from some original type. For example, this might be used to represent local data, or by a GraphQL service which is itself an extension of another GraphQL service."
                     }
                   ]
                 },
@@ -13364,7 +13364,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Object type extensions may choose not to add additional fields, instead only\nadding interfaces or directives."
+                      "value": "Object type extensions may choose not to add additional fields, instead only adding interfaces or directives."
                     }
                   ]
                 },
@@ -13424,7 +13424,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "The fields of an Object type extension must have unique names; no two fields\n   may share the same name."
+                              "value": "The fields of an Object type extension must have unique names; no two fields may share the same name."
                             }
                           ]
                         },
@@ -13433,7 +13433,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any fields of an Object type extension must not be already defined on the\n   original Object type."
+                              "value": "Any fields of an Object type extension must not be already defined on the original Object type."
                             }
                           ]
                         },
@@ -13442,7 +13442,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Object type."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Object type."
                             }
                           ]
                         },
@@ -13451,7 +13451,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any interfaces provided must not be already implemented by the original\n   Object type."
+                              "value": "Any interfaces provided must not be already implemented by the original Object type."
                             }
                           ]
                         },
@@ -13460,7 +13460,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "The resulting extended object type must be a super-set of all interfaces it\n   implements."
+                              "value": "The resulting extended object type must be a super-set of all interfaces it implements."
                             }
                           ]
                         }
@@ -13553,7 +13553,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL interfaces represent a list of named fields and their arguments. GraphQL\nobjects and interfaces can then implement these interfaces which requires that\nthe implementing type will define all fields defined by those interfaces."
+                  "value": "GraphQL interfaces represent a list of named fields and their arguments. GraphQL objects and interfaces can then implement these interfaces which requires that the implementing type will define all fields defined by those interfaces."
                 }
               ]
             },
@@ -13562,7 +13562,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Fields on a GraphQL interface have the same rules as fields on a GraphQL object;\ntheir type can be Scalar, Object, Enum, Interface, or Union, or any wrapping\ntype whose base type is one of those five."
+                  "value": "Fields on a GraphQL interface have the same rules as fields on a GraphQL object; their type can be Scalar, Object, Enum, Interface, or Union, or any wrapping type whose base type is one of those five."
                 }
               ]
             },
@@ -13579,7 +13579,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " may describe a required field and types\nsuch as "
+                  "value": " may describe a required field and types such as "
                 },
                 {
                   "type": "InlineCode",
@@ -13595,7 +13595,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " may then implement this interface to guarantee\nthis field will always exist."
+                  "value": " may then implement this interface to guarantee this field will always exist."
                 }
               ]
             },
@@ -13612,7 +13612,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " implements\nboth the "
+                  "value": " implements both the "
                 },
                 {
                   "type": "InlineCode",
@@ -13645,7 +13645,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Fields which yield an interface are useful when one of many Object types are\nexpected, but some fields should be guaranteed."
+                  "value": "Fields which yield an interface are useful when one of many Object types are expected, but some fields should be guaranteed."
                 }
               ]
             },
@@ -13695,7 +13695,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " that can select the\ncommon fields."
+                  "value": " that can select the common fields."
                 }
               ]
             },
@@ -13712,7 +13712,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "When querying for fields on an interface type, only those fields declared on\nthe interface may be queried. In the above example, "
+                  "value": "When querying for fields on an interface type, only those fields declared on the interface may be queried. In the above example, "
                 },
                 {
                   "type": "InlineCode",
@@ -13720,7 +13720,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " returns a\n"
+                  "value": " returns a "
                 },
                 {
                   "type": "InlineCode",
@@ -13744,7 +13744,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ", so it is valid. However,\nthe following would not be a valid query:"
+                  "value": ", so it is valid. However, the following would not be a valid query:"
                 }
               ]
             },
@@ -13785,7 +13785,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is not defined on that\ninterface. Querying for "
+                  "value": " is not defined on that interface. Querying for "
                 },
                 {
                   "type": "InlineCode",
@@ -13801,7 +13801,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is a\n"
+                  "value": " is a "
                 },
                 {
                   "type": "InlineCode",
@@ -13830,7 +13830,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When defining an interface that implements another interface, the implementing\ninterface must define each field that is specified by the implemented interface.\nFor example, the interface Resource must define the field id to implement the\nNode interface:"
+                      "value": "When defining an interface that implements another interface, the implementing interface must define each field that is specified by the implemented interface. For example, the interface Resource must define the field id to implement the Node interface:"
                     }
                   ]
                 },
@@ -13847,7 +13847,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Transitively implemented interfaces (interfaces implemented by the interface\nthat is being implemented) must also be defined on an implementing type or\ninterface. For example, "
+                      "value": "Transitively implemented interfaces (interfaces implemented by the interface that is being implemented) must also be defined on an implementing type or interface. For example, "
                     },
                     {
                       "type": "InlineCode",
@@ -13863,7 +13863,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " without also\nimplementing "
+                      "value": " without also implementing "
                     },
                     {
                       "type": "InlineCode",
@@ -13888,7 +13888,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Interface definitions must not contain cyclic references nor implement\nthemselves. This example is invalid because "
+                      "value": "Interface definitions must not contain cyclic references nor implement themselves. This example is invalid because "
                     },
                     {
                       "type": "InlineCode",
@@ -13904,7 +13904,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " implement\nthemselves and each other:"
+                      "value": " implement themselves and each other:"
                     }
                   ]
                 },
@@ -13927,7 +13927,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The interface type should have some way of determining which object a given\nresult corresponds to. Once it has done so, the result coercion of the interface\nis the same as the result coercion of the object."
+                      "value": "The interface type should have some way of determining which object a given result corresponds to. Once it has done so, the result coercion of the interface is the same as the result coercion of the object."
                     }
                   ]
                 }
@@ -13990,7 +13990,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The field must have a unique name within that Interface type;\n      no two fields may share the same name."
+                                  "value": "The field must have a unique name within that Interface type; no two fields may share the same name."
                                 }
                               ]
                             },
@@ -13999,7 +13999,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The field must not have a name which begins with the\n      characters "
+                                  "value": "The field must not have a name which begins with the characters "
                                 },
                                 {
                                   "type": "StringLiteral",
@@ -14030,7 +14030,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": "\n      returns "
+                                  "value": " returns "
                                 },
                                 {
                                   "type": "Keyword",
@@ -14058,7 +14058,7 @@
                                       "contents": [
                                         {
                                           "type": "Text",
-                                          "value": "The argument must not have a name which begins with the\n         characters "
+                                          "value": "The argument must not have a name which begins with the characters "
                                         },
                                         {
                                           "type": "StringLiteral",
@@ -14089,7 +14089,7 @@
                                         },
                                         {
                                           "type": "Text",
-                                          "value": "\n         returns "
+                                          "value": " returns "
                                         },
                                         {
                                           "type": "Keyword",
@@ -14114,7 +14114,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "An interface type may declare that it implements one or more unique\n   interfaces, but may not implement itself."
+                          "value": "An interface type may declare that it implements one or more unique interfaces, but may not implement itself."
                         }
                       ]
                     },
@@ -14159,7 +14159,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": ",\n      "
+                                  "value": ", "
                                 },
                                 {
                                   "type": "Call",
@@ -14337,7 +14337,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Interface type extensions are used to represent an interface which has been\nextended from some original interface. For example, this might be used to\nrepresent common local data on many types, or by a GraphQL service which is\nitself an extension of another GraphQL service."
+                      "value": "Interface type extensions are used to represent an interface which has been extended from some original interface. For example, this might be used to represent common local data on many types, or by a GraphQL service which is itself an extension of another GraphQL service."
                     }
                   ]
                 },
@@ -14354,7 +14354,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type along\nwith the types which implement it:"
+                      "value": " type along with the types which implement it:"
                     }
                   ]
                 },
@@ -14371,7 +14371,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Interface type extensions may choose not to add additional fields, instead only\nadding directives."
+                      "value": "Interface type extensions may choose not to add additional fields, instead only adding directives."
                     }
                   ]
                 },
@@ -14388,7 +14388,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type without\nadding fields:"
+                      "value": " type without adding fields:"
                     }
                   ]
                 },
@@ -14431,7 +14431,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "The fields of an Interface type extension must have unique names; no two\n   fields may share the same name."
+                              "value": "The fields of an Interface type extension must have unique names; no two fields may share the same name."
                             }
                           ]
                         },
@@ -14440,7 +14440,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any fields of an Interface type extension must not be already defined on the\n   original Interface type."
+                              "value": "Any fields of an Interface type extension must not be already defined on the original Interface type."
                             }
                           ]
                         },
@@ -14449,7 +14449,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any Object or Interface type which implemented the original Interface type\n   must also be a super-set of the fields of the Interface type extension (which\n   may be due to Object type extension)."
+                              "value": "Any Object or Interface type which implemented the original Interface type must also be a super-set of the fields of the Interface type extension (which may be due to Object type extension)."
                             }
                           ]
                         },
@@ -14458,7 +14458,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Interface type."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Interface type."
                             }
                           ]
                         },
@@ -14467,7 +14467,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "The resulting extended Interface type must be a super-set of all Interfaces\n   it implements."
+                              "value": "The resulting extended Interface type must be a super-set of all Interfaces it implements."
                             }
                           ]
                         }
@@ -14608,7 +14608,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL Unions represent an object that could be one of a list of GraphQL\nObject types, but provides for no guaranteed fields between those types.\nThey also differ from interfaces in that Object types declare what interfaces\nthey implement, but are not aware of what unions contain them."
+                  "value": "GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types. They also differ from interfaces in that Object types declare what interfaces they implement, but are not aware of what unions contain them."
                 }
               ]
             },
@@ -14617,7 +14617,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "With interfaces and objects, only those fields defined on the type can be\nqueried directly; to query other fields on an interface, typed fragments\nmust be used. This is the same as for unions, but unions do not define any\nfields, so "
+                  "value": "With interfaces and objects, only those fields defined on the type can be queried directly; to query other fields on an interface, typed fragments must be used. This is the same as for unions, but unions do not define any fields, so "
                 },
                 {
                   "type": "Bold",
@@ -14630,7 +14630,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " fields may be queried on this type without the use of\ntype refining fragments or inline fragments (with the exception of the\nmeta-field "
+                  "value": " fields may be queried on this type without the use of type refining fragments or inline fragments (with the exception of the meta-field "
                 },
                 {
                   "type": "Variable",
@@ -14680,7 +14680,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ", the\nquery would ask for all fields inside of a fragment indicating the appropriate\ntype. If the query wanted the name if the result was a Person, and the height if\nit was a photo, the following query is invalid, because the union itself\ndefines no fields:"
+                  "value": ", the query would ask for all fields inside of a fragment indicating the appropriate type. If the query wanted the name if the result was a Person, and the height if it was a photo, the following query is invalid, because the union itself defines no fields:"
                 }
               ]
             },
@@ -14722,7 +14722,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " character to aid\nformatting when representing a longer list of possible types:"
+                  "value": " character to aid formatting when representing a longer list of possible types:"
                 }
               ]
             },
@@ -14743,7 +14743,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The union type should have some way of determining which object a given result\ncorresponds to. Once it has done so, the result coercion of the union is the\nsame as the result coercion of the object."
+                      "value": "The union type should have some way of determining which object a given result corresponds to. Once it has done so, the result coercion of the union is the same as the result coercion of the object."
                     }
                   ]
                 }
@@ -14795,7 +14795,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "The member types of a Union type must all be Object base types;\n   Scalar, Interface and Union types must not be member types of a Union.\n   Similarly, wrapping types must not be member types of a Union."
+                          "value": "The member types of a Union type must all be Object base types; Scalar, Interface and Union types must not be member types of a Union. Similarly, wrapping types must not be member types of a Union."
                         }
                       ]
                     }
@@ -14899,7 +14899,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Union type extensions are used to represent a union type which has been\nextended from some original union type. For example, this might be used to\nrepresent additional local data, or by a GraphQL service which is itself an\nextension of another GraphQL service."
+                      "value": "Union type extensions are used to represent a union type which has been extended from some original union type. For example, this might be used to represent additional local data, or by a GraphQL service which is itself an extension of another GraphQL service."
                     }
                   ]
                 },
@@ -14934,7 +14934,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "The member types of a Union type extension must all be Object base types;\n   Scalar, Interface and Union types must not be member types of a Union.\n   Similarly, wrapping types must not be member types of a Union."
+                              "value": "The member types of a Union type extension must all be Object base types; Scalar, Interface and Union types must not be member types of a Union. Similarly, wrapping types must not be member types of a Union."
                             }
                           ]
                         },
@@ -14952,7 +14952,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "All member types of a Union type extension must not already be a member of\n   the original Union type."
+                              "value": "All member types of a Union type extension must not already be a member of the original Union type."
                             }
                           ]
                         },
@@ -14961,7 +14961,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Union type."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Union type."
                             }
                           ]
                         }
@@ -15124,7 +15124,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL Enum types, like Scalar types, also represent leaf values in a GraphQL\ntype system. However Enum types describe the set of possible values."
+                  "value": "GraphQL Enum types, like Scalar types, also represent leaf values in a GraphQL type system. However Enum types describe the set of possible values."
                 }
               ]
             },
@@ -15133,7 +15133,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Enums are not references for a numeric value, but are unique values in their own\nright. They may serialize as a string: the name of the represented value."
+                  "value": "Enums are not references for a numeric value, but are unique values in their own right. They may serialize as a string: the name of the represented value."
                 }
               ]
             },
@@ -15171,7 +15171,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL services must return one of the defined set of possible values. If a\nreasonable coercion is not possible they must raise a field error."
+                      "value": "GraphQL services must return one of the defined set of possible values. If a reasonable coercion is not possible they must raise a field error."
                     }
                   ]
                 }
@@ -15186,7 +15186,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL has a constant literal to represent enum input values. GraphQL string\nliterals must not be accepted as an enum input and instead raise a query error."
+                      "value": "GraphQL has a constant literal to represent enum input values. GraphQL string literals must not be accepted as an enum input and instead raise a query error."
                     }
                   ]
                 },
@@ -15195,7 +15195,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Query variable transport serializations which have a different representation\nfor non-string symbolic values (for example, "
+                      "value": "Query variable transport serializations which have a different representation for non-string symbolic values (for example, "
                     },
                     {
                       "type": "Link",
@@ -15209,7 +15209,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ")\nshould only allow such values as enum input values. Otherwise, for most\ntransport serializations that do not, strings may be interpreted as the enum\ninput value with the same name."
+                      "value": ") should only allow such values as enum input values. Otherwise, for most transport serializations that do not, strings may be interpreted as the enum input value with the same name."
                     }
                   ]
                 }
@@ -15341,7 +15341,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Enum type extensions are used to represent an enum type which has been\nextended from some original enum type. For example, this might be used to\nrepresent additional local data, or by a GraphQL service which is itself an\nextension of another GraphQL service."
+                      "value": "Enum type extensions are used to represent an enum type which has been extended from some original enum type. For example, this might be used to represent additional local data, or by a GraphQL service which is itself an extension of another GraphQL service."
                     }
                   ]
                 },
@@ -15385,7 +15385,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "All values of an Enum type extension must not already be a value of\n   the original Enum."
+                              "value": "All values of an Enum type extension must not already be a value of the original Enum."
                             }
                           ]
                         },
@@ -15394,7 +15394,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Enum type."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Enum type."
                             }
                           ]
                         }
@@ -15510,7 +15510,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Fields may accept arguments to configure their behavior. These inputs are often\nscalars or enums, but they sometimes need to represent more complex values."
+                  "value": "Fields may accept arguments to configure their behavior. These inputs are often scalars or enums, but they sometimes need to represent more complex values."
                 }
               ]
             },
@@ -15519,7 +15519,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL Input Object defines a set of input fields; the input fields are either\nscalars, enums, or other input objects. This allows arguments to accept\narbitrarily complex structs."
+                  "value": "A GraphQL Input Object defines a set of input fields; the input fields are either scalars, enums, or other input objects. This allows arguments to accept arbitrarily complex structs."
                 }
               ]
             },
@@ -15578,7 +15578,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ") defined above is\ninappropriate for re-use here, because Object types can contain fields that\ndefine arguments or contain references to interfaces and unions, neither of\nwhich is appropriate for use as an input argument. For this reason, input\nobjects have a separate type in the system."
+                  "value": ") defined above is inappropriate for re-use here, because Object types can contain fields that define arguments or contain references to interfaces and unions, neither of which is appropriate for use as an input argument. For this reason, input objects have a separate type in the system."
                 }
               ]
             },
@@ -15591,7 +15591,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "An input object is never a valid result. Input Object types cannot be the return\ntype of an Object or Interface field."
+                      "value": "An input object is never a valid result. Input Object types cannot be the return type of an Object or Interface field."
                     }
                   ]
                 }
@@ -15606,7 +15606,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The value for an input object should be an input object literal or an unordered\nmap supplied by a variable, otherwise a query error must be thrown. In either\ncase, the input object literal or unordered map must not contain any entries\nwith names not defined by a field of this input object type, otherwise an error\nmust be thrown."
+                      "value": "The value for an input object should be an input object literal or an unordered map supplied by a variable, otherwise a query error must be thrown. In either case, the input object literal or unordered map must not contain any entries with names not defined by a field of this input object type, otherwise an error must be thrown."
                     }
                   ]
                 },
@@ -15615,7 +15615,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The result of coercion is an unordered map with an entry for each field both\ndefined by the input object type and for which a value exists. The resulting map\nis constructed with the following rules:"
+                      "value": "The result of coercion is an unordered map with an entry for each field both defined by the input object type and for which a value exists. The resulting map is constructed with the following rules:"
                     }
                   ]
                 },
@@ -15628,7 +15628,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If no value is provided for a defined input object field and that field\n  definition provides a default value, the default value should be used. If no\n  default value is provided and the input object field's type is non-null, an\n  error should be thrown. Otherwise, if the field is not required, then no entry\n  is added to the coerced unordered map."
+                          "value": "If no value is provided for a defined input object field and that field definition provides a default value, the default value should be used. If no default value is provided and the input object field’s type is non-null, an error should be thrown. Otherwise, if the field is not required, then no entry is added to the coerced unordered map."
                         }
                       ]
                     },
@@ -15645,7 +15645,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " was provided for an input object field, and the field's\n  type is not a non-null type, an entry in the coerced unordered map is given\n  the value "
+                          "value": " was provided for an input object field, and the field’s type is not a non-null type, an entry in the coerced unordered map is given the value "
                         },
                         {
                           "type": "Keyword",
@@ -15653,7 +15653,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ". In other words, there is a semantic difference between the\n  explicitly provided value "
+                          "value": ". In other words, there is a semantic difference between the explicitly provided value "
                         },
                         {
                           "type": "Keyword",
@@ -15670,7 +15670,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If a literal value is provided for an input object field, an entry in the\n  coerced unordered map is given the result of coercing that value according\n  to the input coercion rules for the type of that field."
+                          "value": "If a literal value is provided for an input object field, an entry in the coerced unordered map is given the result of coercing that value according to the input coercion rules for the type of that field."
                         }
                       ]
                     },
@@ -15679,7 +15679,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If a variable is provided for an input object field, the runtime value of that\n  variable must be used. If the runtime value is "
+                          "value": "If a variable is provided for an input object field, the runtime value of that variable must be used. If the runtime value is "
                         },
                         {
                           "type": "Keyword",
@@ -15687,7 +15687,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " and the field type\n  is non-null, a field error must be thrown. If no runtime value is provided,\n  the variable definition's default value should be used. If the variable\n  definition does not provide a default value, the input object field\n  definition's default value should be used."
+                          "value": " and the field type is non-null, a field error must be thrown. If no runtime value is provided, the variable definition’s default value should be used. If the variable definition does not provide a default value, the input object field definition’s default value should be used."
                         }
                       ]
                     }
@@ -15698,7 +15698,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Following are examples of input coercion for an input object type with a\n"
+                      "value": "Following are examples of input coercion for an input object type with a "
                     },
                     {
                       "type": "InlineCode",
@@ -16162,7 +16162,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The input field must have a unique name within that Input Object type;\n      no two input fields may share the same name."
+                                  "value": "The input field must have a unique name within that Input Object type; no two input fields may share the same name."
                                 }
                               ]
                             },
@@ -16171,7 +16171,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The input field must not have a name which begins with the\n      characters "
+                                  "value": "The input field must not have a name which begins with the characters "
                                 },
                                 {
                                   "type": "StringLiteral",
@@ -16202,7 +16202,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": "\n      returns "
+                                  "value": " returns "
                                 },
                                 {
                                   "type": "Keyword",
@@ -16318,7 +16318,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Input object type extensions are used to represent an input object type which\nhas been extended from some original input object type. For example, this might\nbe used by a GraphQL service which is itself an extension of another GraphQL service."
+                      "value": "Input object type extensions are used to represent an input object type which has been extended from some original input object type. For example, this might be used by a GraphQL service which is itself an extension of another GraphQL service."
                     }
                   ]
                 },
@@ -16362,7 +16362,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "All fields of an Input Object type extension must not already be a field of\n   the original Input Object."
+                              "value": "All fields of an Input Object type extension must not already be a field of the original Input Object."
                             }
                           ]
                         },
@@ -16371,7 +16371,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Any non-repeatable directives provided must not already apply to the\n   original Input Object type."
+                              "value": "Any non-repeatable directives provided must not already apply to the original Input Object type."
                             }
                           ]
                         }
@@ -16393,7 +16393,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL list is a special collection type which declares the type of each\nitem in the List (referred to as the "
+                  "value": "A GraphQL list is a special collection type which declares the type of each item in the List (referred to as the "
                 },
                 {
                   "type": "Italic",
@@ -16406,7 +16406,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " of the list). List values are\nserialized as ordered lists, where each item in the list is serialized as per\nthe item type."
+                  "value": " of the list). List values are serialized as ordered lists, where each item in the list is serialized as per the item type."
                 }
               ]
             },
@@ -16415,7 +16415,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "To denote that a field uses a List type the item type is wrapped in square brackets\nlike this: "
+                  "value": "To denote that a field uses a List type the item type is wrapped in square brackets like this: "
                 },
                 {
                   "type": "InlineCode",
@@ -16444,7 +16444,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL services must return an ordered list as the result of a list type. Each\nitem in the list must be the result of a result coercion of the item type. If a\nreasonable coercion is not possible it must raise a field error. In\nparticular, if a non-list is returned, the coercion should fail, as this\nindicates a mismatch in expectations between the type system and the\nimplementation."
+                      "value": "GraphQL services must return an ordered list as the result of a list type. Each item in the list must be the result of a result coercion of the item type. If a reasonable coercion is not possible it must raise a field error. In particular, if a non-list is returned, the coercion should fail, as this indicates a mismatch in expectations between the type system and the implementation."
                     }
                   ]
                 },
@@ -16453,7 +16453,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If a list's item type is nullable, then errors occurring during preparation or\ncoercion of an individual item in the list must result in a the value "
+                      "value": "If a list’s item type is nullable, then errors occurring during preparation or coercion of an individual item in the list must result in a the value "
                     },
                     {
                       "type": "Keyword",
@@ -16461,7 +16461,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " at\nthat position in the list along with an error added to the response. If a list's\nitem type is non-null, an error occurring at an individual item in the list must\nresult in a field error for the entire list."
+                      "value": " at that position in the list along with an error added to the response. If a list’s item type is non-null, an error occurring at an individual item in the list must result in a field error for the entire list."
                     }
                   ]
                 },
@@ -16470,7 +16470,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "For more information on the error handling process, see \"Errors and\nNon-Nullability\" within the Execution section."
+                      "value": "For more information on the error handling process, see “Errors and Non-Nullability” within the Execution section."
                     }
                   ]
                 }
@@ -16485,7 +16485,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When expected as an input, list values are accepted only when each item in the\nlist can be accepted by the list's item type."
+                      "value": "When expected as an input, list values are accepted only when each item in the list can be accepted by the list’s item type."
                     }
                   ]
                 },
@@ -16507,7 +16507,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " a list and not the\n"
+                      "value": " a list and not the "
                     },
                     {
                       "type": "Keyword",
@@ -16515,7 +16515,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " value, then the result of input coercion is a list of size one,\nwhere the single item value is the result of input coercion for the list's item\ntype on the provided value (note this may apply recursively for nested lists)."
+                      "value": " value, then the result of input coercion is a list of size one, where the single item value is the result of input coercion for the list’s item type on the provided value (note this may apply recursively for nested lists)."
                     }
                   ]
                 },
@@ -16524,7 +16524,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "This allows inputs which accept one or many arguments (sometimes referred to as\n\"var args\") to declare their input type as a list while for the common case of a\nsingle value, a client can just pass that value directly rather than\nconstructing the list."
+                      "value": "This allows inputs which accept one or many arguments (sometimes referred to as “var args”) to declare their input type as a list while for the common case of a single value, a client can just pass that value directly rather than constructing the list."
                     }
                   ]
                 },
@@ -16744,7 +16744,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " value is a valid\nresponse for all of the above types. To declare a type that disallows null,\nthe GraphQL Non-Null type can be used. This type wraps an underlying type,\nand this type acts identically to that wrapped type, with the exception\nthat "
+                  "value": " value is a valid response for all of the above types. To declare a type that disallows null, the GraphQL Non-Null type can be used. This type wraps an underlying type, and this type acts identically to that wrapped type, with the exception that "
                 },
                 {
                   "type": "Keyword",
@@ -16752,7 +16752,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is not a valid response for the wrapping type. A trailing\nexclamation mark is used to denote a field that uses a Non-Null type like this:\n"
+                  "value": " is not a valid response for the wrapping type. A trailing exclamation mark is used to denote a field that uses a Non-Null type like this: "
                 },
                 {
                   "type": "InlineCode",
@@ -16786,7 +16786,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " optional within the context of a query, a field may be\nomitted and the query is still valid. However fields that return Non-Null types\nwill never return the value "
+                      "value": " optional within the context of a query, a field may be omitted and the query is still valid. However fields that return Non-Null types will never return the value "
                     },
                     {
                       "type": "Keyword",
@@ -16803,7 +16803,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Inputs (such as field arguments), are always optional by default. However a\nnon-null input type is required. In addition to not accepting the value "
+                      "value": "Inputs (such as field arguments), are always optional by default. However a non-null input type is required. In addition to not accepting the value "
                     },
                     {
                       "type": "Keyword",
@@ -16811,7 +16811,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ",\nit also does not accept omission. For the sake of simplicity nullable types\nare always optional and non-null types are always required."
+                      "value": ", it also does not accept omission. For the sake of simplicity nullable types are always optional and non-null types are always required."
                     }
                   ]
                 }
@@ -16834,7 +16834,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " was considered a valid value.\nTo coerce the result of a Non-Null type, the coercion of the wrapped type\nshould be performed. If that result was not "
+                      "value": " was considered a valid value. To coerce the result of a Non-Null type, the coercion of the wrapped type should be performed. If that result was not "
                     },
                     {
                       "type": "Keyword",
@@ -16842,7 +16842,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", then the result of coercing\nthe Non-Null type is that result. If that result was "
+                      "value": ", then the result of coercing the Non-Null type is that result. If that result was "
                     },
                     {
                       "type": "Keyword",
@@ -16850,7 +16850,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", then a field error\nmust be raised."
+                      "value": ", then a field error must be raised."
                     }
                   ]
                 },
@@ -16859,7 +16859,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When a field error is raised on a non-null value, the error propagates to\nthe parent field. For more information on this process, see\n\"Errors and Non-Nullability\" within the Execution section."
+                      "value": "When a field error is raised on a non-null value, the error propagates to the parent field. For more information on this process, see “Errors and Non-Nullability” within the Execution section."
                     }
                   ]
                 }
@@ -16874,7 +16874,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If an argument or input-object field of a Non-Null type is not provided, is\nprovided with the literal value "
+                      "value": "If an argument or input-object field of a Non-Null type is not provided, is provided with the literal value "
                     },
                     {
                       "type": "Keyword",
@@ -16882,7 +16882,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", or is provided with a variable that was\neither not provided a value at runtime, or was provided the value "
+                      "value": ", or is provided with a variable that was either not provided a value at runtime, or was provided the value "
                     },
                     {
                       "type": "Keyword",
@@ -16890,7 +16890,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", then\na query error must be raised."
+                      "value": ", then a query error must be raised."
                     }
                   ]
                 },
@@ -16899,7 +16899,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If the value provided to the Non-Null type is provided with a literal value\nother than "
+                      "value": "If the value provided to the Non-Null type is provided with a literal value other than "
                     },
                     {
                       "type": "Keyword",
@@ -16907,7 +16907,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", or a Non-Null variable value, it is coerced using the input\ncoercion for the wrapped type."
+                      "value": ", or a Non-Null variable value, it is coerced using the input coercion for the wrapped type."
                     }
                   ]
                 },
@@ -16975,7 +16975,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The Validation section defines providing a nullable variable type to\na non-null input type as invalid."
+                      "value": "The Validation section defines providing a nullable variable type to a non-null input type as invalid."
                     }
                   ]
                 }
@@ -17012,7 +17012,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The List and Non-Null wrapping types can compose, representing more complex\ntypes. The rules for result coercion and input coercion of Lists and Non-Null\ntypes apply in a recursive fashion."
+                      "value": "The List and Non-Null wrapping types can compose, representing more complex types. The rules for result coercion and input coercion of Lists and Non-Null types apply in a recursive fashion."
                     }
                   ]
                 },
@@ -17029,7 +17029,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "), then\nthat List may not contain any "
+                      "value": "), then that List may not contain any "
                     },
                     {
                       "type": "Keyword",
@@ -17037,7 +17037,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " items. However if the inner type of a\nNon-Null is a List (e.g. "
+                      "value": " items. However if the inner type of a Non-Null is a List (e.g. "
                     },
                     {
                       "type": "InlineCode",
@@ -17053,7 +17053,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " is not accepted however an empty\nlist is accepted."
+                      "value": " is not accepted however an empty list is accepted."
                     }
                   ]
                 },
@@ -17739,7 +17739,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A GraphQL schema describes directives which are used to annotate various parts\nof a GraphQL document as an indicator that they should be evaluated differently\nby a validator, executor, or client tool such as a code generator."
+                  "value": "A GraphQL schema describes directives which are used to annotate various parts of a GraphQL document as an indicator that they should be evaluated differently by a validator, executor, or client tool such as a code generator."
                 }
               ]
             },
@@ -17773,7 +17773,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL implementations that support the type system definition language must\nprovide the "
+                  "value": "GraphQL implementations that support the type system definition language must provide the "
                 },
                 {
                   "type": "InlineCode",
@@ -17781,7 +17781,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " directive if representing deprecated portions of\nthe schema."
+                  "value": " directive if representing deprecated portions of the schema."
                 }
               ]
             },
@@ -17794,7 +17794,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "GraphQL services and client tooling may provide additional directives beyond\nthose defined in this document. Directives are the preferred way to extend\nGraphQL with custom or experimental behavior."
+                      "value": "GraphQL services and client tooling may provide additional directives beyond those defined in this document. Directives are the preferred way to extend GraphQL with custom or experimental behavior."
                     }
                   ]
                 },
@@ -17803,7 +17803,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When defining a directive, it is recommended to prefix the directive's\nname to make its scope of usage clear and to prevent a collision with directives\nwhich may be specified by future versions of this document (which will not\ninclude "
+                      "value": "When defining a directive, it is recommended to prefix the directive’s name to make its scope of usage clear and to prevent a collision with directives which may be specified by future versions of this document (which will not include "
                     },
                     {
                       "type": "InlineCode",
@@ -17811,7 +17811,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " in their name). For example, a custom directive used by Facebook's\nGraphQL service should be named "
+                      "value": " in their name). For example, a custom directive used by Facebook’s GraphQL service should be named "
                     },
                     {
                       "type": "InlineCode",
@@ -17827,7 +17827,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". This is\nespecially recommended for proposed additions to this specification which can\nchange during the "
+                      "value": ". This is especially recommended for proposed additions to this specification which can change during the "
                     },
                     {
                       "type": "Link",
@@ -17841,7 +17841,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ".\nFor example a work in progress version of "
+                      "value": ". For example a work in progress version of "
                     },
                     {
                       "type": "InlineCode",
@@ -17866,7 +17866,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Directives must only be used in the locations they are declared to belong in.\nIn this example, a directive is defined which can be used to annotate a field:"
+                      "value": "Directives must only be used in the locations they are declared to belong in. In this example, a directive is defined which can be used to annotate a field:"
                     }
                   ]
                 },
@@ -17891,7 +17891,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " character to aid\nformatting when representing a longer list of possible locations:"
+                      "value": " character to aid formatting when representing a longer list of possible locations:"
                     }
                   ]
                 },
@@ -17908,7 +17908,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Directives can also be used to annotate the type system definition language\nas well, which can be a useful tool for supplying additional metadata in order\nto generate GraphQL execution services, produce client generated runtime code,\nor many other useful extensions of the GraphQL semantics."
+                      "value": "Directives can also be used to annotate the type system definition language as well, which can be a useful tool for supplying additional metadata in order to generate GraphQL execution services, produce client generated runtime code, or many other useful extensions of the GraphQL semantics."
                     }
                   ]
                 },
@@ -17942,7 +17942,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A directive may be defined as repeatable by including the \"repeatable\" keyword.\nRepeatable directives are often useful when the same directive should be used\nwith different arguments at a single location, especially in cases where\nadditional information needs to be provided to a type or schema extension via\na directive:"
+                      "value": "A directive may be defined as repeatable by including the “repeatable” keyword. Repeatable directives are often useful when the same directive should be used with different arguments at a single location, especially in cases where additional information needs to be provided to a type or schema extension via a directive:"
                     }
                   ]
                 },
@@ -17976,7 +17976,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The order in which directives appear may be significant, including\nrepeatable directives."
+                      "value": "The order in which directives appear may be significant, including repeatable directives."
                     }
                   ]
                 }
@@ -17995,7 +17995,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "A directive definition must not contain the use of a directive which\n   references itself directly."
+                          "value": "A directive definition must not contain the use of a directive which references itself directly."
                         }
                       ]
                     },
@@ -18004,7 +18004,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "A directive definition must not contain the use of a directive which\n   references itself indirectly by referencing a Type or Directive which\n   transitively includes a reference to this directive."
+                          "value": "A directive definition must not contain the use of a directive which references itself indirectly by referencing a Type or Directive which transitively includes a reference to this directive."
                         }
                       ]
                     },
@@ -18013,7 +18013,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "The directive must not have a name which begins with the characters\n   "
+                          "value": "The directive must not have a name which begins with the characters "
                         },
                         {
                           "type": "StringLiteral",
@@ -18041,7 +18041,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "The argument must not have a name which begins with the\n      characters "
+                                  "value": "The argument must not have a name which begins with the characters "
                                 },
                                 {
                                   "type": "StringLiteral",
@@ -18072,7 +18072,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": "\n      returns "
+                                  "value": " returns "
                                 },
                                 {
                                   "type": "Keyword",
@@ -18118,7 +18118,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " directive may be provided for fields, fragment spreads, and\ninline fragments, and allows for conditional exclusion during execution as\ndescribed by the if argument."
+                      "value": " directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."
                     }
                   ]
                 },
@@ -18135,7 +18135,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " will only be queried if the variable\n"
+                      "value": " will only be queried if the variable "
                     },
                     {
                       "type": "InlineCode",
@@ -18191,7 +18191,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " directive may be provided for fields, fragment spreads, and\ninline fragments, and allows for conditional inclusion during execution as\ndescribed by the if argument."
+                      "value": " directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."
                     }
                   ]
                 },
@@ -18208,7 +18208,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " will only be queried if the variable\n"
+                      "value": " will only be queried if the variable "
                     },
                     {
                       "type": "InlineCode",
@@ -18253,7 +18253,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " has precedence over the other. In the case\nthat both the "
+                      "value": " has precedence over the other. In the case that both the "
                     },
                     {
                       "type": "InlineCode",
@@ -18269,7 +18269,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " directives are provided on the same\nfield or fragment, it "
+                      "value": " directives are provided on the same field or fragment, it "
                     },
                     {
                       "type": "Italic",
@@ -18290,7 +18290,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " condition is false\n"
+                      "value": " condition is false "
                     },
                     {
                       "type": "Italic",
@@ -18311,7 +18311,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " condition is true. Stated conversely, the field or fragment\nmust "
+                      "value": " condition is true. Stated conversely, the field or fragment must "
                     },
                     {
                       "type": "Italic",
@@ -18345,7 +18345,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " the\n"
+                      "value": " the "
                     },
                     {
                       "type": "InlineCode",
@@ -18385,7 +18385,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " directive is used within the type system definition language\nto indicate deprecated portions of a GraphQL service's schema, such as\ndeprecated fields on a type or deprecated enum values."
+                      "value": " directive is used within the type system definition language to indicate deprecated portions of a GraphQL service’s schema, such as deprecated fields on a type or deprecated enum values."
                     }
                   ]
                 },
@@ -18394,7 +18394,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Deprecations include a reason for why it is deprecated, which is formatted using\nMarkdown syntax (as specified by "
+                      "value": "Deprecations include a reason for why it is deprecated, which is formatted using Markdown syntax (as specified by "
                     },
                     {
                       "type": "Link",
@@ -18425,7 +18425,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " is deprecated in favor of\nusing "
+                      "value": " is deprecated in favor of using "
                     },
                     {
                       "type": "InlineCode",
@@ -18461,7 +18461,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "A GraphQL service supports introspection over its schema. This schema is queried\nusing GraphQL itself, creating a powerful platform for tool-building."
+              "value": "A GraphQL service supports introspection over its schema. This schema is queried using GraphQL itself, creating a powerful platform for tool-building."
             }
           ]
         },
@@ -18470,7 +18470,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Take an example query for a trivial app. In this case there is a User type with\nthree fields: id, name, and birthday."
+              "value": "Take an example query for a trivial app. In this case there is a User type with three fields: id, name, and birthday."
             }
           ]
         },
@@ -18535,7 +18535,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Types and fields required by the GraphQL introspection system that are used in\nthe same context as user-defined types and fields are prefixed with "
+                  "value": "Types and fields required by the GraphQL introspection system that are used in the same context as user-defined types and fields are prefixed with "
                 },
                 {
                   "type": "StringLiteral",
@@ -18543,7 +18543,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " two\nunderscores. This in order to avoid naming collisions with user-defined GraphQL\ntypes. Conversely, GraphQL type system authors must not define any types,\nfields, arguments, or any other type system artifact with two leading\nunderscores."
+                  "value": " two underscores. This in order to avoid naming collisions with user-defined GraphQL types. Conversely, GraphQL type system authors must not define any types, fields, arguments, or any other type system artifact with two leading underscores."
                 }
               ]
             }
@@ -18567,7 +18567,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " field of type\n"
+                  "value": " field of type "
                 },
                 {
                   "type": "InlineCode",
@@ -18575,7 +18575,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " to allow type designers to publish documentation in addition to\ncapabilities. A GraphQL service may return the "
+                  "value": " to allow type designers to publish documentation in addition to capabilities. A GraphQL service may return the "
                 },
                 {
                   "type": "InlineCode",
@@ -18583,7 +18583,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " field using Markdown\nsyntax (as specified by "
+                  "value": " field using Markdown syntax (as specified by "
                 },
                 {
                   "type": "Link",
@@ -18597,7 +18597,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "). Therefore it is\nrecommended that any tool that displays "
+                  "value": "). Therefore it is recommended that any tool that displays "
                 },
                 {
                   "type": "InlineCode",
@@ -18605,7 +18605,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " use a CommonMark-compliant\nMarkdown renderer."
+                  "value": " use a CommonMark-compliant Markdown renderer."
                 }
               ]
             }
@@ -18621,7 +18621,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "To support the management of backwards compatibility, GraphQL fields and enum\nvalues can indicate whether or not they are deprecated ("
+                  "value": "To support the management of backwards compatibility, GraphQL fields and enum values can indicate whether or not they are deprecated ("
                 },
                 {
                   "type": "InlineCode",
@@ -18629,7 +18629,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ")\nand a description of why it is deprecated ("
+                  "value": ") and a description of why it is deprecated ("
                 },
                 {
                   "type": "InlineCode",
@@ -18646,7 +18646,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Tools built using GraphQL introspection should respect deprecation by\ndiscouraging deprecated use through information hiding or developer-facing\nwarnings."
+                  "value": "Tools built using GraphQL introspection should respect deprecation by discouraging deprecated use through information hiding or developer-facing warnings."
                 }
               ]
             }
@@ -18662,7 +18662,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL supports type name introspection at any point within a query by the\nmeta-field "
+                  "value": "GraphQL supports type name introspection at any point within a query by the meta-field "
                 },
                 {
                   "type": "InlineCode",
@@ -18670,7 +18670,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " when querying against any Object, Interface,\nor Union. It returns the name of the object type currently being queried."
+                  "value": " when querying against any Object, Interface, or Union. It returns the name of the object type currently being queried."
                 }
               ]
             },
@@ -18679,7 +18679,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "This is most often used when querying against Interface or Union types to\nidentify which actual type of the possible types has been returned."
+                  "value": "This is most often used when querying against Interface or Union types to identify which actual type of the possible types has been returned."
                 }
               ]
             },
@@ -18712,7 +18712,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\nand "
+                  "value": " and "
                 },
                 {
                   "type": "InlineCode",
@@ -18720,7 +18720,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " which are accessible from the type of the root of a query\noperation."
+                  "value": " which are accessible from the type of the root of a query operation."
                 }
               ]
             },
@@ -18737,7 +18737,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "These fields are implicit and do not appear in the fields list in the root type\nof the query operation."
+                  "value": "These fields are implicit and do not appear in the fields list in the root type of the query operation."
                 }
               ]
             },
@@ -18772,7 +18772,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " is at the core of the type introspection system.\nIt represents scalars, interfaces, object types, unions, enums, input objects types in the system."
+                      "value": " is at the core of the type introspection system. It represents scalars, interfaces, object types, unions, enums, input objects types in the system."
                     }
                   ]
                 },
@@ -18785,7 +18785,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " also represents type modifiers, which are used to modify a type\nthat it refers to ("
+                      "value": " also represents type modifiers, which are used to modify a type that it refers to ("
                     },
                     {
                       "type": "InlineCode",
@@ -18793,7 +18793,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "). This is how we represent lists,\nnon-nullable types, and the combinations thereof."
+                      "value": "). This is how we represent lists, non-nullable types, and the combinations thereof."
                     }
                   ]
                 }
@@ -18809,7 +18809,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "There are several different kinds of type. In each kind, different fields are\nactually valid. These kinds are listed in the "
+                      "value": "There are several different kinds of type. In each kind, different fields are actually valid. These kinds are listed in the "
                     },
                     {
                       "type": "InlineCode",
@@ -18840,7 +18840,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "A GraphQL type designer should describe the data format and scalar coercion\nrules in the description field of any scalar."
+                          "value": "A GraphQL type designer should describe the data format and scalar coercion rules in the description field of any scalar."
                         }
                       ]
                     },
@@ -18943,7 +18943,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Object types represent concrete instantiations of sets of fields. The\nintrospection types (e.g. "
+                          "value": "Object types represent concrete instantiations of sets of fields. The introspection types (e.g. "
                         },
                         {
                           "type": "InlineCode",
@@ -19067,7 +19067,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": ". If\n    "
+                                      "value": ". If "
                                     },
                                     {
                                       "type": "Keyword",
@@ -19127,7 +19127,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Unions are an abstract type where no common fields are declared. The possible\ntypes of a union are explicitly listed out in "
+                          "value": "Unions are an abstract type where no common fields are declared. The possible types of a union are explicitly listed out in "
                         },
                         {
                           "type": "InlineCode",
@@ -19135,7 +19135,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ". Types can be\nmade parts of unions without modification of that type."
+                          "value": ". Types can be made parts of unions without modification of that type."
                         }
                       ]
                     },
@@ -19216,7 +19216,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " returns the list of types that can be represented within this\n  union. They must be object types."
+                              "value": " returns the list of types that can be represented within this union. They must be object types."
                             }
                           ]
                         },
@@ -19251,7 +19251,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Interfaces are an abstract type where there are common fields declared. Any type\nthat implements an interface must define all the fields with names and types\nexactly matching. The implementations of this interface are explicitly listed\nout in "
+                          "value": "Interfaces are an abstract type where there are common fields declared. Any type that implements an interface must define all the fields with names and types exactly matching. The implementations of this interface are explicitly listed out in "
                         },
                         {
                           "type": "InlineCode",
@@ -19367,7 +19367,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": ". If\n    "
+                                      "value": ". If "
                                     },
                                     {
                                       "type": "Keyword",
@@ -19405,7 +19405,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " returns the list of types that implement this interface.\n  They must be object types."
+                              "value": " returns the list of types that implement this interface. They must be object types."
                             }
                           ]
                         },
@@ -19529,7 +19529,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": ". There must be at least one and they\n  must have unique names."
+                              "value": ". There must be at least one and they must have unique names."
                             },
                             {
                               "type": "List",
@@ -19556,7 +19556,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": ". If\n    "
+                                      "value": ". If "
                                     },
                                     {
                                       "type": "Keyword",
@@ -19603,7 +19603,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Input objects are composite types used as inputs into queries defined as a list\nof named input values."
+                          "value": "Input objects are composite types used as inputs into queries defined as a list of named input values."
                         }
                       ]
                     },
@@ -19752,7 +19752,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Lists represent sequences of values in GraphQL. A List type is a type modifier:\nit wraps another type instance in the "
+                          "value": "Lists represent sequences of values in GraphQL. A List type is a type modifier: it wraps another type instance in the "
                         },
                         {
                           "type": "InlineCode",
@@ -19760,7 +19760,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " field, which defines the type of\neach item in the list."
+                          "value": " field, which defines the type of each item in the list."
                         }
                       ]
                     },
@@ -19859,7 +19859,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "A Non-null type is a type modifier: it wraps another type instance in the\n"
+                          "value": "A Non-null type is a type modifier: it wraps another type instance in the "
                         },
                         {
                           "type": "InlineCode",
@@ -19875,7 +19875,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " as a response, and indicate\nrequired inputs for arguments and input object fields."
+                          "value": " as a response, and indicate required inputs for arguments and input object fields."
                         }
                       ]
                     },
@@ -20022,7 +20022,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " representing the arguments this\n  field accepts."
+                          "value": " representing the arguments this field accepts."
                         }
                       ]
                     },
@@ -20043,7 +20043,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " that represents the type of value returned by\n  this field."
+                          "value": " that represents the type of value returned by this field."
                         }
                       ]
                     },
@@ -20064,7 +20064,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " if this field should no longer be used,\n  otherwise "
+                          "value": " if this field should no longer be used, otherwise "
                         },
                         {
                           "type": "Keyword",
@@ -20111,7 +20111,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type represents field and directive arguments as well as the\n"
+                      "value": " type represents field and directive arguments as well as the "
                     },
                     {
                       "type": "InlineCode",
@@ -20183,7 +20183,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " that represents the type this input\n  value expects."
+                          "value": " that represents the type this input value expects."
                         }
                       ]
                     },
@@ -20196,7 +20196,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " may return a String encoding (using the GraphQL language) of the\n  default value used by this input value in the condition a value is not\n  provided at runtime. If this input value has no default value, returns "
+                          "value": " may return a String encoding (using the GraphQL language) of the default value used by this input value in the condition a value is not provided at runtime. If this input value has no default value, returns "
                         },
                         {
                           "type": "Keyword",
@@ -20294,7 +20294,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " if this enum value should no longer be used,\n  otherwise "
+                          "value": " if this enum value should no longer be used, otherwise "
                         },
                         {
                           "type": "Keyword",
@@ -20405,7 +20405,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " representing the valid\n  locations this directive may be placed."
+                          "value": " representing the valid locations this directive may be placed."
                         }
                       ]
                     },
@@ -20426,7 +20426,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " representing the arguments this\n  directive accepts."
+                          "value": " representing the arguments this directive accepts."
                         }
                       ]
                     },
@@ -20439,7 +20439,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " must return a Boolean that indicates if the directive may be\n  used repeatedly at a single location.\n"
+                          "value": " must return a Boolean that indicates if the directive may be used repeatedly at a single location. "
                         }
                       ]
                     }
@@ -20461,7 +20461,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "GraphQL does not just verify if a request is syntactically correct, but also\nensures that it is unambiguous and mistake-free in the context of a given\nGraphQL schema."
+              "value": "GraphQL does not just verify if a request is syntactically correct, but also ensures that it is unambiguous and mistake-free in the context of a given GraphQL schema."
             }
           ]
         },
@@ -20470,7 +20470,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "An invalid request is still technically executable, and will always produce a\nstable result as defined by the algorithms in the Execution section, however\nthat result may be ambiguous, surprising, or unexpected relative to a request\ncontaining validation errors, so execution should only occur for valid requests."
+              "value": "An invalid request is still technically executable, and will always produce a stable result as defined by the algorithms in the Execution section, however that result may be ambiguous, surprising, or unexpected relative to a request containing validation errors, so execution should only occur for valid requests."
             }
           ]
         },
@@ -20479,7 +20479,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Typically validation is performed in the context of a request immediately\nbefore execution, however a GraphQL service may execute a request without\nexplicitly validating it if that exact same request is known to have been\nvalidated before. For example: the request may be validated during development,\nprovided it does not later change, or a service may validate a request once and\nmemoize the result to avoid validating the same request again in the future.\nAny client-side or development-time tool should report validation errors and not\nallow the formulation or execution of requests known to be invalid at that given\npoint in time."
+              "value": "Typically validation is performed in the context of a request immediately before execution, however a GraphQL service may execute a request without explicitly validating it if that exact same request is known to have been validated before. For example: the request may be validated during development, provided it does not later change, or a service may validate a request once and memoize the result to avoid validating the same request again in the future. Any client-side or development-time tool should report validation errors and not allow the formulation or execution of requests known to be invalid at that given point in time."
             }
           ]
         },
@@ -20492,7 +20492,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "As GraphQL type system schema evolves over time by adding new types and new\nfields, it is possible that a request which was previously valid could later\nbecome invalid. Any change that can cause a previously valid request to become\ninvalid is considered a "
+                  "value": "As GraphQL type system schema evolves over time by adding new types and new fields, it is possible that a request which was previously valid could later become invalid. Any change that can cause a previously valid request to become invalid is considered a "
                 },
                 {
                   "type": "Italic",
@@ -20505,7 +20505,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". GraphQL services and schema\nmaintainers are encouraged to avoid breaking changes, however in order to be\nmore resilient to these breaking changes, sophisticated GraphQL systems may\nstill allow for the execution of requests which "
+                  "value": ". GraphQL services and schema maintainers are encouraged to avoid breaking changes, however in order to be more resilient to these breaking changes, sophisticated GraphQL systems may still allow for the execution of requests which "
                 },
                 {
                   "type": "Italic",
@@ -20518,7 +20518,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " were known to\nbe free of any validation errors, and have not changed since."
+                  "value": " were known to be free of any validation errors, and have not changed since."
                 }
               ]
             }
@@ -20533,7 +20533,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "For this section of this schema, we will assume the following type system\nin order to demonstrate examples:"
+                  "value": "For this section of this schema, we will assume the following type system in order to demonstrate examples:"
                 }
               ]
             },
@@ -20609,7 +20609,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " (it must\n  not be "
+                              "value": " (it must not be "
                             },
                             {
                               "type": "NonTerminal",
@@ -20635,7 +20635,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL execution will only consider the executable definitions Operation and\nFragment. Type system definitions and extensions are not executable, and are not\nconsidered during execution."
+                          "value": "GraphQL execution will only consider the executable definitions Operation and Fragment. Type system definitions and extensions are not executable, and are not considered during execution."
                         }
                       ]
                     },
@@ -20653,7 +20653,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " is invalid\nfor execution."
+                          "value": " is invalid for execution."
                         }
                       ]
                     },
@@ -20662,7 +20662,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL documents not intended to be directly executed may include\n"
+                          "value": "GraphQL documents not intended to be directly executed may include "
                         },
                         {
                           "type": "NonTerminal",
@@ -20680,7 +20680,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "For example, the following document is invalid for execution since the original\nexecuting schema may not know about the provided type extension:"
+                          "value": "For example, the following document is invalid for execution since the original executing schema may not know about the provided type extension:"
                         }
                       ]
                     },
@@ -20837,7 +20837,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Each named operation definition must be unique within a document when referred\nto by its name."
+                              "value": "Each named operation definition must be unique within a document when referred to by its name."
                             }
                           ]
                         },
@@ -20999,7 +20999,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "GraphQL allows a short-hand form for defining query operations when only that\none operation exists in the document."
+                              "value": "GraphQL allows a short-hand form for defining query operations when only that one operation exists in the document."
                             }
                           ]
                         },
@@ -21158,7 +21158,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": " be the result of\n  "
+                                  "value": " be the result of "
                                 },
                                 {
                                   "type": "Call",
@@ -21286,7 +21286,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "While each subscription must have exactly one root field, a document may\ncontain any number of operations, each of which may contain different root\nfields. When executed, a document containing multiple subscription operations\nmust provide the operation name as described in "
+                              "value": "While each subscription must have exactly one root field, a document may contain any number of operations, each of which may contain different root fields. When executed, a document containing multiple subscription operations must provide the operation name as described in "
                             },
                             {
                               "type": "Call",
@@ -21398,7 +21398,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "The target field of a field selection must be defined on the scoped type of the\nselection set. There are no limitations on alias names."
+                          "value": "The target field of a field selection must be defined on the scoped type of the selection set. There are no limitations on alias names."
                         }
                       ]
                     },
@@ -21424,7 +21424,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "For interfaces, direct field selection can only be done on fields. Fields\nof concrete implementors are not relevant to the validity of the given\ninterface-typed selection set."
+                          "value": "For interfaces, direct field selection can only be done on fields. Fields of concrete implementors are not relevant to the validity of the given interface-typed selection set."
                         }
                       ]
                     },
@@ -21467,7 +21467,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Because unions do not define fields, fields may not be directly selected from a\nunion-typed selection set, with the exception of the meta-field "
+                          "value": "Because unions do not define fields, fields may not be directly selected from a union-typed selection set, with the exception of the meta-field "
                         },
                         {
                           "type": "Variable",
@@ -21475,7 +21475,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ".\nFields from a union-typed selection set must only be queried indirectly via\na fragment."
+                          "value": ". Fields from a union-typed selection set must only be queried indirectly via a fragment."
                         }
                       ]
                     },
@@ -21597,7 +21597,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " be the set of selections with a given response name in\n    "
+                                "value": " be the set of selections with a given response name in "
                               },
                               {
                                 "type": "Variable",
@@ -21688,7 +21688,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " are equal or if either is not\n      an Object Type:"
+                                        "value": " are equal or if either is not an Object Type:"
                                       },
                                       {
                                         "type": "List",
@@ -21757,7 +21757,7 @@
                                               },
                                               {
                                                 "type": "Text",
-                                                "value": "\n        and the selection set of "
+                                                "value": " and the selection set of "
                                               },
                                               {
                                                 "type": "Variable",
@@ -22122,7 +22122,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " are the same type return true, otherwise return\n      false."
+                                        "value": " are the same type return true, otherwise return false."
                                       }
                                     ]
                                   }
@@ -22176,7 +22176,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " and\n    the selection set of "
+                                "value": " and the selection set of "
                               },
                               {
                                 "type": "Variable",
@@ -22201,7 +22201,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " be the set of selections with a given response name in\n    "
+                                "value": " be the set of selections with a given response name in "
                               },
                               {
                                 "type": "Variable",
@@ -22302,7 +22302,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If multiple field selections with the same response names are encountered\nduring execution, the field and arguments to execute and the resulting value\nshould be unambiguous. Therefore any two field selections which might both be\nencountered for the same object are only valid if they are equivalent."
+                          "value": "If multiple field selections with the same response names are encountered during execution, the field and arguments to execute and the resulting value should be unambiguous. Therefore any two field selections which might both be encountered for the same object are only valid if they are equivalent."
                         }
                       ]
                     },
@@ -22311,7 +22311,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "During execution, the simultaneous execution of fields with the same response\nname is accomplished by "
+                          "value": "During execution, the simultaneous execution of fields with the same response name is accomplished by "
                         },
                         {
                           "type": "Call",
@@ -22338,7 +22338,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "For simple hand-written GraphQL, this rule is obviously a clear developer error,\nhowever nested fragments can make this difficult to detect manually."
+                          "value": "For simple hand-written GraphQL, this rule is obviously a clear developer error, however nested fragments can make this difficult to detect manually."
                         }
                       ]
                     },
@@ -22381,7 +22381,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Identical arguments are also merged if they have identical arguments. Both\nvalues and variables can be correctly merged."
+                          "value": "Identical arguments are also merged if they have identical arguments. Both values and variables can be correctly merged."
                         }
                       ]
                     },
@@ -22424,7 +22424,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "The following fields would not merge together, however both cannot be\nencountered against the same object, so they are safe:"
+                          "value": "The following fields would not merge together, however both cannot be encountered against the same object, so they are safe:"
                         }
                       ]
                     },
@@ -22441,7 +22441,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "However, the field responses must be shapes which can be merged. For example,\nscalar values must not differ. In this example, "
+                          "value": "However, the field responses must be shapes which can be merged. For example, scalar values must not differ. In this example, "
                         },
                         {
                           "type": "InlineCode",
@@ -22457,7 +22457,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\nor an "
+                          "value": " or an "
                         },
                         {
                           "type": "InlineCode",
@@ -22609,7 +22609,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Field selections on scalars or enums are never allowed, because they\nare the leaf nodes of any GraphQL query."
+                          "value": "Field selections on scalars or enums are never allowed, because they are the leaf nodes of any GraphQL query."
                         }
                       ]
                     },
@@ -22652,7 +22652,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Conversely the leaf field selections of GraphQL queries\nmust be of type scalar or enum. Leaf selections on objects, interfaces,\nand unions without subfields are disallowed."
+                          "value": "Conversely the leaf field selections of GraphQL queries must be of type scalar or enum. Leaf selections on objects, interfaces, and unions without subfields are disallowed."
                         }
                       ]
                     },
@@ -22661,7 +22661,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Let's assume the following additions to the query root type of the schema:"
+                          "value": "Let’s assume the following additions to the query root type of the schema:"
                         }
                       ]
                     },
@@ -22706,7 +22706,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Arguments are provided to both fields and directives. The following validation\nrules apply in both cases."
+                  "value": "Arguments are provided to both fields and directives. The following validation rules apply in both cases."
                 }
               ]
             },
@@ -22816,7 +22816,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Every argument provided to a field or directive must be defined in the set of\npossible arguments of that field or directive."
+                          "value": "Every argument provided to a field or directive must be defined in the set of possible arguments of that field or directive."
                         }
                       ]
                     },
@@ -22908,7 +22908,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "In order to explore more complicated argument examples, let's add the following\nto our type system:"
+                          "value": "In order to explore more complicated argument examples, let’s add the following to our type system:"
                         }
                       ]
                     },
@@ -22951,7 +22951,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Fields and directives treat arguments as a mapping of argument name to value.\nMore than one argument with the same name in an argument set is ambiguous\nand invalid."
+                      "value": "Fields and directives treat arguments as a mapping of argument name to value. More than one argument with the same name in an argument set is ambiguous and invalid."
                     }
                   ]
                 },
@@ -23351,7 +23351,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Arguments can be required. An argument is required if the argument type is\nnon-null and does not have a default value. Otherwise, the argument is optional."
+                              "value": "Arguments can be required. An argument is required if the argument type is non-null and does not have a default value. Otherwise, the argument is optional."
                             }
                           ]
                         },
@@ -23428,7 +23428,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " is also not valid since required arguments\nalways have a non-null type."
+                              "value": " is also not valid since required arguments always have a non-null type."
                             }
                           ]
                         },
@@ -23564,7 +23564,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Fragment definitions are referenced in fragment spreads by name. To avoid\nambiguity, each fragment's name must be unique within a document."
+                              "value": "Fragment definitions are referenced in fragment spreads by name. To avoid ambiguity, each fragment’s name must be unique within a document."
                             }
                           ]
                         },
@@ -23573,7 +23573,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Inline fragments are not considered fragment definitions, and are unaffected by this\nvalidation rule."
+                              "value": "Inline fragments are not considered fragment definitions, and are unaffected by this validation rule."
                             }
                           ]
                         },
@@ -23696,7 +23696,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Fragments must be specified on types that exist in the schema. This\napplies for both named and inline fragments. If they are\nnot defined in the schema, the query does not validate."
+                              "value": "Fragments must be specified on types that exist in the schema. This applies for both named and inline fragments. If they are not defined in the schema, the query does not validate."
                             }
                           ]
                         },
@@ -23791,7 +23791,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": ", or\n  "
+                                  "value": ", or "
                                 },
                                 {
                                   "type": "NonTerminal",
@@ -23817,7 +23817,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Fragments can only be declared on unions, interfaces, and objects. They are\ninvalid on scalars. They can only be applied on non-leaf fields. This rule\napplies to both inline and named fragments."
+                              "value": "Fragments can only be declared on unions, interfaces, and objects. They are invalid on scalars. They can only be applied on non-leaf fields. This rule applies to both inline and named fragments."
                             }
                           ]
                         },
@@ -23952,7 +23952,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Field selection is also determined by spreading fragments into one\nanother. The selection set of the target fragment is unioned with\nthe selection set at the level at which the target fragment is\nreferenced."
+                      "value": "Field selection is also determined by spreading fragments into one another. The selection set of the target fragment is unioned with the selection set at the level at which the target fragment is referenced."
                     }
                   ]
                 },
@@ -24033,7 +24033,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Named fragment spreads must refer to fragments defined within the\ndocument. It is a validation error if the target of a spread is\nnot defined."
+                              "value": "Named fragment spreads must refer to fragments defined within the document. It is a validation error if the target of a spread is not defined."
                             }
                           ]
                         },
@@ -24285,7 +24285,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "The graph of fragment spreads must not form any cycles including spreading itself.\nOtherwise an operation could infinitely spread or infinitely execute on cycles\nin the underlying data."
+                              "value": "The graph of fragment spreads must not form any cycles including spreading itself. Otherwise an operation could infinitely spread or infinitely execute on cycles in the underlying data."
                             }
                           ]
                         },
@@ -24328,7 +24328,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "This also invalidates fragments that would result in an infinite recursion when\nexecuted against cyclic data:"
+                              "value": "This also invalidates fragments that would result in an infinite recursion when executed against cyclic data:"
                             }
                           ]
                         },
@@ -24450,7 +24450,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": " be the intersection of\n  "
+                                  "value": " be the intersection of "
                                 },
                                 {
                                   "type": "Call",
@@ -24586,7 +24586,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Fragments are declared on a type and will only apply when the\nruntime object type matches the type condition. They also are\nspread within the context of a parent type. A fragment spread\nis only valid if its type condition could ever apply within\nthe parent type."
+                              "value": "Fragments are declared on a type and will only apply when the runtime object type matches the type condition. They also are spread within the context of a parent type. A fragment spread is only valid if its type condition could ever apply within the parent type."
                             }
                           ]
                         }
@@ -24602,7 +24602,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "In the scope of an object type, the only valid object type\nfragment spread is one that applies to the same type that\nis in scope."
+                              "value": "In the scope of an object type, the only valid object type fragment spread is one that applies to the same type that is in scope."
                             }
                           ]
                         },
@@ -24652,7 +24652,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "In scope of an object type, unions or interface spreads can be used\nif the object type implements the interface or is a member of the union."
+                              "value": "In scope of an object type, unions or interface spreads can be used if the object type implements the interface or is a member of the union."
                             }
                           ]
                         },
@@ -24731,7 +24731,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " union. It is worth\nnoting that if one inspected the contents of the "
+                              "value": " union. It is worth noting that if one inspected the contents of the "
                             },
                             {
                               "type": "NonTerminal",
@@ -24740,7 +24740,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": "\nyou could note that no valid results would ever be returned. However\nwe do not specify this as invalid because we only consider the fragment\ndeclaration, not its body."
+                              "value": " you could note that no valid results would ever be returned. However we do not specify this as invalid because we only consider the fragment declaration, not its body."
                             }
                           ]
                         }
@@ -24756,7 +24756,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Union or interface spreads can be used within the context of an object type\nfragment, but only if the object type is one of the possible types of\nthat interface or union."
+                              "value": "Union or interface spreads can be used within the context of an object type fragment, but only if the object type is one of the possible types of that interface or union."
                             }
                           ]
                         },
@@ -24804,7 +24804,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": ".\n"
+                              "value": ". "
                             },
                             {
                               "type": "Variable",
@@ -24821,7 +24821,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " is a member of the\n"
+                              "value": " is a member of the "
                             },
                             {
                               "type": "NonTerminal",
@@ -24870,7 +24870,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " and therefore\n"
+                              "value": " and therefore "
                             },
                             {
                               "type": "Variable",
@@ -24878,7 +24878,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " can never return meaningful results. Therefore the fragment\nis invalid. Likewise "
+                              "value": " can never return meaningful results. Therefore the fragment is invalid. Likewise "
                             },
                             {
                               "type": "NonTerminal",
@@ -24896,7 +24896,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": ", and it\ncan also never return meaningful results, making it invalid."
+                              "value": ", and it can also never return meaningful results, making it invalid."
                             }
                           ]
                         }
@@ -24912,7 +24912,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": "Union or interfaces fragments can be used within each other. As long as there\nexists at least "
+                              "value": "Union or interfaces fragments can be used within each other. As long as there exists at least "
                             },
                             {
                               "type": "Italic",
@@ -24925,7 +24925,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " object type that exists in the intersection of the\npossible types of the scope and the spread, the spread is considered valid."
+                              "value": " object type that exists in the intersection of the possible types of the scope and the spread, the spread is considered valid."
                             }
                           ]
                         },
@@ -24969,7 +24969,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " and is a\nmember of "
+                              "value": " and is a member of "
                             },
                             {
                               "type": "NonTerminal",
@@ -25013,7 +25013,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": "\nand "
+                              "value": " and "
                             },
                             {
                               "type": "NonTerminal",
@@ -25035,7 +25035,7 @@
                               "contents": [
                                 {
                                   "type": "Text",
-                                  "value": "Additionally, an interface type fragment can always be spread into an\ninterface scope which it implements."
+                                  "value": "Additionally, an interface type fragment can always be spread into an interface scope which it implements."
                                 }
                               ]
                             },
@@ -25052,7 +25052,7 @@
                                 },
                                 {
                                   "type": "Text",
-                                  "value": " fragments spreads is valid,\nsince "
+                                  "value": " fragments spreads is valid, since "
                                 },
                                 {
                                   "type": "InlineCode",
@@ -25190,7 +25190,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Literal values must be compatible with the type expected in the position they\nare found as per the coercion rules defined in the Type System chapter."
+                          "value": "Literal values must be compatible with the type expected in the position they are found as per the coercion rules defined in the Type System chapter."
                         }
                       ]
                     },
@@ -25199,7 +25199,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "The type expected in a position includes the type defined by the argument a value\nis provided for, the type defined by an input object field a value is provided\nfor, and the type of a variable definition a default value is provided for."
+                          "value": "The type expected in a position includes the type defined by the argument a value is provided for, the type defined by an input object field a value is provided for, and the type of a variable definition a default value is provided for."
                         }
                       ]
                     },
@@ -25225,7 +25225,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Non-coercible values (such as a String into an Int) are invalid. The\nfollowing examples are invalid:"
+                          "value": "Non-coercible values (such as a String into an Int) are invalid. The following examples are invalid:"
                         }
                       ]
                     },
@@ -25309,7 +25309,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " be the input field definition provided by the\n  parent input object type named "
+                              "value": " be the input field definition provided by the parent input object type named "
                             },
                             {
                               "type": "Variable",
@@ -25347,7 +25347,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Every input field provided in an input object value must be defined in the set\nof possible fields of that input object's expected type."
+                          "value": "Every input field provided in an input object value must be defined in the set of possible fields of that input object’s expected type."
                         }
                       ]
                     },
@@ -25373,7 +25373,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "While the following example input-object uses a field \"favoriteCookieFlavor\"\nwhich is not defined on the expected type:"
+                          "value": "While the following example input-object uses a field “favoriteCookieFlavor” which is not defined on the expected type:"
                         }
                       ]
                     },
@@ -25538,7 +25538,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Input objects must not contain more than one field of the same name, otherwise\nan ambiguity would exist which includes an ignored portion of syntax."
+                          "value": "Input objects must not contain more than one field of the same name, otherwise an ambiguity would exist which includes an ignored portion of syntax."
                         }
                       ]
                     },
@@ -25863,7 +25863,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Input object fields may be required. Much like a field may have required\narguments, an input object may have required fields. An input field is required\nif it has a non-null type and does not have a default value. Otherwise, the\ninput object field is optional."
+                          "value": "Input object fields may be required. Much like a field may have required arguments, an input object may have required fields. An input field is required if it has a non-null type and does not have a default value. Otherwise, the input object field is optional."
                         }
                       ]
                     }
@@ -25984,7 +25984,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL services define what directives they support. For each\nusage of a directive, the directive must be available on that service."
+                          "value": "GraphQL services define what directives they support. For each usage of a directive, the directive must be available on that service."
                         }
                       ]
                     }
@@ -26148,7 +26148,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL services define what directives they support and where they support them.\nFor each usage of a directive, the directive must be used in a location that the\nservice has declared support for."
+                          "value": "GraphQL services define what directives they support and where they support them. For each usage of a directive, the directive must be used in a location that the service has declared support for."
                         }
                       ]
                     },
@@ -26165,7 +26165,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " does\nnot provide "
+                          "value": " does not provide "
                         },
                         {
                           "type": "InlineCode",
@@ -26242,7 +26242,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": " and\n    are not repeatable."
+                                      "value": " and are not repeatable."
                                     }
                                   ]
                                 },
@@ -26319,7 +26319,7 @@
                                             },
                                             {
                                               "type": "Text",
-                                              "value": "\n      in "
+                                              "value": " in "
                                             },
                                             {
                                               "type": "Variable",
@@ -26365,7 +26365,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Directives are used to describe some metadata or behavioral change on the\ndefinition they apply to. When more than one directive of the same name is used,\nthe expected metadata or behavior becomes ambiguous, therefore only one of each\ndirective is allowed per location."
+                          "value": "Directives are used to describe some metadata or behavioral change on the definition they apply to. When more than one directive of the same name is used, the expected metadata or behavior becomes ambiguous, therefore only one of each directive is allowed per location."
                         }
                       ]
                     },
@@ -26382,7 +26382,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " has\nbeen used twice for the same field:"
+                          "value": " has been used twice for the same field:"
                         }
                       ]
                     },
@@ -26407,7 +26407,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " has been used only once\nper location, despite being used twice in the query and on the same named field:"
+                          "value": " has been used only once per location, despite being used twice in the query and on the same named field:"
                         }
                       ]
                     },
@@ -26527,7 +26527,7 @@
                                             },
                                             {
                                               "type": "Text",
-                                              "value": " on\n      "
+                                              "value": " on "
                                             },
                                             {
                                               "type": "Variable",
@@ -26569,7 +26569,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If any operation defines more than one variable with the same name, it is\nambiguous and invalid. It is invalid even if the type of the duplicate variable\nis the same."
+                          "value": "If any operation defines more than one variable with the same name, it is ambiguous and invalid. It is invalid even if the type of the duplicate variable is the same."
                         }
                       ]
                     },
@@ -26586,7 +26586,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "It is valid for multiple operations to define a variable with the same name. If\ntwo operations reference the same fragment, it might actually be necessary:"
+                          "value": "It is valid for multiple operations to define a variable with the same name. If two operations reference the same fragment, it might actually be necessary:"
                         }
                       ]
                     },
@@ -26720,7 +26720,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Variables can only be input types. Objects, unions, and interfaces cannot be\nused as inputs."
+                          "value": "Variables can only be input types. Objects, unions, and interfaces cannot be used as inputs."
                         }
                       ]
                     },
@@ -26832,7 +26832,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": "'s variable list."
+                                      "value": "‘s variable list."
                                     }
                                   ]
                                 },
@@ -26905,7 +26905,7 @@
                                             },
                                             {
                                               "type": "Text",
-                                              "value": ", variable must be in\n      "
+                                              "value": ", variable must be in "
                                             },
                                             {
                                               "type": "Variable",
@@ -26913,7 +26913,7 @@
                                             },
                                             {
                                               "type": "Text",
-                                              "value": "'s variable list."
+                                              "value": "‘s variable list."
                                             }
                                           ]
                                         }
@@ -26938,7 +26938,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Variables are scoped on a per-operation basis. That means that any variable\nused within the context of an operation must be defined at the top level of that\noperation"
+                          "value": "Variables are scoped on a per-operation basis. That means that any variable used within the context of an operation must be defined at the top level of that operation"
                         }
                       ]
                     },
@@ -27015,7 +27015,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Fragments complicate this rule. Any fragment transitively included by an\noperation has access to the variables defined by that operation. Fragments\ncan appear within multiple operations and therefore variable usages\nmust correspond to variable definitions in all of those operations."
+                          "value": "Fragments complicate this rule. Any fragment transitively included by an operation has access to the variables defined by that operation. Fragments can appear within multiple operations and therefore variable usages must correspond to variable definitions in all of those operations."
                         }
                       ]
                     },
@@ -27049,7 +27049,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " is used within the context of the operation\n"
+                          "value": " is used within the context of the operation "
                         },
                         {
                           "type": "Variable",
@@ -27057,7 +27057,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " and the variable is defined by that\noperation."
+                          "value": " and the variable is defined by that operation."
                         }
                       ]
                     },
@@ -27066,7 +27066,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "On the other hand, if a fragment is included within an operation that does\nnot define a referenced variable, the query is invalid."
+                          "value": "On the other hand, if a fragment is included within an operation that does not define a referenced variable, the query is invalid."
                         }
                       ]
                     },
@@ -27100,7 +27100,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Variables must be defined in all operations in which a fragment\nis used."
+                          "value": "Variables must be defined in all operations in which a fragment is used."
                         }
                       ]
                     },
@@ -27142,7 +27142,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " does not define\na variable $"
+                          "value": " does not define a variable $"
                         },
                         {
                           "type": "Variable",
@@ -27158,7 +27158,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\nwhich is included in that operation."
+                          "value": " which is included in that operation."
                         }
                       ]
                     }
@@ -27238,7 +27238,7 @@
                             },
                             {
                               "type": "Text",
-                              "value": " must be used at least once in either\n  the operation scope itself or any fragment transitively referenced by that\n  operation."
+                              "value": " must be used at least once in either the operation scope itself or any fragment transitively referenced by that operation."
                             }
                           ]
                         }
@@ -27255,7 +27255,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "All variables defined by an operation must be used in that operation or a\nfragment transitively included by that operation. Unused variables cause\na validation error."
+                          "value": "All variables defined by an operation must be used in that operation or a fragment transitively included by that operation. Unused variables cause a validation error."
                         }
                       ]
                     },
@@ -27331,7 +27331,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\nwhich is included by "
+                          "value": " which is included by "
                         },
                         {
                           "type": "Variable",
@@ -27407,7 +27407,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " defines\nan extraneous variable."
+                          "value": " defines an extraneous variable."
                         }
                       ]
                     }
@@ -27560,7 +27560,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": "\n    defined within "
+                                      "value": " defined within "
                                     },
                                     {
                                       "type": "Variable",
@@ -27685,7 +27685,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": ",\n    or "
+                                "value": ", or "
                               },
                               {
                                 "type": "NonTerminal",
@@ -27754,7 +27754,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " if a default value exists\n      for "
+                                        "value": " if a default value exists for "
                                       },
                                       {
                                         "type": "Variable",
@@ -27795,7 +27795,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " if a default value exists for\n      the "
+                                        "value": " if a default value exists for the "
                                       },
                                       {
                                         "type": "NonTerminal",
@@ -27846,7 +27846,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " AND\n      "
+                                        "value": " AND "
                                       },
                                       {
                                         "type": "Variable",
@@ -28394,7 +28394,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Validation failures occur when variables are used in the context of types\nthat are complete mismatches, or if a nullable type in a variable is passed to\na non-null argument type."
+                          "value": "Validation failures occur when variables are used in the context of types that are complete mismatches, or if a nullable type in a variable is passed to a non-null argument type."
                         }
                       ]
                     },
@@ -28463,7 +28463,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "List cardinality must also be the same. For example, lists cannot be passed into singular\nvalues."
+                          "value": "List cardinality must also be the same. For example, lists cannot be passed into singular values."
                         }
                       ]
                     },
@@ -28480,7 +28480,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Nullability must also be respected. In general a nullable variable cannot\nbe passed to a non-null argument."
+                          "value": "Nullability must also be respected. In general a nullable variable cannot be passed to a non-null argument."
                         }
                       ]
                     },
@@ -28497,7 +28497,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "For list types, the same rules around nullability apply to both outer types\nand inner types. A nullable list cannot be passed to a non-null list, and a list\nof nullable values cannot be passed to a list of non-null values.\nThe following is valid:"
+                          "value": "For list types, the same rules around nullability apply to both outer types and inner types. A nullable list cannot be passed to a non-null list, and a list of nullable values cannot be passed to a list of non-null values. The following is valid:"
                         }
                       ]
                     },
@@ -28547,7 +28547,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ".\nSimilarly a "
+                          "value": ". Similarly a "
                         },
                         {
                           "type": "InlineCode",
@@ -28578,7 +28578,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "A notable exception to typical variable type compatibility is allowing a\nvariable definition with a nullable type to be provided to a non-null location\nas long as either that variable or that location provides a default value."
+                          "value": "A notable exception to typical variable type compatibility is allowing a variable definition with a nullable type to be provided to a non-null location as long as either that variable or that location provides a default value."
                         }
                       ]
                     },
@@ -28595,7 +28595,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " is allowed to be used\nin the non-null argument "
+                          "value": " is allowed to be used in the non-null argument "
                         },
                         {
                           "type": "InlineCode",
@@ -28603,7 +28603,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " because the field argument is\noptional since it provides a default value in the schema."
+                          "value": " because the field argument is optional since it provides a default value in the schema."
                         }
                       ]
                     },
@@ -28628,7 +28628,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " is allowed to be used\nin the non-null argument ("
+                          "value": " is allowed to be used in the non-null argument ("
                         },
                         {
                           "type": "InlineCode",
@@ -28636,7 +28636,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ") because the variable provides\na default value in the query. This behavior is explicitly supported for\ncompatibility with earlier editions of this specification. GraphQL authoring\ntools may wish to report this as a warning with the suggestion to replace\n"
+                          "value": ") because the variable provides a default value in the query. This behavior is explicitly supported for compatibility with earlier editions of this specification. GraphQL authoring tools may wish to report this as a warning with the suggestion to replace "
                         },
                         {
                           "type": "InlineCode",
@@ -28677,7 +28677,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " could still be provided to such a variable at runtime.\nA non-null argument must produce a field error if provided a "
+                          "value": " could still be provided to such a variable at runtime. A non-null argument must produce a field error if provided a "
                         },
                         {
                           "type": "Keyword",
@@ -28685,7 +28685,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " value.\n"
+                          "value": " value. "
                         }
                       ]
                     }
@@ -28792,7 +28792,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "An initial value corresponding to the root type being executed.\n  Conceptually, an initial value represents the \"universe\" of data available via\n  a GraphQL Service. It is common for a GraphQL Service to always use the same\n  initial value for every request."
+                  "value": "An initial value corresponding to the root type being executed. Conceptually, an initial value represents the “universe” of data available via a GraphQL Service. It is common for a GraphQL Service to always use the same initial value for every request."
                 }
               ]
             }
@@ -28812,7 +28812,7 @@
             },
             {
               "type": "Text",
-              "value": " produces the response,\nto be formatted according to the Response section below."
+              "value": " produces the response, to be formatted according to the Response section below."
             }
           ]
         },
@@ -28835,7 +28835,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " and a selected\noperation name to run if the document defines multiple operations, otherwise the\ndocument is expected to only contain a single operation. The result of the\nrequest is determined by the result of executing this operation according to the\n\"Executing Operations” section below."
+                  "value": " and a selected operation name to run if the document defines multiple operations, otherwise the document is expected to only contain a single operation. The result of the request is determined by the result of executing this operation according to the “Executing Operations” section below."
                 }
               ]
             },
@@ -29325,7 +29325,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "As explained in the Validation section, only requests which pass all validation\nrules should be executed. If validation errors are known, they should be\nreported in the list of \"errors\" in the response and the request must fail\nwithout execution."
+                      "value": "As explained in the Validation section, only requests which pass all validation rules should be executed. If validation errors are known, they should be reported in the list of “errors” in the response and the request must fail without execution."
                     }
                   ]
                 },
@@ -29334,20 +29334,20 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Typically validation is performed in the context of a request immediately\nbefore execution, however a GraphQL service may execute a request without\nimmediately validating it if that exact same request is known to have been\nvalidated before. A GraphQL service should only execute requests which "
+                      "value": "Typically validation is performed in the context of a request immediately before execution, however a GraphQL service may execute a request without immediately validating it if that exact same request is known to have been validated before. A GraphQL service should only execute requests which "
                     },
                     {
                       "type": "Italic",
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "at some\npoint"
+                          "value": "at some point"
                         }
                       ]
                     },
                     {
                       "type": "Text",
-                      "value": " were known to be free of any validation errors, and have since\nnot changed."
+                      "value": " were known to be free of any validation errors, and have since not changed."
                     }
                   ]
                 },
@@ -29356,7 +29356,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "For example: the request may be validated during development, provided it does\nnot later change, or a service may validate a request once and memoize the\nresult to avoid validating the same request again in the future."
+                      "value": "For example: the request may be validated during development, provided it does not later change, or a service may validate a request once and memoize the result to avoid validating the same request again in the future."
                     }
                   ]
                 }
@@ -29372,7 +29372,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If the operation has defined any variables, then the values for\nthose variables need to be coerced using the input coercion rules\nof variable's declared type. If a query error is encountered during\ninput coercion of variable values, then the operation fails without\nexecution."
+                      "value": "If the operation has defined any variables, then the values for those variables need to be coerced using the input coercion rules of variable’s declared type. If a query error is encountered during input coercion of variable values, then the operation fails without execution."
                     }
                   ]
                 },
@@ -29604,7 +29604,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " provides a value for the\n      name "
+                                    "value": " provides a value for the name "
                                   },
                                   {
                                     "type": "Variable",
@@ -29637,7 +29637,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " for the\n      name "
+                                    "value": " for the name "
                                   },
                                   {
                                     "type": "Variable",
@@ -29713,7 +29713,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " with the\n        value "
+                                            "value": " with the value "
                                           },
                                           {
                                             "type": "Variable",
@@ -29750,7 +29750,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": "\n      is not "
+                                    "value": " is not "
                                   },
                                   {
                                     "type": "Keyword",
@@ -29845,7 +29845,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " with the\n          value "
+                                                    "value": " with the value "
                                                   },
                                                   {
                                                     "type": "Keyword",
@@ -29885,7 +29885,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " cannot be coerced according to the input coercion\n          rules of "
+                                                    "value": " cannot be coerced according to the input coercion rules of "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -29918,7 +29918,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " according to the\n          input coercion rules of "
+                                                    "value": " according to the input coercion rules of "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -29951,7 +29951,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " with the\n          value "
+                                                    "value": " with the value "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -30027,7 +30027,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "The type system, as described in the \"Type System\" section of the spec, must\nprovide a query root object type. If mutations or subscriptions are supported,\nit must also provide a mutation or subscription root object type, respectively."
+                  "value": "The type system, as described in the “Type System” section of the spec, must provide a query root object type. If mutations or subscriptions are supported, it must also provide a mutation or subscription root object type, respectively."
                 }
               ]
             },
@@ -30041,7 +30041,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If the operation is a query, the result of the operation is the result of\nexecuting the query’s top level selection set with the query root object type."
+                      "value": "If the operation is a query, the result of the operation is the result of executing the query’s top level selection set with the query root object type."
                     }
                   ]
                 },
@@ -30162,7 +30162,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " be the result of running\n    "
+                            "value": " be the result of running "
                           },
                           {
                             "type": "Call",
@@ -30188,7 +30188,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": "\n    "
+                            "value": " "
                           },
                           {
                             "type": "Italic",
@@ -30231,7 +30231,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " produced while executing the\n    selection set."
+                            "value": " produced while executing the selection set."
                           }
                         ]
                       },
@@ -30275,7 +30275,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If the operation is a mutation, the result of the operation is the result of\nexecuting the mutation’s top level selection set on the mutation root\nobject type. This selection set should be executed serially."
+                      "value": "If the operation is a mutation, the result of the operation is the result of executing the mutation’s top level selection set on the mutation root object type. This selection set should be executed serially."
                     }
                   ]
                 },
@@ -30284,7 +30284,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "It is expected that the top level fields in a mutation operation perform\nside-effects on the underlying data system. Serial execution of the provided\nmutations ensures against race conditions during these side-effects."
+                      "value": "It is expected that the top level fields in a mutation operation perform side-effects on the underlying data system. Serial execution of the provided mutations ensures against race conditions during these side-effects."
                     }
                   ]
                 },
@@ -30396,7 +30396,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " be the result of running\n    "
+                            "value": " be the result of running "
                           },
                           {
                             "type": "Call",
@@ -30422,7 +30422,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": "\n    "
+                            "value": " "
                           },
                           {
                             "type": "Italic",
@@ -30465,7 +30465,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " produced while executing the\n    selection set."
+                            "value": " produced while executing the selection set."
                           }
                         ]
                       },
@@ -30509,7 +30509,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If the operation is a subscription, the result is an event stream called the\n\"Response Stream\" where each event in the event stream is the result of\nexecuting the operation for each new event on an underlying \"Source Stream\"."
+                      "value": "If the operation is a subscription, the result is an event stream called the “Response Stream” where each event in the event stream is the result of executing the operation for each new event on an underlying “Source Stream”."
                     }
                   ]
                 },
@@ -30518,7 +30518,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Executing a subscription creates a persistent function on the service that\nmaps an underlying Source Stream to a returned Response Stream."
+                      "value": "Executing a subscription creates a persistent function on the service that maps an underlying Source Stream to a returned Response Stream."
                     }
                   ]
                 },
@@ -30666,7 +30666,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and\n"
+                      "value": " and "
                     },
                     {
                       "type": "Call",
@@ -30675,7 +30675,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " algorithms may be run on separate services to\nmaintain predictable scaling properties. See the section below on Supporting\nSubscriptions at Scale."
+                      "value": " algorithms may be run on separate services to maintain predictable scaling properties. See the section below on Supporting Subscriptions at Scale."
                     }
                   ]
                 },
@@ -30684,7 +30684,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "As an example, consider a chat application. To subscribe to new messages posted\nto the chat room, the client sends a request like so:"
+                      "value": "As an example, consider a chat application. To subscribe to new messages posted to the chat room, the client sends a request like so:"
                     }
                   ]
                 },
@@ -30701,7 +30701,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "While the client is subscribed, whenever new messages are posted to chat room\nwith ID \"123\", the selection for \"sender\" and \"text\" will be evaluated and\npublished to the client, for example:"
+                      "value": "While the client is subscribed, whenever new messages are posted to chat room with ID “123”, the selection for “sender” and “text” will be evaluated and published to the client, for example:"
                     }
                   ]
                 },
@@ -30718,7 +30718,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The \"new message posted to chat room\" could use a \"Pub-Sub\" system where the\nchat room ID is the \"topic\" and each \"publish\" contains the sender and text."
+                      "value": "The “new message posted to chat room” could use a “Pub-Sub” system where the chat room ID is the “topic” and each “publish” contains the sender and text."
                     }
                   ]
                 },
@@ -30731,7 +30731,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "An event stream represents a sequence of discrete events over time which can be\nobserved. As an example, a \"Pub-Sub\" system may produce an event stream when\n\"subscribing to a topic\", with an event occurring on that event stream for each\n\"publish\" to that topic. Event streams may produce an infinite sequence of\nevents or may complete at any point. Event streams may complete in response to\nan error or simply because no more events will occur. An observer may at any\npoint decide to stop observing an event stream by cancelling it, after which it\nmust receive no more events from that event stream."
+                          "value": "An event stream represents a sequence of discrete events over time which can be observed. As an example, a “Pub-Sub” system may produce an event stream when “subscribing to a topic”, with an event occurring on that event stream for each “publish” to that topic. Event streams may produce an infinite sequence of events or may complete at any point. Event streams may complete in response to an error or simply because no more events will occur. An observer may at any point decide to stop observing an event stream by cancelling it, after which it must receive no more events from that event stream."
                         }
                       ]
                     }
@@ -30746,7 +30746,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Supporting subscriptions is a significant change for any GraphQL service. Query\nand mutation operations are stateless, allowing scaling via cloning of GraphQL\nservice instances. Subscriptions, by contrast, are stateful and require\nmaintaining the GraphQL document, variables, and other context over the lifetime\nof the subscription."
+                          "value": "Supporting subscriptions is a significant change for any GraphQL service. Query and mutation operations are stateless, allowing scaling via cloning of GraphQL service instances. Subscriptions, by contrast, are stateful and require maintaining the GraphQL document, variables, and other context over the lifetime of the subscription."
                         }
                       ]
                     },
@@ -30755,7 +30755,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Consider the behavior of your system when state is lost due to the failure of a\nsingle machine in a service. Durability and availability may be improved by\nhaving separate dedicated services for managing subscription state and client\nconnectivity."
+                          "value": "Consider the behavior of your system when state is lost due to the failure of a single machine in a service. Durability and availability may be improved by having separate dedicated services for managing subscription state and client connectivity."
                         }
                       ]
                     }
@@ -30770,7 +30770,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL subscriptions do not require any specific serialization format or\ntransport mechanism. Subscriptions specifies algorithms for the creation of a\nstream, the content of each payload on that stream, and the closing of that\nstream. There are intentionally no specifications for message acknowledgement,\nbuffering, resend requests, or any other quality of service (QoS) details.\nMessage serialization, transport mechanisms, and quality of service details\nshould be chosen by the implementing service."
+                          "value": "GraphQL subscriptions do not require any specific serialization format or transport mechanism. Subscriptions specifies algorithms for the creation of a stream, the content of each payload on that stream, and the closing of that stream. There are intentionally no specifications for message acknowledgement, buffering, resend requests, or any other quality of service (QoS) details. Message serialization, transport mechanisms, and quality of service details should be chosen by the implementing service."
                         }
                       ]
                     }
@@ -30786,7 +30786,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "A Source Stream represents the sequence of events, each of which will\ntrigger a GraphQL execution corresponding to that event. Like field value\nresolution, the logic to create a Source Stream is application-specific."
+                          "value": "A Source Stream represents the sequence of events, each of which will trigger a GraphQL execution corresponding to that event. Like field value resolution, the logic to create a Source Stream is application-specific."
                         }
                       ]
                     },
@@ -30873,7 +30873,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " be the result of\n    "
+                                "value": " be the result of "
                               },
                               {
                                 "type": "Call",
@@ -30962,7 +30962,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": ".\n    Note: This value is unaffected if an alias is used."
+                                "value": ". Note: This value is unaffected if an alias is used."
                               }
                             ]
                           },
@@ -31138,7 +31138,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " for\n    determining the resolved event stream of a subscription field named "
+                                "value": " for determining the resolved event stream of a subscription field named "
                               },
                               {
                                 "type": "Variable",
@@ -31200,7 +31200,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " algorithm is intentionally similar\nto "
+                          "value": " algorithm is intentionally similar to "
                         },
                         {
                           "type": "Call",
@@ -31209,7 +31209,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " to enable consistency when defining resolvers\non any operation type."
+                          "value": " to enable consistency when defining resolvers on any operation type."
                         }
                       ]
                     }
@@ -31225,7 +31225,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Each event in the underlying Source Stream triggers execution of the subscription\nselection set using that event as a root value."
+                          "value": "Each event in the underlying Source Stream triggers execution of the subscription selection set using that event as a root value."
                         }
                       ]
                     },
@@ -31314,7 +31314,7 @@
                                       },
                                       {
                                         "type": "Text",
-                                        "value": " be the result of running\n      "
+                                        "value": " be the result of running "
                                       },
                                       {
                                         "type": "Call",
@@ -31493,7 +31493,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " be the result of running\n    "
+                                "value": " be the result of running "
                               },
                               {
                                 "type": "Call",
@@ -31519,7 +31519,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": "\n    "
+                                "value": " "
                               },
                               {
                                 "type": "Italic",
@@ -31562,7 +31562,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " produced while executing the\n    selection set."
+                                "value": " produced while executing the selection set."
                               }
                             ]
                           },
@@ -31608,7 +31608,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " algorithm is intentionally similar to\n"
+                          "value": " algorithm is intentionally similar to "
                         },
                         {
                           "type": "Call",
@@ -31633,7 +31633,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Unsubscribe cancels the Response Stream when a client no longer wishes to receive\npayloads for a subscription. This may in turn also cancel the Source Stream.\nThis is also a good opportunity to clean up any other resources used by\nthe subscription."
+                          "value": "Unsubscribe cancels the Response Stream when a client no longer wishes to receive payloads for a subscription. This may in turn also cancel the Source Stream. This is also a good opportunity to clean up any other resources used by the subscription."
                         }
                       ]
                     },
@@ -31685,7 +31685,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "To execute a selection set, the object value being evaluated and the object type\nneed to be known, as well as whether it must be executed serially, or may be\nexecuted in parallel."
+                  "value": "To execute a selection set, the object value being evaluated and the object type need to be known, as well as whether it must be executed serially, or may be executed in parallel."
                 }
               ]
             },
@@ -31694,7 +31694,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "First, the selection set is turned into a grouped field set; then, each\nrepresented field in the grouped field set produces an entry into a\nresponse map."
+                  "value": "First, the selection set is turned into a grouped field set; then, each represented field in the grouped field set produces an entry into a response map."
                 }
               ]
             },
@@ -31739,7 +31739,7 @@
                       },
                       {
                         "type": "Text",
-                        "value": " be the result of\n    "
+                        "value": " be the result of "
                       },
                       {
                         "type": "Call",
@@ -31838,7 +31838,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": ".\n      Note: This value is unaffected if an alias is used."
+                                "value": ". Note: This value is unaffected if an alias is used."
                               }
                             ]
                           },
@@ -32011,7 +32011,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is ordered by which fields appear first in the query. This\nis explained in greater detail in the Field Collection section below."
+                  "value": " is ordered by which fields appear first in the query. This is explained in greater detail in the Field Collection section below."
                 }
               ]
             },
@@ -32041,7 +32041,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " throws a\nfield error then that error must propagate to this entire selection set, either\nresolving to "
+                      "value": " throws a field error then that error must propagate to this entire selection set, either resolving to "
                     },
                     {
                       "type": "Keyword",
@@ -32058,7 +32058,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If this occurs, any sibling fields which have not yet executed or have not yet\nyielded a value may be cancelled to avoid unnecessary work."
+                      "value": "If this occurs, any sibling fields which have not yet executed or have not yet yielded a value may be cancelled to avoid unnecessary work."
                     }
                   ]
                 },
@@ -32081,7 +32081,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " section\nof Field Execution for more about this behavior."
+                      "value": " section of Field Execution for more about this behavior."
                     }
                   ]
                 }
@@ -32097,7 +32097,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Normally the executor can execute the entries in a grouped field set in whatever\norder it chooses (normally in parallel). Because the resolution of fields other\nthan top-level mutation fields must always be side effect-free and idempotent,\nthe execution order must not affect the result, and hence the service has the\nfreedom to execute the field entries in whatever order it deems optimal."
+                      "value": "Normally the executor can execute the entries in a grouped field set in whatever order it chooses (normally in parallel). Because the resolution of fields other than top-level mutation fields must always be side effect-free and idempotent, the execution order must not affect the result, and hence the service has the freedom to execute the field entries in whatever order it deems optimal."
                     }
                   ]
                 },
@@ -32123,7 +32123,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A valid GraphQL executor can resolve the four fields in whatever order it\nchose (however of course "
+                      "value": "A valid GraphQL executor can resolve the four fields in whatever order it chose (however of course "
                     },
                     {
                       "type": "InlineCode",
@@ -32139,7 +32139,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", and\n"
+                      "value": ", and "
                     },
                     {
                       "type": "InlineCode",
@@ -32164,7 +32164,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When executing a mutation, the selections in the top most selection set will be\nexecuted in serial order, starting with the first appearing field textually."
+                      "value": "When executing a mutation, the selections in the top most selection set will be executed in serial order, starting with the first appearing field textually."
                     }
                   ]
                 },
@@ -32173,7 +32173,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When executing a grouped field set serially, the executor must consider each entry\nfrom the grouped field set in the order provided in the grouped field set. It must\ndetermine the corresponding entry in the result map for each item to completion\nbefore it continues on to the next item in the grouped field set:"
+                      "value": "When executing a grouped field set serially, the executor must consider each entry from the grouped field set in the order provided in the grouped field set. It must determine the corresponding entry in the result map for each item to completion before it continues on to the next item in the grouped field set:"
                     }
                   ]
                 },
@@ -32238,7 +32238,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\n   will execute the "
+                          "value": " will execute the "
                         },
                         {
                           "type": "InlineCode",
@@ -32281,7 +32281,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\n   will execute the "
+                          "value": " will execute the "
                         },
                         {
                           "type": "InlineCode",
@@ -32300,7 +32300,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "As an illustrative example, let's assume we have a mutation field\n"
+                      "value": "As an illustrative example, let’s assume we have a mutation field "
                     },
                     {
                       "type": "InlineCode",
@@ -32308,7 +32308,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " that returns an object containing one field,\n"
+                      "value": " that returns an object containing one field, "
                     },
                     {
                       "type": "InlineCode",
@@ -32498,7 +32498,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Before execution, the selection set is converted to a grouped field set by\ncalling "
+                      "value": "Before execution, the selection set is converted to a grouped field set by calling "
                     },
                     {
                       "type": "Call",
@@ -32507,7 +32507,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". Each entry in the grouped field set is a list of\nfields that share a response key (the alias if defined, otherwise the field\nname). This ensures all fields with the same response key included via\nreferenced fragments are executed at the same time."
+                      "value": ". Each entry in the grouped field set is a list of fields that share a response key (the alias if defined, otherwise the field name). This ensures all fields with the same response key included via referenced fragments are executed at the same time."
                     }
                   ]
                 },
@@ -32516,7 +32516,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "As an example, collecting the fields of this selection set would collect two\ninstances of the field "
+                      "value": "As an example, collecting the fields of this selection set would collect two instances of the field "
                     },
                     {
                       "type": "InlineCode",
@@ -32558,7 +32558,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nis maintained through execution, ensuring that fields appear in the executed\nresponse in a stable and predictable order."
+                      "value": " is maintained through execution, ensuring that fields appear in the executed response in a stable and predictable order."
                     }
                   ]
                 },
@@ -32699,7 +32699,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": "'s "
+                                            "value": "‘s "
                                           },
                                           {
                                             "type": "Variable",
@@ -32731,7 +32731,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": ", continue with the next\n      "
+                                            "value": ", continue with the next "
                                           },
                                           {
                                             "type": "Variable",
@@ -32803,7 +32803,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": "'s "
+                                            "value": "‘s "
                                           },
                                           {
                                             "type": "Variable",
@@ -32835,7 +32835,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": ", continue with the next\n      "
+                                            "value": ", continue with the next "
                                           },
                                           {
                                             "type": "Variable",
@@ -32933,7 +32933,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " for\n        "
+                                            "value": " for "
                                           },
                                           {
                                             "type": "Variable",
@@ -33048,7 +33048,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": ", continue with the\n        next "
+                                            "value": ", continue with the next "
                                           },
                                           {
                                             "type": "Variable",
@@ -33106,7 +33106,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " be the Fragment in the current Document whose name is\n        "
+                                            "value": " be the Fragment in the current Document whose name is "
                                           },
                                           {
                                             "type": "Variable",
@@ -33139,7 +33139,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " in\n        "
+                                            "value": " in "
                                           },
                                           {
                                             "type": "Variable",
@@ -33199,7 +33199,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " is false, continue\n        with the next "
+                                            "value": " is false, continue with the next "
                                           },
                                           {
                                             "type": "Variable",
@@ -33257,7 +33257,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " be the result of calling\n        "
+                                            "value": " be the result of calling "
                                           },
                                           {
                                             "type": "Call",
@@ -33360,7 +33360,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " for\n          "
+                                                    "value": " for "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -33497,7 +33497,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " is false, continue\n        with the next "
+                                            "value": " is false, continue with the next "
                                           },
                                           {
                                             "type": "Variable",
@@ -33658,7 +33658,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " for\n          "
+                                                    "value": " for "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -33972,7 +33972,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ndirectives may be applied in either order since they apply commutatively."
+                      "value": " directives may be applied in either order since they apply commutatively."
                     }
                   ]
                 }
@@ -33990,7 +33990,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Each field requested in the grouped field set that is defined on the selected\nobjectType will result in an entry in the response map. Field execution first\ncoerces any provided argument values, then resolves a value for the field, and\nfinally completes that value either by recursively executing another selection\nset or coercing a scalar value."
+                  "value": "Each field requested in the grouped field set that is defined on the selected objectType will result in an entry in the response map. Field execution first coerces any provided argument values, then resolves a value for the field, and finally completes that value either by recursively executing another selection set or coercing a scalar value."
                 }
               ]
             },
@@ -34202,7 +34202,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Fields may include arguments which are provided to the underlying runtime in\norder to correctly produce a value. These arguments are defined by the field in\nthe type system to have a specific input type."
+                      "value": "Fields may include arguments which are provided to the underlying runtime in order to correctly produce a value. These arguments are defined by the field in the type system to have a specific input type."
                     }
                   ]
                 },
@@ -34229,7 +34229,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nto be provided at runtime."
+                      "value": " to be provided at runtime."
                     }
                   ]
                 },
@@ -34345,7 +34345,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " for the\n    field named "
+                            "value": " for the field named "
                           },
                           {
                             "type": "Variable",
@@ -34488,7 +34488,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " provides a value for the\n      name "
+                                    "value": " provides a value for the name "
                                   },
                                   {
                                     "type": "Variable",
@@ -34521,7 +34521,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " for the\n      name "
+                                    "value": " for the name "
                                   },
                                   {
                                     "type": "Variable",
@@ -34615,7 +34615,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " provides a value for the\n        name "
+                                            "value": " provides a value for the name "
                                           },
                                           {
                                             "type": "Variable",
@@ -34648,7 +34648,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " for the\n        name "
+                                            "value": " for the name "
                                           },
                                           {
                                             "type": "Variable",
@@ -34753,7 +34753,7 @@
                                           },
                                           {
                                             "type": "Text",
-                                            "value": " with the\n        value "
+                                            "value": " with the value "
                                           },
                                           {
                                             "type": "Variable",
@@ -34790,7 +34790,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": "\n      is not "
+                                    "value": " is not "
                                   },
                                   {
                                     "type": "Keyword",
@@ -34885,7 +34885,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " with the\n          value "
+                                                    "value": " with the value "
                                                   },
                                                   {
                                                     "type": "Keyword",
@@ -34950,7 +34950,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " with the\n          value "
+                                                    "value": " with the value "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -34990,7 +34990,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " cannot be coerced according to the input coercion\n            rules of "
+                                                    "value": " cannot be coerced according to the input coercion rules of "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -35023,7 +35023,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " according to the\n          input coercion rules of "
+                                                    "value": " according to the input coercion rules of "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -35056,7 +35056,7 @@
                                                   },
                                                   {
                                                     "type": "Text",
-                                                    "value": " with the\n          value "
+                                                    "value": " with the value "
                                                   },
                                                   {
                                                     "type": "Variable",
@@ -35105,7 +35105,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Variable values are not coerced because they are expected to be coerced\nbefore executing the operation in "
+                      "value": "Variable values are not coerced because they are expected to be coerced before executing the operation in "
                     },
                     {
                       "type": "Call",
@@ -35114,7 +35114,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", and valid queries\nmust only allow usage of variables of appropriate types."
+                      "value": ", and valid queries must only allow usage of variables of appropriate types."
                     }
                   ]
                 }
@@ -35130,7 +35130,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "While nearly all of GraphQL execution can be described generically, ultimately\nthe internal system exposing the GraphQL interface must provide values.\nThis is exposed via "
+                      "value": "While nearly all of GraphQL execution can be described generically, ultimately the internal system exposing the GraphQL interface must provide values. This is exposed via "
                     },
                     {
                       "type": "NonTerminal",
@@ -35139,7 +35139,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", which produces a value for a given\nfield on a type for a real value."
+                      "value": ", which produces a value for a given field on a type for a real value."
                     }
                   ]
                 },
@@ -35172,7 +35172,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\n"
+                      "value": " "
                     },
                     {
                       "type": "StringLiteral",
@@ -35188,7 +35188,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " representing John Lennon. It would be\nexpected to yield the value representing Yoko Ono."
+                      "value": " representing John Lennon. It would be expected to yield the value representing Yoko Ono."
                     }
                   ]
                 },
@@ -35241,7 +35241,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " for\n    determining the resolved value of a field named "
+                            "value": " for determining the resolved value of a field named "
                           },
                           {
                             "type": "Variable",
@@ -35302,7 +35302,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " to be asynchronous due to relying on reading\nan underlying database or networked service to produce a value. This\nnecessitates the rest of a GraphQL executor to handle an asynchronous\nexecution flow."
+                      "value": " to be asynchronous due to relying on reading an underlying database or networked service to produce a value. This necessitates the rest of a GraphQL executor to handle an asynchronous execution flow."
                     }
                   ]
                 }
@@ -35318,7 +35318,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "After resolving the value for a field, it is completed by ensuring it adheres\nto the expected return type. If the return type is another Object type, then\nthe field execution process continues recursively."
+                      "value": "After resolving the value for a field, it is completed by ensuring it adheres to the expected return type. If the return type is another Object type, then the field execution process continues recursively."
                     }
                   ]
                 },
@@ -35407,7 +35407,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": " be the result of calling\n      "
+                                    "value": " be the result of calling "
                                   },
                                   {
                                     "type": "Call",
@@ -35512,7 +35512,7 @@
                           },
                           {
                             "type": "Text",
-                            "value": " such as\n    "
+                            "value": " such as "
                           },
                           {
                             "type": "Keyword",
@@ -35607,7 +35607,7 @@
                                 "contents": [
                                   {
                                     "type": "Text",
-                                    "value": "Return a list where each list item is the result of calling\n      "
+                                    "value": "Return a list where each list item is the result of calling "
                                   },
                                   {
                                     "type": "Call",
@@ -35633,7 +35633,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": ", where\n      "
+                                    "value": ", where "
                                   },
                                   {
                                     "type": "Variable",
@@ -35681,7 +35681,7 @@
                                 "contents": [
                                   {
                                     "type": "Text",
-                                    "value": "Return the result of \"coercing\" "
+                                    "value": "Return the result of “coercing” "
                                   },
                                   {
                                     "type": "Variable",
@@ -35689,7 +35689,7 @@
                                   },
                                   {
                                     "type": "Text",
-                                    "value": ", ensuring it is a legal value of\n      "
+                                    "value": ", ensuring it is a legal value of "
                                   },
                                   {
                                     "type": "Variable",
@@ -35933,7 +35933,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "When completing a field with an abstract return type, that is an Interface or\nUnion return type, first the abstract type must be resolved to a relevant Object\ntype. This determination is made by the internal system using whatever\nmeans appropriate."
+                          "value": "When completing a field with an abstract return type, that is an Interface or Union return type, first the abstract type must be resolved to a relevant Object type. This determination is made by the internal system using whatever means appropriate."
                         }
                       ]
                     },
@@ -35950,7 +35950,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " in\nobject-oriented environments, such as Java or C#, is to use the class name of\nthe "
+                          "value": " in object-oriented environments, such as Java or C#, is to use the class name of the "
                         },
                         {
                           "type": "Variable",
@@ -35987,7 +35987,7 @@
                             "contents": [
                               {
                                 "type": "Text",
-                                "value": "Return the result of calling the internal method provided by the type\n    system for determining the Object type of "
+                                "value": "Return the result of calling the internal method provided by the type system for determining the Object type of "
                               },
                               {
                                 "type": "Variable",
@@ -35995,7 +35995,7 @@
                               },
                               {
                                 "type": "Text",
-                                "value": " given the\n    value "
+                                "value": " given the value "
                               },
                               {
                                 "type": "Variable",
@@ -36021,7 +36021,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "When more than one field of the same name is executed in parallel, their\nselection sets are merged together when completing the value in order to\ncontinue execution of the sub-selection sets."
+                          "value": "When more than one field of the same name is executed in parallel, their selection sets are merged together when completing the value in order to continue execution of the sub-selection sets."
                         }
                       ]
                     },
@@ -36030,7 +36030,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "An example query illustrating parallel fields with the same name with\nsub-selections."
+                          "value": "An example query illustrating parallel fields with the same name with sub-selections."
                         }
                       ]
                     },
@@ -36055,7 +36055,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ", the selection sets are merged together so\n"
+                          "value": ", the selection sets are merged together so "
                         },
                         {
                           "type": "InlineCode",
@@ -36240,7 +36240,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If an error is thrown while resolving a field, it should be treated as though\nthe field returned "
+                      "value": "If an error is thrown while resolving a field, it should be treated as though the field returned "
                     },
                     {
                       "type": "Keyword",
@@ -36256,7 +36256,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " list\nin the response."
+                      "value": " list in the response."
                     }
                   ]
                 },
@@ -36273,7 +36273,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " (either because the function to\nresolve the field returned "
+                      "value": " (either because the function to resolve the field returned "
                     },
                     {
                       "type": "Keyword",
@@ -36281,7 +36281,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " or because an error occurred), and that\nfield is of a "
+                      "value": " or because an error occurred), and that field is of a "
                     },
                     {
                       "type": "InlineCode",
@@ -36289,7 +36289,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type, then a field error is thrown. The\nerror must be added to the "
+                      "value": " type, then a field error is thrown. The error must be added to the "
                     },
                     {
                       "type": "StringLiteral",
@@ -36314,7 +36314,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " because of an error which has already been added to\nthe "
+                      "value": " because of an error which has already been added to the "
                     },
                     {
                       "type": "StringLiteral",
@@ -36330,7 +36330,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " list must not be\nfurther affected. That is, only one error should be added to the errors list per\nfield."
+                      "value": " list must not be further affected. That is, only one error should be added to the errors list per field."
                     }
                   ]
                 },
@@ -36355,7 +36355,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", field errors are propagated to be\nhandled by the parent field. If the parent field may be "
+                      "value": ", field errors are propagated to be handled by the parent field. If the parent field may be "
                     },
                     {
                       "type": "Keyword",
@@ -36363,7 +36363,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " then it resolves\nto "
+                      "value": " then it resolves to "
                     },
                     {
                       "type": "Keyword",
@@ -36379,7 +36379,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type, the field error is further\npropagated to it's parent field."
+                      "value": " type, the field error is further propagated to it’s parent field."
                     }
                   ]
                 },
@@ -36404,7 +36404,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " type, and one of the elements of that list\nresolves to "
+                      "value": " type, and one of the elements of that list resolves to "
                     },
                     {
                       "type": "Keyword",
@@ -36420,7 +36420,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ".\nIf the "
+                      "value": ". If the "
                     },
                     {
                       "type": "InlineCode",
@@ -36436,7 +36436,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", the field error continues\nto propagate upwards."
+                      "value": ", the field error continues to propagate upwards."
                     }
                   ]
                 },
@@ -36445,7 +36445,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If all fields from the root of the request to the source of the field error\nreturn "
+                      "value": "If all fields from the root of the request to the source of the field error return "
                     },
                     {
                       "type": "InlineCode",
@@ -36461,7 +36461,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " entry in the response should\nbe "
+                      "value": " entry in the response should be "
                     },
                     {
                       "type": "Keyword",
@@ -36469,7 +36469,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ".\n"
+                      "value": ". "
                     }
                   ]
                 }
@@ -36489,7 +36489,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "When a GraphQL service receives a request, it must return a well-formed\nresponse. The service's response describes the result of executing the requested\noperation if successful, and describes any errors encountered during the\nrequest."
+              "value": "When a GraphQL service receives a request, it must return a well-formed response. The service’s response describes the result of executing the requested operation if successful, and describes any errors encountered during the request."
             }
           ]
         },
@@ -36498,7 +36498,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "A response may contain both a partial response as well as encountered errors in\nthe case that a field error occurred on a field which was replaced with "
+              "value": "A response may contain both a partial response as well as encountered errors in the case that a field error occurred on a field which was replaced with "
             },
             {
               "type": "Keyword",
@@ -36529,7 +36529,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "If the operation encountered any errors, the response map must contain an\nentry with key "
+                  "value": "If the operation encountered any errors, the response map must contain an entry with key "
                 },
                 {
                   "type": "InlineCode",
@@ -36537,7 +36537,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". The value of this entry is described in the \"Errors\"\nsection. If the operation completed without encountering any errors, this entry\nmust not be present."
+                  "value": ". The value of this entry is described in the “Errors” section. If the operation completed without encountering any errors, this entry must not be present."
                 }
               ]
             },
@@ -36546,7 +36546,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "If the operation included execution, the response map must contain an entry\nwith key "
+                  "value": "If the operation included execution, the response map must contain an entry with key "
                 },
                 {
                   "type": "InlineCode",
@@ -36554,7 +36554,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". The value of this entry is described in the \"Data\" section. If\nthe operation failed before execution, due to a syntax error, missing\ninformation, or validation error, this entry must not be present."
+                  "value": ". The value of this entry is described in the “Data” section. If the operation failed before execution, due to a syntax error, missing information, or validation error, this entry must not be present."
                 }
               ]
             },
@@ -36571,7 +36571,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". This entry,\nif set, must have a map as its value. This entry is reserved for implementors\nto extend the protocol however they see fit, and hence there are no additional\nrestrictions on its contents."
+                  "value": ". This entry, if set, must have a map as its value. This entry is reserved for implementors to extend the protocol however they see fit, and hence there are no additional restrictions on its contents."
                 }
               ]
             },
@@ -36580,7 +36580,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "To ensure future changes to the protocol do not break existing services and\nclients, the top level response map must not contain any entries other than the\nthree described above."
+                  "value": "To ensure future changes to the protocol do not break existing services and clients, the top level response map must not contain any entries other than the three described above."
                 }
               ]
             },
@@ -36597,7 +36597,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " is present in the response, it may be helpful for it to\nappear first when serialized to make it more clear when errors are present\nin a response during debugging."
+                  "value": " is present in the response, it may be helpful for it to appear first when serialized to make it more clear when errors are present in a response during debugging."
                 }
               ]
             },
@@ -36619,7 +36619,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " entry in the response will be the result of the execution of the\nrequested operation. If the operation was a query, this output will be an\nobject of the schema's query root type; if the operation was a mutation, this\noutput will be an object of the schema's mutation root type."
+                      "value": " entry in the response will be the result of the execution of the requested operation. If the operation was a query, this output will be an object of the schema’s query root type; if the operation was a mutation, this output will be an object of the schema’s mutation root type."
                     }
                   ]
                 },
@@ -36636,7 +36636,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " entry should\nnot be present in the result."
+                      "value": " entry should not be present in the result."
                     }
                   ]
                 },
@@ -36645,7 +36645,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If an error was encountered during the execution that prevented a valid\nresponse, the "
+                      "value": "If an error was encountered during the execution that prevented a valid response, the "
                     },
                     {
                       "type": "InlineCode",
@@ -36685,7 +36685,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " entry in the response is a non-empty list of errors, where each\nerror is a map."
+                      "value": " entry in the response is a non-empty list of errors, where each error is a map."
                     }
                   ]
                 },
@@ -36702,7 +36702,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nentry should not be present in the result."
+                      "value": " entry should not be present in the result."
                     }
                   ]
                 },
@@ -36727,7 +36727,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nentry in the response must not be empty. It must contain at least one error.\nThe errors it contains should indicate why no data was able to be returned."
+                      "value": " entry in the response must not be empty. It must contain at least one error. The errors it contains should indicate why no data was able to be returned."
                     }
                   ]
                 },
@@ -36744,7 +36744,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " entry in the response is present (including if it is the value\n"
+                      "value": " entry in the response is present (including if it is the value "
                     },
                     {
                       "type": "Keyword",
@@ -36760,7 +36760,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " entry in the response may contain any errors that\noccurred during execution. If errors occurred during execution, it should\ncontain those errors."
+                      "value": " entry in the response may contain any errors that occurred during execution. If errors occurred during execution, it should contain those errors."
                     }
                   ]
                 },
@@ -36781,7 +36781,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " with a string\ndescription of the error intended for the developer as a guide to understand\nand correct the error."
+                          "value": " with a string description of the error intended for the developer as a guide to understand and correct the error."
                         }
                       ]
                     },
@@ -36790,7 +36790,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If an error can be associated to a particular point in the requested GraphQL\ndocument, it should contain an entry with the key "
+                          "value": "If an error can be associated to a particular point in the requested GraphQL document, it should contain an entry with the key "
                         },
                         {
                           "type": "InlineCode",
@@ -36798,7 +36798,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " with a list of\nlocations, where each location is a map with the keys "
+                          "value": " with a list of locations, where each location is a map with the keys "
                         },
                         {
                           "type": "InlineCode",
@@ -36814,7 +36814,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ", both\npositive numbers starting from "
+                          "value": ", both positive numbers starting from "
                         },
                         {
                           "type": "InlineCode",
@@ -36822,7 +36822,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " which describe the beginning of an\nassociated syntax element."
+                          "value": " which describe the beginning of an associated syntax element."
                         }
                       ]
                     },
@@ -36831,7 +36831,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If an error can be associated to a particular field in the GraphQL result, it\nmust contain an entry with the key "
+                          "value": "If an error can be associated to a particular field in the GraphQL result, it must contain an entry with the key "
                         },
                         {
                           "type": "InlineCode",
@@ -36839,7 +36839,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " that details the path of the\nresponse field which experienced the error. This allows clients to identify\nwhether a "
+                          "value": " that details the path of the response field which experienced the error. This allows clients to identify whether a "
                         },
                         {
                           "type": "InlineCode",
@@ -36856,7 +36856,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "This field should be a list of path segments starting at the root of the\nresponse and ending with the field associated with the error. Path segments\nthat represent fields should be strings, and path segments that\nrepresent list indices should be 0-indexed integers. If the error happens\nin an aliased field, the path to the error should use the aliased name, since\nit represents a path in the response, not in the query."
+                          "value": "This field should be a list of path segments starting at the root of the response and ending with the field associated with the error. Path segments that represent fields should be strings, and path segments that represent list indices should be 0-indexed integers. If the error happens in an aliased field, the path to the error should use the aliased name, since it represents a path in the response, not in the query."
                         }
                       ]
                     },
@@ -36865,7 +36865,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "For example, if fetching one of the friends' names fails in the following\nquery:"
+                          "value": "For example, if fetching one of the friends’ names fails in the following query:"
                         }
                       ]
                     },
@@ -36915,7 +36915,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\nresult will bubble up to the next nullable field. In that case, the "
+                          "value": " result will bubble up to the next nullable field. In that case, the "
                         },
                         {
                           "type": "InlineCode",
@@ -36923,7 +36923,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "\nfor the error should include the full path to the result field where the error\noccurred, even if that field is not present in the response."
+                          "value": " for the error should include the full path to the result field where the error occurred, even if that field is not present in the response."
                         }
                       ]
                     },
@@ -36948,7 +36948,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " return\ntype in the schema, the result would look different but the error reported would\nbe the same:"
+                          "value": " return type in the schema, the result would look different but the error reported would be the same:"
                         }
                       ]
                     },
@@ -36973,7 +36973,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": ".\nThis entry, if set, must have a map as its value. This entry is reserved for\nimplementors to add additional information to errors however they see fit, and\nthere are no additional restrictions on its contents."
+                          "value": ". This entry, if set, must have a map as its value. This entry is reserved for implementors to add additional information to errors however they see fit, and there are no additional restrictions on its contents."
                         }
                       ]
                     },
@@ -36990,7 +36990,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "GraphQL services should not provide any additional entries to the error format\nsince they could conflict with additional entries that may be added in future\nversions of this specification."
+                          "value": "GraphQL services should not provide any additional entries to the error format since they could conflict with additional entries that may be added in future versions of this specification."
                         }
                       ]
                     },
@@ -37007,7 +37007,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " entry\nfor error formatting. While non-specified entries are not violations, they are\nstill discouraged."
+                          "value": " entry for error formatting. While non-specified entries are not violations, they are still discouraged."
                         }
                       ]
                     },
@@ -37035,7 +37035,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "GraphQL does not require a specific serialization format. However, clients\nshould use a serialization format that supports the major primitives in the\nGraphQL response. In particular, the serialization format must at least support\nrepresentations of the following four primitives:"
+                  "value": "GraphQL does not require a specific serialization format. However, clients should use a serialization format that supports the major primitives in the GraphQL response. In particular, the serialization format must at least support representations of the following four primitives:"
                 }
               ]
             },
@@ -37086,7 +37086,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A serialization format should also support the following primitives, each\nrepresenting one of the common GraphQL scalar types, however a string or simpler\nprimitive may be used as a substitute if any are not directly supported:"
+                  "value": "A serialization format should also support the following primitives, each representing one of the common GraphQL scalar types, however a string or simpler primitive may be used as a substitute if any are not directly supported:"
                 }
               ]
             },
@@ -37137,7 +37137,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "This is not meant to be an exhaustive list of what a serialization format may\nencode. For example custom scalars representing a Date, Time, URI, or number\nwith a different precision may be represented in whichever relevant format a\ngiven serialization format may support."
+                  "value": "This is not meant to be an exhaustive list of what a serialization format may encode. For example custom scalars representing a Date, Time, URI, or number with a different precision may be represented in whichever relevant format a given serialization format may support."
                 }
               ]
             },
@@ -37151,7 +37151,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "JSON is the most common serialization format for GraphQL. Though as mentioned\nabove, GraphQL does not require a specific serialization format."
+                      "value": "JSON is the most common serialization format for GraphQL. Though as mentioned above, GraphQL does not require a specific serialization format."
                     }
                   ]
                 },
@@ -37160,7 +37160,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When using JSON as a serialization of GraphQL responses, the following JSON\nvalues should be used to encode the related GraphQL values:"
+                      "value": "When using JSON as a serialization of GraphQL responses, the following JSON values should be used to encode the related GraphQL values:"
                     }
                   ]
                 },
@@ -37308,7 +37308,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "For consistency and ease of notation, examples of responses are given in\nJSON format throughout this document."
+                      "value": "For consistency and ease of notation, examples of responses are given in JSON format throughout this document."
                     }
                   ]
                 }
@@ -37324,7 +37324,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Since the result of evaluating a selection set is ordered, the serialized Map of\nresults should preserve this order by writing the map entries in the same order\nas those fields were requested as defined by query execution. Producing a\nserialized response where fields are represented in the same order in which\nthey appear in the request improves human readability during debugging and\nenables more efficient parsing of responses if the order of properties can\nbe anticipated."
+                      "value": "Since the result of evaluating a selection set is ordered, the serialized Map of results should preserve this order by writing the map entries in the same order as those fields were requested as defined by query execution. Producing a serialized response where fields are represented in the same order in which they appear in the request improves human readability during debugging and enables more efficient parsing of responses if the order of properties can be anticipated."
                     }
                   ]
                 },
@@ -37333,7 +37333,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Serialization formats which represent an ordered map should preserve the\norder of requested fields as defined by "
+                      "value": "Serialization formats which represent an ordered map should preserve the order of requested fields as defined by "
                     },
                     {
                       "type": "Call",
@@ -37342,7 +37342,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " in the Execution\nsection. Serialization formats which only represent unordered maps but where\norder is still implicit in the serialization's textual order (such as JSON)\nshould preserve the order of requested fields textually."
+                      "value": " in the Execution section. Serialization formats which only represent unordered maps but where order is still implicit in the serialization’s textual order (such as JSON) should preserve the order of requested fields textually."
                     }
                   ]
                 },
@@ -37359,7 +37359,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", a GraphQL service responding in\nJSON should respond with "
+                      "value": ", a GraphQL service responding in JSON should respond with "
                     },
                     {
                       "type": "InlineCode",
@@ -37367,7 +37367,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and should not respond\nwith "
+                      "value": " and should not respond with "
                     },
                     {
                       "type": "InlineCode",
@@ -37384,7 +37384,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "While JSON Objects are specified as an\n"
+                      "value": "While JSON Objects are specified as an "
                     },
                     {
                       "type": "Link",
@@ -37398,7 +37398,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nthe pairs are represented in an ordered manner. In other words, while the JSON\nstrings "
+                      "value": " the pairs are represented in an ordered manner. In other words, while the JSON strings "
                     },
                     {
                       "type": "InlineCode",
@@ -37414,7 +37414,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nencode the same value, they also have observably different property orderings."
+                      "value": " encode the same value, they also have observably different property orderings."
                     }
                   ]
                 },
@@ -37423,7 +37423,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "This does not violate the JSON spec, as clients may still interpret\nobjects in the response as unordered Maps and arrive at a valid value.\n"
+                      "value": "This does not violate the JSON spec, as clients may still interpret objects in the response as unordered Maps and arrive at a valid value. "
                     }
                   ]
                 }
@@ -37445,7 +37445,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "This specification document contains a number of notation conventions used to\ndescribe technical concepts such as language grammar and semantics as well as\nruntime algorithms."
+              "value": "This specification document contains a number of notation conventions used to describe technical concepts such as language grammar and semantics as well as runtime algorithms."
             }
           ]
         },
@@ -37454,7 +37454,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "This appendix seeks to explain these notations in greater detail to\navoid ambiguity."
+              "value": "This appendix seeks to explain these notations in greater detail to avoid ambiguity."
             }
           ]
         },
@@ -37468,7 +37468,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A context-free grammar consists of a number of productions. Each production has\nan abstract symbol called a \"non-terminal\" as its left-hand side, and zero or\nmore possible sequences of non-terminal symbols and or terminal characters as\nits right-hand side."
+                  "value": "A context-free grammar consists of a number of productions. Each production has an abstract symbol called a “non-terminal” as its left-hand side, and zero or more possible sequences of non-terminal symbols and or terminal characters as its right-hand side."
                 }
               ]
             },
@@ -37477,7 +37477,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Starting from a single goal non-terminal symbol, a context-free grammar\ndescribes a language: the set of possible sequences of characters that can be\ndescribed by repeatedly replacing any non-terminal in the goal sequence with one\nof the sequences it is defined by, until all non-terminal symbols have been\nreplaced by terminal characters."
+                  "value": "Starting from a single goal non-terminal symbol, a context-free grammar describes a language: the set of possible sequences of characters that can be described by repeatedly replacing any non-terminal in the goal sequence with one of the sequences it is defined by, until all non-terminal symbols have been replaced by terminal characters."
                 }
               ]
             },
@@ -37486,7 +37486,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Terminals are represented in this document in a monospace font in two forms: a\nspecific Unicode character or sequence of Unicode characters (ie. "
+                  "value": "Terminals are represented in this document in a monospace font in two forms: a specific Unicode character or sequence of Unicode characters (ie. "
                 },
                 {
                   "type": "Terminal",
@@ -37494,7 +37494,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " or\n"
+                  "value": " or "
                 },
                 {
                   "type": "Terminal",
@@ -37502,7 +37502,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "), and prose typically describing a specific Unicode code-point\n"
+                  "value": "), and prose typically describing a specific Unicode code-point "
                 },
                 {
                   "type": "StringLiteral",
@@ -37510,7 +37510,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". Sequences of Unicode characters only appear in syntactic\ngrammars and represent a "
+                  "value": ". Sequences of Unicode characters only appear in syntactic grammars and represent a "
                 },
                 {
                   "type": "NonTerminal",
@@ -37528,7 +37528,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Non-terminal production rules are represented in this document using the\nfollowing notation for a non-terminal with a single definition:"
+                  "value": "Non-terminal production rules are represented in this document using the following notation for a non-terminal with a single definition:"
                 }
               ]
             },
@@ -37609,7 +37609,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A definition may refer to itself, which describes repetitive sequences,\nfor example:"
+                  "value": "A definition may refer to itself, which describes repetitive sequences, for example:"
                 }
               ]
             },
@@ -37664,7 +37664,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "The GraphQL language is defined in a syntactic grammar where terminal symbols\nare tokens. Tokens are defined in a lexical grammar which matches patterns of\nsource characters. The result of parsing a source text sequence of Unicode\ncharacters first produces a sequence of lexical tokens according to the lexical\ngrammar which then produces abstract syntax tree (AST) according to the\nsyntactical grammar."
+                  "value": "The GraphQL language is defined in a syntactic grammar where terminal symbols are tokens. Tokens are defined in a lexical grammar which matches patterns of source characters. The result of parsing a source text sequence of Unicode characters first produces a sequence of lexical tokens according to the lexical grammar which then produces abstract syntax tree (AST) according to the syntactical grammar."
                 }
               ]
             },
@@ -37673,7 +37673,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A lexical grammar production describes non-terminal \"tokens\" by\npatterns of terminal Unicode characters. No \"whitespace\" or other ignored\ncharacters may appear between any terminal Unicode characters in the lexical\ngrammar production. A lexical grammar production is distinguished by a two colon\n"
+                  "value": "A lexical grammar production describes non-terminal “tokens” by patterns of terminal Unicode characters. No “whitespace” or other ignored characters may appear between any terminal Unicode characters in the lexical grammar production. A lexical grammar production is distinguished by a two colon "
                 },
                 {
                   "type": "InlineCode",
@@ -37715,7 +37715,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A Syntactical grammar production describes non-terminal \"rules\" by patterns of\nterminal Tokens. "
+                  "value": "A Syntactical grammar production describes non-terminal “rules” by patterns of terminal Tokens. "
                 },
                 {
                   "type": "NonTerminal",
@@ -37733,7 +37733,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " sequences may appear before or\nafter any terminal "
+                  "value": " sequences may appear before or after any terminal "
                 },
                 {
                   "type": "NonTerminal",
@@ -37742,7 +37742,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". A syntactical grammar production is distinguished by\na one colon "
+                  "value": ". A syntactical grammar production is distinguished by a one colon "
                 },
                 {
                   "type": "InlineCode",
@@ -37795,7 +37795,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "This specification uses some additional notation to describe common patterns,\nsuch as optional or repeated patterns, or parameterized alterations of the\ndefinition of a non-terminal. This section explains these short-hand notations\nand their expanded definitions in the context-free grammar."
+                  "value": "This specification uses some additional notation to describe common patterns, such as optional or repeated patterns, or parameterized alterations of the definition of a non-terminal. This section explains these short-hand notations and their expanded definitions in the context-free grammar."
                 }
               ]
             },
@@ -37808,7 +37808,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A grammar production may specify that certain expansions are not permitted by\nusing the phrase \"but not\" and then indicating the expansions to be excluded."
+                      "value": "A grammar production may specify that certain expansions are not permitted by using the phrase “but not” and then indicating the expansions to be excluded."
                     }
                   ]
                 },
@@ -37826,7 +37826,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " may\nbe replaced by any sequence of characters that could replace "
+                      "value": " may be replaced by any sequence of characters that could replace "
                     },
                     {
                       "type": "NonTerminal",
@@ -37835,7 +37835,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " provided\nthat the same sequence of characters could not replace "
+                      "value": " provided that the same sequence of characters could not replace "
                     },
                     {
                       "type": "NonTerminal",
@@ -37886,7 +37886,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A grammar may also list a number of restrictions after \"but not\" separated\nby \"or\"."
+                      "value": "A grammar may also list a number of restrictions after “but not” separated by “or”."
                     }
                   ]
                 },
@@ -37946,7 +37946,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A grammar production may specify that certain characters or tokens are not\npermitted to follow it by using the pattern "
+                      "value": "A grammar production may specify that certain characters or tokens are not permitted to follow it by using the pattern "
                     },
                     {
                       "type": "Lookahead",
@@ -37962,7 +37962,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ".\nLookahead restrictions are often used to remove ambiguity from the grammar."
+                      "value": ". Lookahead restrictions are often used to remove ambiguity from the grammar."
                     }
                   ]
                 },
@@ -37994,7 +37994,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ncannot be followed by yet another "
+                      "value": " cannot be followed by yet another "
                     },
                     {
                       "type": "NonTerminal",
@@ -38055,7 +38055,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A subscript suffix \""
+                      "value": "A subscript suffix “"
                     },
                     {
                       "type": "Quantified",
@@ -38069,7 +38069,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\" is shorthand for two possible sequences, one\nincluding that symbol and one excluding it."
+                      "value": "” is shorthand for two possible sequences, one including that symbol and one excluding it."
                     }
                   ]
                 },
@@ -38182,7 +38182,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A subscript suffix \""
+                      "value": "A subscript suffix “"
                     },
                     {
                       "type": "Quantified",
@@ -38196,7 +38196,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\" is shorthand for a list of one or more of that\nsymbol, represented as an additional recursive production."
+                      "value": "” is shorthand for a list of one or more of that symbol, represented as an additional recursive production."
                     }
                   ]
                 },
@@ -38335,7 +38335,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A symbol definition subscript suffix parameter in braces \""
+                      "value": "A symbol definition subscript suffix parameter in braces “"
                     },
                     {
                       "type": "NonTerminal",
@@ -38351,7 +38351,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\"\nis shorthand for two symbol definitions, one appended with that parameter name,\nthe other without. The same subscript suffix on a symbol is shorthand for that\nvariant of the definition. If the parameter starts with \"?\", that\nform of the symbol is used if in a symbol definition with the same parameter.\nSome possible sequences can be included or excluded conditionally when\nrespectively prefixed with \"[+Param]\" and \"[~Param]\"."
+                      "value": "” is shorthand for two symbol definitions, one appended with that parameter name, the other without. The same subscript suffix on a symbol is shorthand for that variant of the definition. If the parameter starts with “?”, that form of the symbol is used if in a symbol definition with the same parameter. Some possible sequences can be included or excluded conditionally when respectively prefixed with “[+Param]” and “[~Param]”."
                     }
                   ]
                 },
@@ -38601,7 +38601,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "This specification describes the semantic value of many grammar productions in\nthe form of a list of algorithmic steps."
+                  "value": "This specification describes the semantic value of many grammar productions in the form of a list of algorithmic steps."
                 }
               ]
             },
@@ -38696,7 +38696,7 @@
                       },
                       {
                         "type": "Text",
-                        "value": "\n    Unicode character values."
+                        "value": " Unicode character values."
                       }
                     ]
                   }
@@ -38715,7 +38715,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "This specification describes some algorithms used by the static and runtime\nsemantics, they're defined in the form of a function-like syntax with the\nalgorithm's name and the arguments it accepts along with a list of algorithmic\nsteps to take in the order listed. Each step may establish references to other\nvalues, check various conditions, call other algorithms, and eventually return\na value representing the outcome of the algorithm for the provided arguments."
+                  "value": "This specification describes some algorithms used by the static and runtime semantics, they’re defined in the form of a function-like syntax with the algorithm’s name and the arguments it accepts along with a list of algorithmic steps to take in the order listed. Each step may establish references to other values, check various conditions, call other algorithms, and eventually return a value representing the outcome of the algorithm for the provided arguments."
                 }
               ]
             },
@@ -38733,7 +38733,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " which\naccepts a single argument "
+                  "value": " which accepts a single argument "
                 },
                 {
                   "type": "Variable",
@@ -38741,7 +38741,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". The algoritm's steps produce the next number\nin the Fibonacci sequence:"
+                  "value": ". The algoritm’s steps produce the next number in the Fibonacci sequence:"
                 }
               ]
             },
@@ -38968,7 +38968,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Algorithms described in this document are written to be easy to understand.\nImplementers are encouraged to include equivalent but optimized implementations.\n"
+                  "value": "Algorithms described in this document are written to be easy to understand. Implementers are encouraged to include equivalent but optimized implementations. "
                 }
               ]
             }
@@ -40571,7 +40571,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Block string values are interpreted to exclude blank initial and trailing\nlines and uniform indentation with "
+                  "value": "Block string values are interpreted to exclude blank initial and trailing lines and uniform indentation with "
                 },
                 {
                   "type": "Call",

--- a/test/graphql-spec/output.html
+++ b/test/graphql-spec/output.html
@@ -1030,25 +1030,25 @@ pre[class*="language-"] {
 <p><em>Current Working Draft</em></p>
 <section id="sec-Introduction" class="subsec">
 <h6><a href="#sec-Introduction" title="link to this subsection">Introduction</a></h6>
-<p>This is the specification for GraphQL, a query language and execution engine originally created at Facebook in 2012 for describing the capabilities and requirements of data models for client&#8208;server applications. The development of this open standard started in 2015. This specification was licensed under OWFa 1.0 in 2017. Copyright and trademark was transferred to the GraphQL Foundation in 2019.</p>
+<p>This is the specification for GraphQL, a query language and execution engine originally created at Facebook in 2012 for describing the capabilities and requirements of data models for client-server applications. The development of this open standard started in 2015. This specification was licensed under OWFa 1.0 in 2017. Copyright and trademark was transferred to the GraphQL Foundation in 2019.</p>
 <p>GraphQL has evolved and may continue to evolve in future editions of this specification. Previous editions of the GraphQL specification can be found at permalinks that match their <a href="https://github.com/graphql/graphql-spec/releases">release tag</a>. The latest working draft release can be found at <a href="https://spec.graphql.org/draft">https://spec.graphql.org/draft</a>.</p>
 </section>
 <section id="sec-Copyright-notice" class="subsec">
 <h6><a href="#sec-Copyright-notice" title="link to this subsection">Copyright notice</a></h6>
-<p>Copyright © 2015&#8208;2018, Facebook, Inc.</p>
-<p>Copyright © 2019&#8208;present, GraphQL Foundation</p>
+<p>Copyright © 2015-2018, Facebook, Inc.</p>
+<p>Copyright © 2019-present, GraphQL Foundation</p>
 <p>As of September 26, 2017, the following persons or entities have made this Specification available under the Open Web Foundation Final Specification Agreement (OWFa 1.0), which is available at <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0">openwebfoundation.org</a>.</p>
 <ul>
 <li>Facebook, Inc.</li>
 </ul>
-<p>You can review the signed copies of the Open Web Foundation Final Specification Agreement Version 1.0 for this specification at <a href="https://github.com/graphql/graphql-spec/tree/master/signed-agreements">github.com/graphql/graphql&#8208;spec</a>, which may also include additional parties to those listed above.</p>
-<p>Your use of this Specification may be subject to other third party rights. THIS SPECIFICATION IS PROVIDED &ldquo;AS IS.&rdquo; The contributors expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non&#8208;infringement, fitness for a particular purpose, or title, related to the Specification. The entire risk as to implementing or otherwise using the Specification is assumed by the Specification implementer and user. IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS SPECIFICATION OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+<p>You can review the signed copies of the Open Web Foundation Final Specification Agreement Version 1.0 for this specification at <a href="https://github.com/graphql/graphql-spec/tree/master/signed-agreements">github.com/graphql/graphql-spec</a>, which may also include additional parties to those listed above.</p>
+<p>Your use of this Specification may be subject to other third party rights. THIS SPECIFICATION IS PROVIDED &ldquo;AS IS.&rdquo; The contributors expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the Specification. The entire risk as to implementing or otherwise using the Specification is assumed by the Specification implementer and user. IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS SPECIFICATION OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 </section>
 <section id="sec-Conformance" class="subsec">
 <h6><a href="#sec-Conformance" title="link to this subsection">Conformance</a></h6>
 <p>A conforming implementation of GraphQL must fulfill all normative requirements. Conformance requirements are described in this document via both descriptive assertions and key words with clearly defined meanings.</p>
-<p>The key words &ldquo;MUST&rdquo;, &ldquo;MUST NOT&rdquo;, &ldquo;REQUIRED&rdquo;, &ldquo;SHALL&rdquo;, &ldquo;SHALL NOT&rdquo;, &ldquo;SHOULD&rdquo;, &ldquo;SHOULD NOT&rdquo;, &ldquo;RECOMMENDED&rdquo;, &ldquo;MAY&rdquo;, and &ldquo;OPTIONAL&rdquo; in the normative portions of this document are to be interpreted as described in <a href="https://tools.ietf.org/html/rfc2119">IETF RFC 2119</a>. These key words may appear in lowercase and still retain their meaning unless explicitly declared as non&#8208;normative.</p>
-<p>A conforming implementation of GraphQL may provide additional functionality, but must not where explicitly disallowed or would otherwise result in non&#8208;conformance.</p>
+<p>The key words &ldquo;MUST&rdquo;, &ldquo;MUST NOT&rdquo;, &ldquo;REQUIRED&rdquo;, &ldquo;SHALL&rdquo;, &ldquo;SHALL NOT&rdquo;, &ldquo;SHOULD&rdquo;, &ldquo;SHOULD NOT&rdquo;, &ldquo;RECOMMENDED&rdquo;, &ldquo;MAY&rdquo;, and &ldquo;OPTIONAL&rdquo; in the normative portions of this document are to be interpreted as described in <a href="https://tools.ietf.org/html/rfc2119">IETF RFC 2119</a>. These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative.</p>
+<p>A conforming implementation of GraphQL may provide additional functionality, but must not where explicitly disallowed or would otherwise result in non-conformance.</p>
 </section>
 <section id="sec-Conforming-Algorithms" class="subsec">
 <h6><a href="#sec-Conforming-Algorithms" title="link to this subsection">Conforming Algorithms</a></h6>
@@ -1058,16 +1058,16 @@ pre[class*="language-"] {
 </section>
 <section id="sec-Non-Normative-Portions" class="subsec">
 <h6><a href="#sec-Non-Normative-Portions" title="link to this subsection">Non-Normative Portions</a></h6>
-<p>All contents of this document are normative except portions explicitly declared as non&#8208;normative.</p>
-<p>Examples in this document are non&#8208;normative, and are presented to aid understanding of introduced concepts and the behavior of normative portions of the specification. Examples are either introduced explicitly in prose (e.g. &ldquo;for example&rdquo;) or are set apart in example or counter&#8208;example blocks, like this:</p>
+<p>All contents of this document are normative except portions explicitly declared as non-normative.</p>
+<p>Examples in this document are non-normative, and are presented to aid understanding of introduced concepts and the behavior of normative portions of the specification. Examples are either introduced explicitly in prose (e.g. &ldquo;for example&rdquo;) or are set apart in example or counter-example blocks, like this:</p>
 <pre id="example-fed99" class="spec-example"><a href="#example-fed99">Example № 1</a><code>This is an example of a non-normative example.
 </code></pre>
 <pre id="example-881bd" class="spec-counter-example"><a href="#example-881bd">Counter Example № 2</a><code>This is an example of a non-normative counter-example.
 </code></pre>
-<p>Notes in this document are non&#8208;normative, and are presented to clarify intent, draw attention to potential edge&#8208;cases and pit&#8208;falls, and answer common questions that arise during implementation. Notes are either introduced explicitly in prose (e.g. &ldquo;Note: &ldquo;) or are set apart in a note block, like this:</p>
-<div id="note-b22ea" class="spec-note">
-<a href="#note-b22ea">Note</a>
-This is an example of a non&#8208;normative note.</div>
+<p>Notes in this document are non-normative, and are presented to clarify intent, draw attention to potential edge-cases and pit-falls, and answer common questions that arise during implementation. Notes are either introduced explicitly in prose (e.g. &ldquo;Note: &ldquo;) or are set apart in a note block, like this:</p>
+<div id="note-c0129" class="spec-note">
+<a href="#note-c0129">Note</a>
+This is an example of a non-normative note.</div>
 </section>
 </section>
 <nav class="spec-toc">
@@ -1357,13 +1357,13 @@ This is an example of a non&#8208;normative note.</div>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>GraphQL is not a programming language capable of arbitrary computation, but is instead a language used to query application services that have capabilities defined in this specification. GraphQL does not mandate a particular programming language or storage system for application services that implement it. Instead, application services take their capabilities and map them to a uniform language, type system, and philosophy that GraphQL encodes. This provides a unified interface friendly to product development and a powerful platform for tool&#8208;building.</p>
+<p>GraphQL is not a programming language capable of arbitrary computation, but is instead a language used to query application services that have capabilities defined in this specification. GraphQL does not mandate a particular programming language or storage system for application services that implement it. Instead, application services take their capabilities and map them to a uniform language, type system, and philosophy that GraphQL encodes. This provides a unified interface friendly to product development and a powerful platform for tool-building.</p>
 <p>GraphQL has a number of design principles:</p>
 <ul>
 <li><strong>Hierarchical</strong>: Most product development today involves the creation and manipulation of view hierarchies. To achieve congruence with the structure of these applications, a GraphQL query itself is structured hierarchically. The query is shaped just like the data it returns. It is a natural way for clients to describe data requirements.</li>
-<li><strong>Product&#8208;centric</strong>: GraphQL is unapologetically driven by the requirements of views and the front&#8208;end engineers that write them. GraphQL starts with their way of thinking and requirements and builds the language and runtime necessary to enable that.</li>
-<li><strong>Strong&#8208;typing</strong>: Every GraphQL service defines an application&#8208;specific type system. Queries are executed within the context of that type system. Given a query, tools can ensure that the query is both syntactically correct and valid within the GraphQL type system before execution, i.e. at development time, and the service can make certain guarantees about the shape and nature of the response.</li>
-<li><strong>Client&#8208;specified queries</strong>: Through its type system, a GraphQL service publishes the capabilities that its clients are allowed to consume. It is the client that is responsible for specifying exactly how it will consume those published capabilities. These queries are specified at field&#8208;level granularity. In the majority of client&#8208;server applications written without GraphQL, the service determines the data returned in its various scripted endpoints. A GraphQL query, on the other hand, returns exactly what a client asks for and no more.</li>
+<li><strong>Product-centric</strong>: GraphQL is unapologetically driven by the requirements of views and the front-end engineers that write them. GraphQL starts with their way of thinking and requirements and builds the language and runtime necessary to enable that.</li>
+<li><strong>Strong-typing</strong>: Every GraphQL service defines an application-specific type system. Queries are executed within the context of that type system. Given a query, tools can ensure that the query is both syntactically correct and valid within the GraphQL type system before execution, i.e. at development time, and the service can make certain guarantees about the shape and nature of the response.</li>
+<li><strong>Client-specified queries</strong>: Through its type system, a GraphQL service publishes the capabilities that its clients are allowed to consume. It is the client that is responsible for specifying exactly how it will consume those published capabilities. These queries are specified at field-level granularity. In the majority of client-server applications written without GraphQL, the service determines the data returned in its various scripted endpoints. A GraphQL query, on the other hand, returns exactly what a client asks for and no more.</li>
 <li><strong>Introspective</strong>: GraphQL is introspective. A GraphQL service&rsquo;s type system must be queryable by the GraphQL language itself, as will be described in this specification. GraphQL introspection serves as a powerful platform for building common tools and client software libraries.</li>
 </ul>
 <p>Because of these principles, GraphQL is a powerful and productive environment for building client applications. Product developers and designers building applications against working GraphQL services&mdash;supported with quality tools&mdash;can quickly become productive without reading extensive documentation and with little or no formal training. To enable that experience, there must be those that build those services and tools.</p>
@@ -1372,14 +1372,14 @@ This is an example of a non&#8208;normative note.</div>
 <section id="sec-Language" secid="2">
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Language">2</a></span>Language</h1>
 <p>Clients use the GraphQL query language to make requests to a GraphQL service. We refer to these request sources as documents. A document may contain operations (queries, mutations, and subscriptions) as well as fragments, a common unit of composition allowing for query reuse.</p>
-<p>A GraphQL document is defined as a syntactic grammar where terminal symbols are tokens (indivisible lexical units). These tokens are defined in a lexical grammar which matches patterns of source characters. In this document, syntactic grammar productions are distinguished with a colon <code>:</code> while lexical grammar productions are distinguished with a double&#8208;colon <code>::</code>.</p>
+<p>A GraphQL document is defined as a syntactic grammar where terminal symbols are tokens (indivisible lexical units). These tokens are defined in a lexical grammar which matches patterns of source characters. In this document, syntactic grammar productions are distinguished with a colon <code>:</code> while lexical grammar productions are distinguished with a double-colon <code>::</code>.</p>
 <p>The source text of a GraphQL document must be a sequence of <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span>. The character sequence must be described by a sequence of <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span> and <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> lexical grammars. The lexical token sequence, omitting <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span>, must be described by a single <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span> syntactic grammar.</p>
 <div id="note-e800c" class="spec-note">
 <a href="#note-e800c">Note</a>
 See <a href="#sec-Appendix-Notation-Conventions">Appendix A</a> for more information about the lexical and syntactic grammar and other notational conventions used throughout this document.</div>
 <section id="sec-Language.Lexical-Analysis-Syntactic-Parse" class="subsec">
 <h6><a href="#sec-Language.Lexical-Analysis-Syntactic-Parse" title="link to this subsection">Lexical Analysis &amp; Syntactic Parse</a></h6>
-<p>The source text of a GraphQL document is first converted into a sequence of lexical tokens, <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span>, and ignored tokens, <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span>. The source text is scanned from left to right, repeatedly taking the next possible sequence of code&#8208;points allowed by the lexical grammar productions as the next token. This sequence of lexical tokens are then scanned from left to right to produce an abstract syntax tree (AST) according to the <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span> syntactical grammar.</p>
+<p>The source text of a GraphQL document is first converted into a sequence of lexical tokens, <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span>, and ignored tokens, <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span>. The source text is scanned from left to right, repeatedly taking the next possible sequence of code-points allowed by the lexical grammar productions as the next token. This sequence of lexical tokens are then scanned from left to right to produce an abstract syntax tree (AST) according to the <span class="spec-nt"><a href="#Document" data-name="Document">Document</a></span> syntactical grammar.</p>
 <p>Lexical grammar productions in this document use <em>lookahead restrictions</em> to remove ambiguity and ensure a single valid lexical analysis. A lexical token is only valid if not followed by a character in its lookahead restriction.</p>
 <p>For example, an <span class="spec-nt"><a href="#IntValue" data-name="IntValue">IntValue</a></span> has the restriction <span class="spec-lookahead ntset not"><span class="spec-nt"><a href="#Digit" data-name="Digit">Digit</a></span></span>, so cannot be followed by a <span class="spec-nt"><a href="#Digit" data-name="Digit">Digit</a></span>. Because of this, the sequence <span class="spec-t">123</span> cannot represent the tokens (<span class="spec-t">12</span>, <span class="spec-t">3</span>) since <span class="spec-t">12</span> is followed by the <span class="spec-nt"><a href="#Digit" data-name="Digit">Digit</a></span> <span class="spec-t">3</span> and so must only represent a single token. Use <span class="spec-nt"><a href="#WhiteSpace" data-name="WhiteSpace">WhiteSpace</a></span> or other <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> between characters to represent multiple tokens.</p>
 <div id="note-ba22f" class="spec-note">
@@ -1394,13 +1394,13 @@ This typically has the same behavior as a &ldquo;<a href="https://en.wikipedia.o
 <div class="spec-rhs"><span class="spec-prose">U+000D</span></div>
 <div class="spec-rhs"><span class="spec-prose">U+0020&ndash;U+FFFF</span></div>
 </div>
-<p>GraphQL documents are expressed as a sequence of <a href="https://unicode.org/standard/standard.html">Unicode</a> characters. However, with few exceptions, most of GraphQL is expressed only in the original non&#8208;control ASCII range so as to be as widely compatible with as many existing tools, languages, and serialization formats as possible and avoid display issues in text editors and source control.</p>
+<p>GraphQL documents are expressed as a sequence of <a href="https://unicode.org/standard/standard.html">Unicode</a> characters. However, with few exceptions, most of GraphQL is expressed only in the original non-control ASCII range so as to be as widely compatible with as many existing tools, languages, and serialization formats as possible and avoid display issues in text editors and source control.</p>
 <section id="sec-Unicode" secid="2.1.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Unicode">2.1.1</a></span>Unicode</h3>
 <div class="spec-production d2" id="UnicodeBOM">
 <span class="spec-nt"><a href="#UnicodeBOM" data-name="UnicodeBOM">UnicodeBOM</a></span><div class="spec-rhs"><span class="spec-prose">Byte Order Mark (U+FEFF)</span></div>
 </div>
-<p>Non&#8208;ASCII Unicode characters may freely appear within <span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span> and <span class="spec-nt"><a href="#Comment" data-name="Comment">Comment</a></span> portions of GraphQL.</p>
+<p>Non-ASCII Unicode characters may freely appear within <span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span> and <span class="spec-nt"><a href="#Comment" data-name="Comment">Comment</a></span> portions of GraphQL.</p>
 <p>The &ldquo;Byte Order Mark&rdquo; is a special Unicode character which may appear at the beginning of a file containing Unicode which programs may use to determine the fact that the text stream is Unicode, what endianness the text stream is in, and which of several Unicode encodings to interpret.</p>
 </section>
 <section id="sec-White-Space" secid="2.1.2">
@@ -1410,9 +1410,9 @@ This typically has the same behavior as a &ldquo;<a href="https://en.wikipedia.o
 <div class="spec-rhs"><span class="spec-prose">Space (U+0020)</span></div>
 </div>
 <p>White space is used to improve legibility of source text and act as separation between tokens, and any amount of white space may appear before or after any token. White space between tokens is not significant to the semantic meaning of a GraphQL Document, however white space characters may appear within a <span class="spec-nt"><span data-name="String">String</span></span> or <span class="spec-nt"><a href="#Comment" data-name="Comment">Comment</a></span> token.</p>
-<div id="note-fdd28" class="spec-note">
-<a href="#note-fdd28">Note</a>
-GraphQL intentionally does not consider Unicode &ldquo;Zs&rdquo; category characters as white&#8208;space, avoiding misinterpretation by text editors and source control tools.</div>
+<div id="note-e49cd" class="spec-note">
+<a href="#note-e49cd">Note</a>
+GraphQL intentionally does not consider Unicode &ldquo;Zs&rdquo; category characters as white-space, avoiding misinterpretation by text editors and source control tools.</div>
 </section>
 <section id="sec-Line-Terminators" secid="2.1.3">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Line-Terminators">2.1.3</a></span>Line Terminators</h3>
@@ -1434,7 +1434,7 @@ Any error reporting which provides the line number in the source of the offendin
 <div class="spec-production d2" id="CommentChar">
 <span class="spec-nt"><a href="#CommentChar" data-name="CommentChar">CommentChar</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
 </div>
-<p>GraphQL source documents may contain single&#8208;line comments, starting with the <span class="spec-t">#</span> marker.</p>
+<p>GraphQL source documents may contain single-line comments, starting with the <span class="spec-t">#</span> marker.</p>
 <p>A comment can contain any Unicode code point in <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span> except <span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span> so a comment always consists of all code points starting with the <span class="spec-t">#</span> character up to but not including the <span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span> (or end of the source).</p>
 <p>Comments are <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> like white space and may appear after any token, or before a <span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span>, and have no significance to the semantic meaning of a GraphQL Document.</p>
 </section>
@@ -1444,7 +1444,7 @@ Any error reporting which provides the line number in the source of the offendin
 <span class="spec-nt"><a href="#Comma" data-name="Comma">Comma</a></span><div class="spec-rhs"><span class="spec-t">,</span></div>
 </div>
 <p>Similar to white space and line terminators, commas (<span class="spec-t">,</span>) are used to improve the legibility of source text and separate lexical tokens but are otherwise syntactically and semantically insignificant within GraphQL Documents.</p>
-<p>Non&#8208;significant comma characters ensure that the absence or presence of a comma does not meaningfully alter the interpreted syntax of the document, as this can be a common user&#8208;error in other languages. It also allows for the stylistic use of either trailing commas or line&#8208;terminators as list delimiters which are both often desired for legibility and maintainability of source code.</p>
+<p>Non-significant comma characters ensure that the absence or presence of a comma does not meaningfully alter the interpreted syntax of the document, as this can be a common user-error in other languages. It also allows for the stylistic use of either trailing commas or line-terminators as list delimiters which are both often desired for legibility and maintainability of source code.</p>
 </section>
 <section id="sec-Language.Source-Text.Lexical-Tokens" secid="2.1.6">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Language.Source-Text.Lexical-Tokens">2.1.6</a></span>Lexical Tokens</h3>
@@ -1513,7 +1513,7 @@ Any error reporting which provides the line number in the source of the offendin
 </table></div></div>
 </div>
 <p>GraphQL Documents are full of named things: operations, fields, arguments, types, directives, fragments, and variables. All names must follow the same grammatical form.</p>
-<p>Names in GraphQL are case&#8208;sensitive. That is to say <code>name</code>, <code>Name</code>, and <code>NAME</code> all refer to different names. Underscores are significant, which means <code>other_name</code> and <code>othername</code> are two different names.</p>
+<p>Names in GraphQL are case-sensitive. That is to say <code>name</code>, <code>Name</code>, and <code>NAME</code> all refer to different names. Underscores are significant, which means <code>other_name</code> and <code>othername</code> are two different names.</p>
 <p>A <span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span> must not be followed by a <span class="spec-nt"><a href="#NameContinue" data-name="NameContinue">NameContinue</a></span>. In other words, a <span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span> token is always the longest possible valid sequence. The source characters <span class="spec-t">a1</span> cannot be interpreted as two tokens since <span class="spec-t">a</span> is followed by the <span class="spec-nt"><a href="#NameContinue" data-name="NameContinue">NameContinue</a></span> <span class="spec-t">1</span>.</p>
 <div id="note-46408" class="spec-note">
 <a href="#note-46408">Note</a>
@@ -1553,9 +1553,9 @@ Names in GraphQL are limited to the Latin <acronym>ASCII</acronym> subset of <sp
 </div>
 <p>There are three types of operations that GraphQL models:</p>
 <ul>
-<li>query &ndash; a read&#8208;only fetch.</li>
+<li>query &ndash; a read-only fetch.</li>
 <li>mutation &ndash; a write followed by a fetch.</li>
-<li>subscription &ndash; a long&#8208;lived request that fetches data in response to source events.</li>
+<li>subscription &ndash; a long-lived request that fetches data in response to source events.</li>
 </ul>
 <p>Each operation is represented by an optional operation name and a selection set.</p>
 <p>For example, this mutation operation might &ldquo;like&rdquo; a story and then retrieve the new number of likes:</p>
@@ -1569,15 +1569,15 @@ Names in GraphQL are limited to the Latin <acronym>ASCII</acronym> subset of <sp
 </code></pre>
 <section id="sec-Language.Operations.Query-shorthand" class="subsec">
 <h6><a href="#sec-Language.Operations.Query-shorthand" title="link to this subsection">Query shorthand</a></h6>
-<p>If a document contains only one query operation, and that query defines no variables and contains no directives, that operation may be represented in a short&#8208;hand form which omits the query keyword and query name.</p>
+<p>If a document contains only one query operation, and that query defines no variables and contains no directives, that operation may be represented in a short-hand form which omits the query keyword and query name.</p>
 <p>For example, this unnamed query operation is written via query shorthand.</p>
 <pre id="example-63b18" class="spec-example" data-language="graphql"><a href="#example-63b18">Example № 6</a><code><span class="token punctuation">{</span>
   field
 <span class="token punctuation">}</span>
 </code></pre>
-<div id="note-9f839" class="spec-note">
-<a href="#note-9f839">Note</a>
-many examples below will use the query short&#8208;hand syntax.</div>
+<div id="note-5e20f" class="spec-note">
+<a href="#note-5e20f">Note</a>
+many examples below will use the query short-hand syntax.</div>
 </section>
 </section>
 <section id="sec-Selection-Sets" secid="2.4">
@@ -1590,7 +1590,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#FragmentSpread" data-name="FragmentSpread">FragmentSpread</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#InlineFragment" data-name="InlineFragment">InlineFragment</a></span></div>
 </div>
-<p>An operation selects the set of information it needs, and will receive exactly that information and nothing more, avoiding over&#8208;fetching and under&#8208;fetching data.</p>
+<p>An operation selects the set of information it needs, and will receive exactly that information and nothing more, avoiding over-fetching and under-fetching data.</p>
 <pre id="example-21649" class="spec-example" data-language="graphql"><a href="#example-21649">Example № 7</a><code><span class="token punctuation">{</span>
   id
   firstName
@@ -1622,7 +1622,7 @@ many examples below will use the query short&#8208;hand syntax.</div>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>Fields in the top&#8208;level selection set of an operation often represent some information that is globally accessible to your application and its current viewer. Some typical examples of these top fields include references to a current logged&#8208;in viewer, or accessing certain types of data referenced by a unique identifier.</p>
+<p>Fields in the top-level selection set of an operation often represent some information that is globally accessible to your application and its current viewer. Some typical examples of these top fields include references to a current logged-in viewer, or accessing certain types of data referenced by a unique identifier.</p>
 <pre id="example-e1984" class="spec-example" data-language="graphql"><a href="#example-e1984">Example № 9</a><code><span class="token comment"># `me` could represent the currently logged in viewer.</span>
 <span class="token punctuation">{</span>
   me <span class="token punctuation">{</span>
@@ -1957,12 +1957,12 @@ The numeric literals <span class="spec-nt"><a href="#IntValue" data-name="IntVal
 <section id="sec-String-Value" secid="2.9.4">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-String-Value">2.9.4</a></span>String Value</h3>
 <div class="spec-production d2" id="StringValue">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;&quot;</span><span class="spec-lookahead not"><span class="spec-t">&quot;</span></span></div>
-<div class="spec-rhs"><span class="spec-t">&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">&quot;</span></div>
-<div class="spec-rhs"><span class="spec-t">&quot;&quot;&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">&quot;&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">""</span><span class="spec-lookahead not"><span class="spec-t">"</span></span></div>
+<div class="spec-rhs"><span class="spec-t">"</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">"</span></div>
+<div class="spec-rhs"><span class="spec-t">"""</span><span class="spec-quantified"><span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">"""</span></div>
 </div>
 <div class="spec-production d2" id="StringCharacter">
-<span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">&quot;</span><span class="spec-t">\</span><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
+<span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">"</span><span class="spec-t">\</span><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
 <div class="spec-rhs"><span class="spec-t">\u</span><span class="spec-nt"><a href="#EscapedUnicode" data-name="EscapedUnicode">EscapedUnicode</a></span></div>
 <div class="spec-rhs"><span class="spec-t">\</span><span class="spec-nt"><a href="#EscapedCharacter" data-name="EscapedCharacter">EscapedCharacter</a></span></div>
 </div>
@@ -1972,21 +1972,21 @@ The numeric literals <span class="spec-nt"><a href="#IntValue" data-name="IntVal
 <div class="spec-production d2" id="EscapedCharacter">
 <span class="spec-nt"><a href="#EscapedCharacter" data-name="EscapedCharacter">EscapedCharacter</a></span><div class="spec-oneof"><div class="spec-oneof-grid"><table>
 <tr>
-<td class="spec-rhs"><span class="spec-t">&quot;</span></td><td class="spec-rhs"><span class="spec-t">\</span></td><td class="spec-rhs"><span class="spec-t">/</span></td><td class="spec-rhs"><span class="spec-t">b</span></td><td class="spec-rhs"><span class="spec-t">f</span></td><td class="spec-rhs"><span class="spec-t">n</span></td><td class="spec-rhs"><span class="spec-t">r</span></td><td class="spec-rhs"><span class="spec-t">t</span></td></tr>
+<td class="spec-rhs"><span class="spec-t">"</span></td><td class="spec-rhs"><span class="spec-t">\</span></td><td class="spec-rhs"><span class="spec-t">/</span></td><td class="spec-rhs"><span class="spec-t">b</span></td><td class="spec-rhs"><span class="spec-t">f</span></td><td class="spec-rhs"><span class="spec-t">n</span></td><td class="spec-rhs"><span class="spec-t">r</span></td><td class="spec-rhs"><span class="spec-t">t</span></td></tr>
 </table></div></div>
 </div>
 <div class="spec-production d2" id="BlockStringCharacter">
-<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">&quot;&quot;&quot;</span><span class="spec-t">\&quot;&quot;&quot;</span></span></span></div>
-<div class="spec-rhs"><span class="spec-t">\&quot;&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">"""</span><span class="spec-t">\"""</span></span></span></div>
+<div class="spec-rhs"><span class="spec-t">\"""</span></div>
 </div>
-<p>Strings are sequences of characters wrapped in quotation marks (U+0022). (ex. <span class="spec-t">&quot;Hello World&quot;</span>). White space and other otherwise&#8208;ignored characters are significant within a string value.</p>
-<p>The empty string <span class="spec-t">&quot;&quot;</span> must not be followed by another <span class="spec-t">&quot;</span> otherwise it would be interpreted as the beginning of a block string. As an example, the source <span class="spec-t">&quot;&quot;&quot;&quot;&quot;&quot;</span> can only be interpreted as a single empty block string and not three empty strings.</p>
+<p>Strings are sequences of characters wrapped in quotation marks (U+0022). (ex. <span class="spec-t">"Hello World"</span>). White space and other otherwise-ignored characters are significant within a string value.</p>
+<p>The empty string <span class="spec-t">""</span> must not be followed by another <span class="spec-t">"</span> otherwise it would be interpreted as the beginning of a block string. As an example, the source <span class="spec-t">""""""</span> can only be interpreted as a single empty block string and not three empty strings.</p>
 <div id="note-1c619" class="spec-note">
 <a href="#note-1c619">Note</a>
 Unicode characters are allowed within String value literals, however <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span> must not contain some ASCII control characters so escape sequences must be used to represent these characters.</div>
 <section id="sec-String-Value.Block-Strings" class="subsec">
 <h6><a href="#sec-String-Value.Block-Strings" title="link to this subsection">Block Strings</a></h6>
-<p>Block strings are sequences of characters wrapped in triple&#8208;quotes (<code>&quot;&quot;&quot;</code>). White space, line terminators, quote, and backslash characters may all be used unescaped to enable verbatim text. Characters must all be valid <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span>.</p>
+<p>Block strings are sequences of characters wrapped in triple-quotes (<code>"""</code>). White space, line terminators, quote, and backslash characters may all be used unescaped to enable verbatim text. Characters must all be valid <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span>.</p>
 <p>Since block strings represent freeform text often used in indented positions, the string value semantics of a block string excludes uniform indentation and blank initial and trailing lines via <span class="spec-call"><a href="#BlockStringValue()" data-name="BlockStringValue">BlockStringValue</a>()</span>.</p>
 <p>For example, the following operation containing a block string:</p>
 <pre id="example-fe73f" class="spec-example" data-language="graphql"><a href="#example-fe73f">Example № 25</a><code><span class="token keyword">mutation</span> <span class="token punctuation">{</span>
@@ -2013,26 +2013,26 @@ which makes it easier to read.
 <pre id="example-b874e" class="spec-counter-example" data-language="graphql"><a href="#example-b874e">Counter Example № 28</a><code><span class="token string">"""This does not start with or end with any empty lines,
 which makes it a little harder to read."""</span>
 </code></pre>
-<div id="note-8f188" class="spec-note">
-<a href="#note-8f188">Note</a>
-If non&#8208;printable ASCII characters are needed in a string value, a standard quoted string with appropriate escape sequences must be used instead of a block string.</div>
+<div id="note-65771" class="spec-note">
+<a href="#note-65771">Note</a>
+If non-printable ASCII characters are needed in a string value, a standard quoted string with appropriate escape sequences must be used instead of a block string.</div>
 </section>
 <section id="sec-String-Value.Semantics" class="subsec">
 <h6><a href="#sec-String-Value.Semantics" title="link to this subsection">Semantics</a></h6>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">""</span></div>
 <ol>
 <li>Return an empty sequence.</li>
 </ol>
 </div>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">"</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">"</span></div>
 <ol>
 <li>Return the Unicode character sequence of all <span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span> Unicode character values.</li>
 </ol>
 </div>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">&quot;</span><span class="spec-t">\</span><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
+<span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">"</span><span class="spec-t">\</span><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
 <ol>
 <li>Return the character value of <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span>.</li>
 </ol>
@@ -2040,7 +2040,7 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
 <div class="spec-semantic d2">
 <span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-t">\u</span><span class="spec-nt"><a href="#EscapedUnicode" data-name="EscapedUnicode">EscapedUnicode</a></span></div>
 <ol>
-<li>Return the character whose code unit value in the Unicode Basic Multilingual Plane is the 16&#8208;bit hexadecimal value <span class="spec-nt"><a href="#EscapedUnicode" data-name="EscapedUnicode">EscapedUnicode</a></span>.</li>
+<li>Return the character whose code unit value in the Unicode Basic Multilingual Plane is the 16-bit hexadecimal value <span class="spec-nt"><a href="#EscapedUnicode" data-name="EscapedUnicode">EscapedUnicode</a></span>.</li>
 </ol>
 </div>
 <div class="spec-semantic d2">
@@ -2057,7 +2057,7 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
 </tr></thead>
 <tbody>
 <tr>
-<td><code>&quot;</code></td><td>U+0022</td><td>double quote</td></tr>
+<td><code>"</code></td><td>U+0022</td><td>double quote</td></tr>
 <tr>
 <td><code>\</code></td><td>U+005C</td><td>reverse solidus (back slash)</td></tr>
 <tr>
@@ -2075,22 +2075,22 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
 </tbody>
 </table>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;&quot;&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">&quot;&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">"""</span><span class="spec-quantified"><span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">"""</span></div>
 <ol>
 <li>Let <var data-name="rawValue">rawValue</var> be the Unicode character sequence of all <span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span> Unicode character values (which may be an empty sequence).</li>
 <li>Return the result of <span class="spec-call"><a href="#BlockStringValue()" data-name="BlockStringValue">BlockStringValue</a>(<var data-name="rawValue">rawValue</var>)</span>.</li>
 </ol>
 </div>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">&quot;&quot;&quot;</span><span class="spec-t">\&quot;&quot;&quot;</span></span></span></div>
+<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">"""</span><span class="spec-t">\"""</span></span></span></div>
 <ol>
 <li>Return the character value of <span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span>.</li>
 </ol>
 </div>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-t">\&quot;&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-t">\"""</span></div>
 <ol>
-<li>Return the character sequence <code>&quot;&quot;&quot;</code>.</li>
+<li>Return the character sequence <code>"""</code>.</li>
 </ol>
 </div>
 <div class="spec-algo" id="BlockStringValue()">
@@ -2161,7 +2161,7 @@ If non&#8208;printable ASCII characters are needed in a string value, a standard
   field
 <span class="token punctuation">}</span>
 </code></pre>
-<p>The first has explicitly provided <span class="spec-keyword">null</span> to the argument &ldquo;arg&rdquo;, while the second has implicitly not provided a value to the argument &ldquo;arg&rdquo;. These two forms may be interpreted differently. For example, a mutation representing deleting a field vs not altering a field, respectively. Neither form may be used for an input expecting a Non&#8208;Null type.</p>
+<p>The first has explicitly provided <span class="spec-keyword">null</span> to the argument &ldquo;arg&rdquo;, while the second has implicitly not provided a value to the argument &ldquo;arg&rdquo;. These two forms may be interpreted differently. For example, a mutation representing deleting a field vs not altering a field, respectively. Neither form may be used for an input expecting a Non-Null type.</p>
 <div id="note-eab9b" class="spec-note">
 <a href="#note-eab9b">Note</a>
 The same two methods of representing the lack of a value are possible via variables by either providing the variable value as <span class="spec-keyword">null</span> or not providing a variable value at all.</div>
@@ -2179,7 +2179,7 @@ The same two methods of representing the lack of a value are possible via variab
 <span class="spec-nt"><a href="#ListValue" data-name="ListValue">ListValue</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-t">[</span><span class="spec-t">]</span></div>
 <div class="spec-rhs"><span class="spec-t">[</span><span class="spec-quantified"><span class="spec-nt"><a href="#Value" data-name="Value">Value</a><span class="spec-params"><span class="spec-param conditional">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">]</span></div>
 </div>
-<p>Lists are ordered sequences of values wrapped in square&#8208;brackets <code>[ ]</code>. The values of a List literal may be any value literal or variable (ex. <code>[1, 2, 3]</code>).</p>
+<p>Lists are ordered sequences of values wrapped in square-brackets <code>[ ]</code>. The values of a List literal may be any value literal or variable (ex. <code>[1, 2, 3]</code>).</p>
 <p>Commas are optional throughout GraphQL so trailing commas are allowed and repeated commas do not represent missing values.</p>
 <section id="sec-List-Value.Semantics" class="subsec">
 <h6><a href="#sec-List-Value.Semantics" title="link to this subsection">Semantics</a></h6>
@@ -2212,7 +2212,7 @@ The same two methods of representing the lack of a value are possible via variab
 <div class="spec-production" id="ObjectField">
 <span class="spec-nt"><a href="#ObjectField" data-name="ObjectField">ObjectField</a><span class="spec-params"><span class="spec-param">Const</span></span></span><div class="spec-rhs"><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-t">:</span><span class="spec-nt"><a href="#Value" data-name="Value">Value</a><span class="spec-params"><span class="spec-param conditional">Const</span></span></span></div>
 </div>
-<p>Input object literal values are unordered lists of keyed input values wrapped in curly&#8208;braces <code>{ }</code>. The values of an object literal may be any input value literal or variable (ex. <code>{ name: &quot;Hello world&quot;, score: 1.0 }</code>). We refer to literal representation of input objects as &ldquo;object literals.&rdquo;</p>
+<p>Input object literal values are unordered lists of keyed input values wrapped in curly-braces <code>{ }</code>. The values of an object literal may be any input value literal or variable (ex. <code>{ name: "Hello world", score: 1.0 }</code>). We refer to literal representation of input objects as &ldquo;object literals.&rdquo;</p>
 <section id="sec-Input-Object-Values.Input-object-fields-are-unordered" class="subsec">
 <h6><a href="#sec-Input-Object-Values.Input-object-fields-are-unordered" title="link to this subsection">Input object fields are unordered</a></h6>
 <p>Input object fields may be provided in any syntactic order and maintain identical semantic meaning.</p>
@@ -2283,7 +2283,7 @@ The same two methods of representing the lack of a value are possible via variab
 </code></pre>
 <section id="sec-Language.Variables.Variable-use-within-Fragments" class="subsec">
 <h6><a href="#sec-Language.Variables.Variable-use-within-Fragments" title="link to this subsection">Variable use within Fragments</a></h6>
-<p>Query variables can be used within fragments. Query variables have global scope with a given operation, so a variable used within a fragment must be declared in any top&#8208;level operation that transitively consumes that fragment. If a variable is referenced in a fragment and is included by an operation that does not define that variable, the operation cannot be executed.</p>
+<p>Query variables can be used within fragments. Query variables have global scope with a given operation, so a variable used within a fragment must be declared in any top-level operation that transitively consumes that fragment. If a variable is referenced in a fragment and is included by an operation that does not define that variable, the operation cannot be executed.</p>
 </section>
 </section>
 <section id="sec-Type-References" secid="2.11">
@@ -2303,7 +2303,7 @@ The same two methods of representing the lack of a value are possible via variab
 <span class="spec-nt"><a href="#NonNullType" data-name="NonNullType">NonNullType</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#NamedType" data-name="NamedType">NamedType</a></span><span class="spec-t">!</span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#ListType" data-name="ListType">ListType</a></span><span class="spec-t">!</span></div>
 </div>
-<p>GraphQL describes the types of data expected by query variables. Input types may be lists of another input type, or a non&#8208;null variant of any other input type.</p>
+<p>GraphQL describes the types of data expected by query variables. Input types may be lists of another input type, or a non-null variant of any other input type.</p>
 <section id="sec-Type-References.Semantics" class="subsec">
 <h6><a href="#sec-Type-References.Semantics" title="link to this subsection">Semantics</a></h6>
 <div class="spec-semantic">
@@ -2327,7 +2327,7 @@ The same two methods of representing the lack of a value are possible via variab
 <span class="spec-nt"><a href="#Type" data-name="Type">Type</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#Type" data-name="Type">Type</a></span><span class="spec-t">!</span></div>
 <ol>
 <li>Let <var data-name="nullableType">nullableType</var> be the result of evaluating <span class="spec-nt"><a href="#Type" data-name="Type">Type</a></span></li>
-<li>Let <var data-name="type">type</var> be a Non&#8208;Null type where <var data-name="nullableType">nullableType</var> is the contained type.</li>
+<li>Let <var data-name="type">type</var> be a Non-Null type where <var data-name="nullableType">nullableType</var> is the contained type.</li>
 <li>Return <var data-name="type">type</var></li>
 </ol>
 </div>
@@ -2369,7 +2369,7 @@ The same two methods of representing the lack of a value are possible via variab
 <div class="spec-rhs"><span class="spec-nt"><a href="#TypeDefinition" data-name="TypeDefinition">TypeDefinition</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#DirectiveDefinition" data-name="DirectiveDefinition">DirectiveDefinition</a></span></div>
 </div>
-<p>The GraphQL language includes an <a href="https://en.wikipedia.org/wiki/Interface_description_language">IDL</a> used to describe a GraphQL service&rsquo;s type system. Tools may use this definition language to provide utilities such as client code generation or service boot&#8208;strapping.</p>
+<p>The GraphQL language includes an <a href="https://en.wikipedia.org/wiki/Interface_description_language">IDL</a> used to describe a GraphQL service&rsquo;s type system. Tools may use this definition language to provide utilities such as client code generation or service boot-strapping.</p>
 <p>GraphQL tools which only seek to provide GraphQL query execution may choose not to parse <span class="spec-nt"><a href="#TypeSystemDefinition" data-name="TypeSystemDefinition">TypeSystemDefinition</a></span>.</p>
 <p>A GraphQL Document which contains <span class="spec-nt"><a href="#TypeSystemDefinition" data-name="TypeSystemDefinition">TypeSystemDefinition</a></span> must not be executed; GraphQL execution services which receive a GraphQL Document containing type system definitions should return a descriptive error.</p>
 <div id="note-d5e8e" class="spec-note">
@@ -2388,7 +2388,7 @@ The type system definition language is used throughout the remainder of this spe
 <div class="spec-production" id="Description">
 <span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span></div>
 </div>
-<p>Documentation is a first&#8208;class feature of GraphQL type systems. To ensure the documentation of a GraphQL service remains consistent with its capabilities, descriptions of GraphQL definitions are provided alongside their definitions and made available via introspection.</p>
+<p>Documentation is a first-class feature of GraphQL type systems. To ensure the documentation of a GraphQL service remains consistent with its capabilities, descriptions of GraphQL definitions are provided alongside their definitions and made available via introspection.</p>
 <p>To allow GraphQL service designers to easily publish documentation alongside the capabilities of a GraphQL service, GraphQL descriptions are defined using the Markdown syntax (as specified by <a href="https://commonmark.org/">CommonMark</a>). In the type system definition language, these description strings (often <span class="spec-nt"><span data-name="BlockString">BlockString</span></span>) occur immediately before the definition they describe.</p>
 <p>GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.) which can be described should provide a <span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span> unless they are considered self descriptive.</p>
 <p>As an example, this simple GraphQL schema is well described:</p>
@@ -2507,7 +2507,7 @@ The set of languages supported by `translate`.
 <p>Schema extensions have the potential to be invalid if incorrectly defined.</p>
 <ol>
 <li>The Schema must already be defined.</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Schema.</li>
+<li>Any non-repeatable directives provided must not already apply to the original Schema.</li>
 </ol>
 </section>
 </section>
@@ -2534,14 +2534,14 @@ The set of languages supported by `translate`.
 <p>All of the types so far are assumed to be both nullable and singular: e.g. a scalar string returns either null or a singular string.</p>
 <p>A GraphQL schema may describe that a field represents a list of another type; the <code>List</code> type is provided for this reason, and wraps another type.</p>
 <p>Similarly, the <code>Non-Null</code> type wraps another type, and denotes that the resulting value will never be <span class="spec-keyword">null</span> (and that an error cannot result in a <span class="spec-keyword">null</span> value).</p>
-<p>These two types are referred to as &ldquo;wrapping types&rdquo;; non&#8208;wrapping types are referred to as &ldquo;named types&rdquo;. A wrapping type has an underlying named type, found by continually unwrapping the type until a named type is found.</p>
+<p>These two types are referred to as &ldquo;wrapping types&rdquo;; non-wrapping types are referred to as &ldquo;named types&rdquo;. A wrapping type has an underlying named type, found by continually unwrapping the type until a named type is found.</p>
 </section>
 <section id="sec-Input-and-Output-Types" secid="3.4.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Input-and-Output-Types">3.4.2</a></span>Input and Output Types</h3>
-<p>Types are used throughout GraphQL to describe both the values accepted as input to arguments and variables as well as the values output by fields. These two uses categorize types as <em>input types</em> and <em>output types</em>. Some kinds of types, like Scalar and Enum types, can be used as both input types and output types; other kinds of types can only be used in one or the other. Input Object types can only be used as input types. Object, Interface, and Union types can only be used as output types. Lists and Non&#8208;Null types may be used as input types or output types depending on how the wrapped type may be used.</p>
+<p>Types are used throughout GraphQL to describe both the values accepted as input to arguments and variables as well as the values output by fields. These two uses categorize types as <em>input types</em> and <em>output types</em>. Some kinds of types, like Scalar and Enum types, can be used as both input types and output types; other kinds of types can only be used in one or the other. Input Object types can only be used as input types. Object, Interface, and Union types can only be used as output types. Lists and Non-Null types may be used as input types or output types depending on how the wrapped type may be used.</p>
 <div class="spec-algo" id="IsInputType()">
 <span class="spec-call"><a href="#IsInputType()" data-name="IsInputType">IsInputType</a>(<var data-name="type">type</var>)</span><ol>
-<li>If <var data-name="type">type</var> is a List type or Non&#8208;Null type:<ol>
+<li>If <var data-name="type">type</var> is a List type or Non-Null type:<ol>
 <li>Let <var data-name="unwrappedType">unwrappedType</var> be the unwrapped type of <var data-name="type">type</var>.</li>
 <li>Return IsInputType(<var data-name="unwrappedType">unwrappedType</var>)</li>
 </ol>
@@ -2555,7 +2555,7 @@ The set of languages supported by `translate`.
 </div>
 <div class="spec-algo" id="IsOutputType()">
 <span class="spec-call"><a href="#IsOutputType()" data-name="IsOutputType">IsOutputType</a>(<var data-name="type">type</var>)</span><ol>
-<li>If <var data-name="type">type</var> is a List type or Non&#8208;Null type:<ol>
+<li>If <var data-name="type">type</var> is a List type or Non-Null type:<ol>
 <li>Let <var data-name="unwrappedType">unwrappedType</var> be the unwrapped type of <var data-name="type">type</var>.</li>
 <li>Return IsOutputType(<var data-name="unwrappedType">unwrappedType</var>)</li>
 </ol>
@@ -2587,20 +2587,20 @@ The set of languages supported by `translate`.
 <span class="spec-nt"><a href="#ScalarTypeDefinition" data-name="ScalarTypeDefinition">ScalarTypeDefinition</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Description" data-name="Description">Description</a></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">scalar</span><span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span><span class="spec-quantified"><span class="spec-nt"><a href="#Directives" data-name="Directives">Directives</a><span class="spec-params"><span class="spec-param">Const</span></span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
 </div>
 <p>Scalar types represent primitive leaf values in a GraphQL type system. GraphQL responses take the form of a hierarchical tree; the leaves of this tree are typically GraphQL Scalar types (but may also be Enum types or <span class="spec-keyword">null</span> values).</p>
-<p>GraphQL provides a number of built&#8208;in scalars (see below), but type systems can add additional scalars with semantic meaning. For example, a GraphQL system could define a scalar called <code>Time</code> which, while serialized as a string, promises to conform to ISO&#8208;8601. When querying a field of type <code>Time</code>, you can then rely on the ability to parse the result with an ISO&#8208;8601 parser and use a client&#8208;specific primitive for time. Another example of a potentially useful custom scalar is <code>Url</code>, which serializes as a string, but is guaranteed by the service to be a valid URL.</p>
+<p>GraphQL provides a number of built-in scalars (see below), but type systems can add additional scalars with semantic meaning. For example, a GraphQL system could define a scalar called <code>Time</code> which, while serialized as a string, promises to conform to ISO-8601. When querying a field of type <code>Time</code>, you can then rely on the ability to parse the result with an ISO-8601 parser and use a client-specific primitive for time. Another example of a potentially useful custom scalar is <code>Url</code>, which serializes as a string, but is guaranteed by the service to be a valid URL.</p>
 <pre id="example-cb7e7" class="spec-example" data-language="graphql"><a href="#example-cb7e7">Example № 42</a><code><span class="token keyword">scalar</span> <span class="token class-name">Time</span>
 <span class="token keyword">scalar</span> <span class="token class-name">Url</span>
 </code></pre>
 <section id="sec-Scalars.Built-in-Scalars" class="subsec">
 <h6><a href="#sec-Scalars.Built-in-Scalars" title="link to this subsection">Built-in Scalars</a></h6>
-<p>GraphQL specifies a basic set of well&#8208;defined Scalar types: <span class="spec-nt"><span data-name="Int">Int</span></span>, <span class="spec-nt"><span data-name="Float">Float</span></span>, <span class="spec-nt"><span data-name="String">String</span></span>, <span class="spec-nt"><span data-name="Boolean">Boolean</span></span>, and <span class="spec-nt"><span data-name="ID">ID</span></span>. A GraphQL framework should support all of these types, and a GraphQL service which provides a type by these names must adhere to the behavior described for them in this document. As an example, a service must not include a type called <span class="spec-nt"><span data-name="Int">Int</span></span> and use it to represent 64&#8208;bit numbers, internationalization information, or anything other than what is defined in this document.</p>
-<p>When returning the set of types from the <code>__Schema</code> introspection type, all referenced built&#8208;in scalars must be included. If a built&#8208;in scalar type is not referenced anywhere in a schema (there is no field, argument, or input field of that type) then it must not be included.</p>
-<p>When representing a GraphQL schema using the type system definition language, all built&#8208;in scalars must be omitted for brevity.</p>
+<p>GraphQL specifies a basic set of well-defined Scalar types: <span class="spec-nt"><span data-name="Int">Int</span></span>, <span class="spec-nt"><span data-name="Float">Float</span></span>, <span class="spec-nt"><span data-name="String">String</span></span>, <span class="spec-nt"><span data-name="Boolean">Boolean</span></span>, and <span class="spec-nt"><span data-name="ID">ID</span></span>. A GraphQL framework should support all of these types, and a GraphQL service which provides a type by these names must adhere to the behavior described for them in this document. As an example, a service must not include a type called <span class="spec-nt"><span data-name="Int">Int</span></span> and use it to represent 64-bit numbers, internationalization information, or anything other than what is defined in this document.</p>
+<p>When returning the set of types from the <code>__Schema</code> introspection type, all referenced built-in scalars must be included. If a built-in scalar type is not referenced anywhere in a schema (there is no field, argument, or input field of that type) then it must not be included.</p>
+<p>When representing a GraphQL schema using the type system definition language, all built-in scalars must be omitted for brevity.</p>
 </section>
 <section id="sec-Scalars.Result-Coercion-and-Serialization" class="subsec">
 <h6><a href="#sec-Scalars.Result-Coercion-and-Serialization" title="link to this subsection">Result Coercion and Serialization</a></h6>
 <p>A GraphQL service, when preparing a field of a given scalar type, must uphold the contract the scalar type describes, either by coercing the value or producing a field error if a value cannot be coerced or if coercion may result in data loss.</p>
-<p>A GraphQL service may decide to allow coercing different internal types to the expected return type. For example when coercing a field of type <span class="spec-nt"><span data-name="Int">Int</span></span> a boolean <span class="spec-keyword">true</span> value may produce <span class="spec-t">1</span> or a string value <span class="spec-string">"123"</span> may be parsed as base&#8208;10 <span class="spec-t">123</span>. However if internal type coercion cannot be reasonably performed without losing information, then it must raise a field error.</p>
+<p>A GraphQL service may decide to allow coercing different internal types to the expected return type. For example when coercing a field of type <span class="spec-nt"><span data-name="Int">Int</span></span> a boolean <span class="spec-keyword">true</span> value may produce <span class="spec-t">1</span> or a string value <span class="spec-string">"123"</span> may be parsed as base-10 <span class="spec-t">123</span>. However if internal type coercion cannot be reasonably performed without losing information, then it must raise a field error.</p>
 <p>Since this coercion behavior is not observable to clients of the GraphQL service, the precise rules of coercion are left to the implementation. The only requirement is that the service must yield values which adhere to the expected Scalar type.</p>
 <p>GraphQL scalars are serialized according to the serialization format being used. There may be a most appropriate serialized primitive for each given scalar type, and the service should produce each primitive where appropriate.</p>
 <p>See <a href="#sec-Serialization-Format">Serialization Format</a> for more detailed information on the serialization of scalars in common JSON and other formats.</p>
@@ -2608,33 +2608,33 @@ The set of languages supported by `translate`.
 <section id="sec-Scalars.Input-Coercion" class="subsec">
 <h6><a href="#sec-Scalars.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
 <p>If a GraphQL service expects a scalar type as input to an argument, coercion is observable and the rules must be well defined. If an input value does not match a coercion rule, a query error must be raised.</p>
-<p>GraphQL has different constant literals to represent integer and floating&#8208;point input values, and coercion rules may apply differently depending on which type of input value is encountered. GraphQL may be parameterized by query variables, the values of which are often serialized when sent over a transport like HTTP. Since some common serializations (ex. JSON) do not discriminate between integer and floating&#8208;point values, they are interpreted as an integer input value if they have an empty fractional part (ex. <code>1.0</code>) and otherwise as floating&#8208;point input value.</p>
-<p>For all types below, with the exception of Non&#8208;Null, if the explicit value <span class="spec-keyword">null</span> is provided, then the result of input coercion is <span class="spec-keyword">null</span>.</p>
+<p>GraphQL has different constant literals to represent integer and floating-point input values, and coercion rules may apply differently depending on which type of input value is encountered. GraphQL may be parameterized by query variables, the values of which are often serialized when sent over a transport like HTTP. Since some common serializations (ex. JSON) do not discriminate between integer and floating-point values, they are interpreted as an integer input value if they have an empty fractional part (ex. <code>1.0</code>) and otherwise as floating-point input value.</p>
+<p>For all types below, with the exception of Non-Null, if the explicit value <span class="spec-keyword">null</span> is provided, then the result of input coercion is <span class="spec-keyword">null</span>.</p>
 </section>
 <section id="sec-Int" secid="3.5.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Int">3.5.1</a></span>Int</h3>
-<p>The Int scalar type represents a signed 32&#8208;bit numeric non&#8208;fractional value. Response formats that support a 32&#8208;bit integer or a number type should use that type to represent this scalar.</p>
+<p>The Int scalar type represents a signed 32-bit numeric non-fractional value. Response formats that support a 32-bit integer or a number type should use that type to represent this scalar.</p>
 <section id="sec-Int.Result-Coercion" class="subsec">
 <h6><a href="#sec-Int.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
-<p>Fields returning the type <span class="spec-nt"><span data-name="Int">Int</span></span> expect to encounter 32&#8208;bit integer internal values.</p>
-<p>GraphQL services may coerce non&#8208;integer internal values to integers when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning <code>1</code> for the floating&#8208;point number <code>1.0</code>, or returning <code>123</code> for the string <code>&quot;123&quot;</code>. In scenarios where coercion may lose data, raising a field error is more appropriate. For example, a floating&#8208;point number <code>1.2</code> should raise a field error instead of being truncated to <code>1</code>.</p>
+<p>Fields returning the type <span class="spec-nt"><span data-name="Int">Int</span></span> expect to encounter 32-bit integer internal values.</p>
+<p>GraphQL services may coerce non-integer internal values to integers when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning <code>1</code> for the floating-point number <code>1.0</code>, or returning <code>123</code> for the string <code>"123"</code>. In scenarios where coercion may lose data, raising a field error is more appropriate. For example, a floating-point number <code>1.2</code> should raise a field error instead of being truncated to <code>1</code>.</p>
 <p>If the integer internal value represents a value less than -2<sup>31</sup> or greater than or equal to 2<sup>31</sup>, a field error should be raised.</p>
 </section>
 <section id="sec-Int.Input-Coercion" class="subsec">
 <h6><a href="#sec-Int.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
 <p>When expected as an input type, only integer input values are accepted. All other input values, including strings with numeric content, must raise a query error indicating an incorrect type. If the integer input value represents a value less than -2<sup>31</sup> or greater than or equal to 2<sup>31</sup>, a query error should be raised.</p>
-<div id="note-989b8" class="spec-note">
-<a href="#note-989b8">Note</a>
-Numeric integer values larger than 32&#8208;bit should either use String or a custom&#8208;defined Scalar type, as not all platforms and transports support encoding integer numbers larger than 32&#8208;bit.</div>
+<div id="note-0770a" class="spec-note">
+<a href="#note-0770a">Note</a>
+Numeric integer values larger than 32-bit should either use String or a custom-defined Scalar type, as not all platforms and transports support encoding integer numbers larger than 32-bit.</div>
 </section>
 </section>
 <section id="sec-Float" secid="3.5.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Float">3.5.2</a></span>Float</h3>
-<p>The Float scalar type represents signed double&#8208;precision fractional values as specified by <a href="https://en.wikipedia.org/wiki/IEEE_floating_point">IEEE 754</a>. Response formats that support an appropriate double&#8208;precision number type should use that type to represent this scalar.</p>
+<p>The Float scalar type represents signed double-precision fractional values as specified by <a href="https://en.wikipedia.org/wiki/IEEE_floating_point">IEEE 754</a>. Response formats that support an appropriate double-precision number type should use that type to represent this scalar.</p>
 <section id="sec-Float.Result-Coercion" class="subsec">
 <h6><a href="#sec-Float.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
-<p>Fields returning the type <span class="spec-nt"><span data-name="Float">Float</span></span> expect to encounter double&#8208;precision floating&#8208;point internal values.</p>
-<p>GraphQL services may coerce non&#8208;floating&#8208;point internal values to <span class="spec-nt"><span data-name="Float">Float</span></span> when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning <code>1.0</code> for the integer number <code>1</code>, or <code>123.0</code> for the string <code>&quot;123&quot;</code>.</p>
+<p>Fields returning the type <span class="spec-nt"><span data-name="Float">Float</span></span> expect to encounter double-precision floating-point internal values.</p>
+<p>GraphQL services may coerce non-floating-point internal values to <span class="spec-nt"><span data-name="Float">Float</span></span> when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning <code>1.0</code> for the integer number <code>1</code>, or <code>123.0</code> for the string <code>"123"</code>.</p>
 </section>
 <section id="sec-Float.Input-Coercion" class="subsec">
 <h6><a href="#sec-Float.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
@@ -2643,24 +2643,24 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 <section id="sec-String" secid="3.5.3">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-String">3.5.3</a></span>String</h3>
-<p>The String scalar type represents textual data, represented as UTF&#8208;8 character sequences. The String type is most often used by GraphQL to represent free&#8208;form human&#8208;readable text. All response formats must support string representations, and that representation must be used here.</p>
+<p>The String scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text. All response formats must support string representations, and that representation must be used here.</p>
 <section id="sec-String.Result-Coercion" class="subsec">
 <h6><a href="#sec-String.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
-<p>Fields returning the type <span class="spec-nt"><span data-name="String">String</span></span> expect to encounter UTF&#8208;8 string internal values.</p>
-<p>GraphQL services may coerce non&#8208;string raw values to <span class="spec-nt"><span data-name="String">String</span></span> when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning the string <code>&quot;true&quot;</code> for a boolean true value, or the string <code>&quot;1&quot;</code> for the integer <code>1</code>.</p>
+<p>Fields returning the type <span class="spec-nt"><span data-name="String">String</span></span> expect to encounter UTF-8 string internal values.</p>
+<p>GraphQL services may coerce non-string raw values to <span class="spec-nt"><span data-name="String">String</span></span> when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning the string <code>"true"</code> for a boolean true value, or the string <code>"1"</code> for the integer <code>1</code>.</p>
 </section>
 <section id="sec-String.Input-Coercion" class="subsec">
 <h6><a href="#sec-String.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
-<p>When expected as an input type, only valid UTF&#8208;8 string input values are accepted. All other input values must raise a query error indicating an incorrect type.</p>
+<p>When expected as an input type, only valid UTF-8 string input values are accepted. All other input values must raise a query error indicating an incorrect type.</p>
 </section>
 </section>
 <section id="sec-Boolean" secid="3.5.4">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Boolean">3.5.4</a></span>Boolean</h3>
-<p>The Boolean scalar type represents <code>true</code> or <code>false</code>. Response formats should use a built&#8208;in boolean type if supported; otherwise, they should use their representation of the integers <code>1</code> and <code>0</code>.</p>
+<p>The Boolean scalar type represents <code>true</code> or <code>false</code>. Response formats should use a built-in boolean type if supported; otherwise, they should use their representation of the integers <code>1</code> and <code>0</code>.</p>
 <section id="sec-Boolean.Result-Coercion" class="subsec">
 <h6><a href="#sec-Boolean.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
 <p>Fields returning the type <span class="spec-nt"><span data-name="Boolean">Boolean</span></span> expect to encounter boolean internal values.</p>
-<p>GraphQL services may coerce non&#8208;boolean raw values to <span class="spec-nt"><span data-name="Boolean">Boolean</span></span> when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning <code>true</code> for non&#8208;zero numbers.</p>
+<p>GraphQL services may coerce non-boolean raw values to <span class="spec-nt"><span data-name="Boolean">Boolean</span></span> when reasonable without losing information, otherwise they must raise a field error. Examples of this may include returning <code>true</code> for non-zero numbers.</p>
 </section>
 <section id="sec-Boolean.Input-Coercion" class="subsec">
 <h6><a href="#sec-Boolean.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
@@ -2669,15 +2669,15 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </section>
 <section id="sec-ID" secid="3.5.5">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-ID">3.5.5</a></span>ID</h3>
-<p>The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a <span class="spec-nt"><span data-name="String">String</span></span>; however, it is not intended to be human&#8208;readable. While it is often numeric, it should always serialize as a <span class="spec-nt"><span data-name="String">String</span></span>.</p>
+<p>The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a <span class="spec-nt"><span data-name="String">String</span></span>; however, it is not intended to be human-readable. While it is often numeric, it should always serialize as a <span class="spec-nt"><span data-name="String">String</span></span>.</p>
 <section id="sec-ID.Result-Coercion" class="subsec">
 <h6><a href="#sec-ID.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
-<p>GraphQL is agnostic to ID format, and serializes to string to ensure consistency across many formats ID could represent, from small auto&#8208;increment numbers, to large 128&#8208;bit random numbers, to base64 encoded values, or string values of a format like <a href="https://en.wikipedia.org/wiki/Globally_unique_identifier">GUID</a>.</p>
+<p>GraphQL is agnostic to ID format, and serializes to string to ensure consistency across many formats ID could represent, from small auto-increment numbers, to large 128-bit random numbers, to base64 encoded values, or string values of a format like <a href="https://en.wikipedia.org/wiki/Globally_unique_identifier">GUID</a>.</p>
 <p>GraphQL services should coerce as appropriate given the ID formats they expect. When coercion is not possible they must raise a field error.</p>
 </section>
 <section id="sec-ID.Input-Coercion" class="subsec">
 <h6><a href="#sec-ID.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
-<p>When expected as an input type, any string (such as <code>&quot;4&quot;</code>) or integer (such as <code>4</code> or <code>-4</code>) input value should be coerced to ID as appropriate for the ID formats a given GraphQL service expects. Any other input value, including float input values (such as <code>4.0</code>), must raise a query error indicating an incorrect type.</p>
+<p>When expected as an input type, any string (such as <code>"4"</code>) or integer (such as <code>4</code> or <code>-4</code>) input value should be coerced to ID as appropriate for the ID formats a given GraphQL service expects. Any other input value, including float input values (such as <code>4.0</code>), must raise a query error indicating an incorrect type.</p>
 </section>
 </section>
 <section id="sec-Scalar-Extensions" secid="3.5.6">
@@ -2691,7 +2691,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 <p>Scalar type extensions have the potential to be invalid if incorrectly defined.</p>
 <ol>
 <li>The named type must already be defined and must be a Scalar type.</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Scalar type.</li>
+<li>Any non-repeatable directives provided must not already apply to the original Scalar type.</li>
 </ol>
 </section>
 </section>
@@ -2783,7 +2783,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 <section id="sec-Objects.Field-Ordering" class="subsec">
 <h6><a href="#sec-Objects.Field-Ordering" title="link to this subsection">Field Ordering</a></h6>
 <p>When querying an Object, the resulting mapping of fields are conceptually ordered in the same order in which they were encountered during query execution, excluding fragments for which the type does not apply and fields or fragments that are skipped via <code>@skip</code> or <code>@include</code> directives. This ordering is correctly produced when using the <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span> algorithm.</p>
-<p>Response serialization formats capable of representing ordered maps should maintain this ordering. Serialization formats which can only represent unordered maps (such as JSON) should retain this order textually. That is, if two fields <code>{foo, bar}</code> were queried in that order, the resulting JSON serialization should contain <code>{&quot;foo&quot;: &quot;...&quot;, &quot;bar&quot;: &quot;...&quot;}</code> in the same order.</p>
+<p>Response serialization formats capable of representing ordered maps should maintain this ordering. Serialization formats which can only represent unordered maps (such as JSON) should retain this order textually. That is, if two fields <code>{foo, bar}</code> were queried in that order, the resulting JSON serialization should contain <code>{"foo": "...", "bar": "..."}</code> in the same order.</p>
 <p>Producing a response where fields are represented in the same order in which they appear in the request improves human readability during debugging and enables more efficient parsing of responses if the order of properties can be anticipated.</p>
 <p>If a fragment is spread before other fields, the fields that fragment specifies occur in the response before the following fields.</p>
 <pre id="example-7924b" class="spec-example" data-language="graphql"><a href="#example-7924b">Example № 52</a><code><span class="token punctuation">{</span>
@@ -2870,7 +2870,7 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </ol>
 </li>
 <li>An object type may declare that it implements one or more unique interfaces.</li>
-<li>An object type must be a super&#8208;set of all interfaces it implements:<ol>
+<li>An object type must be a super-set of all interfaces it implements:<ol>
 <li>Let this object type be <var data-name="objectType">objectType</var>.</li>
 <li>For each interface declared implemented as <var data-name="interfaceType">interfaceType</var>, <span class="spec-call"><a href="#IsValidImplementation()" data-name="IsValidImplementation">IsValidImplementation</a>(<var data-name="objectType">objectType</var>, <var data-name="interfaceType">interfaceType</var>)</span> must be <span class="spec-keyword">true</span>.</li>
 </ol>
@@ -2886,8 +2886,8 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 <li>That named argument on <var data-name="field">field</var> must accept the same type (invariant) as that named argument on <var data-name="implementedField">implementedField</var>.</li>
 </ol>
 </li>
-<li><var data-name="field">field</var> may include additional arguments not defined in <var data-name="implementedField">implementedField</var>, but any additional argument must not be required, e.g. must not be of a non&#8208;nullable type.</li>
-<li><var data-name="field">field</var> must return a type which is equal to or a sub&#8208;type of (covariant) the return type of <var data-name="implementedField">implementedField</var> field&rsquo;s return type:<ol>
+<li><var data-name="field">field</var> may include additional arguments not defined in <var data-name="implementedField">implementedField</var>, but any additional argument must not be required, e.g. must not be of a non-nullable type.</li>
+<li><var data-name="field">field</var> must return a type which is equal to or a sub-type of (covariant) the return type of <var data-name="implementedField">implementedField</var> field&rsquo;s return type:<ol>
 <li>Let <var data-name="fieldType">fieldType</var> be the return type of <var data-name="field">field</var>.</li>
 <li>Let <var data-name="implementedFieldType">implementedFieldType</var> be the return type of <var data-name="implementedField">implementedField</var>.</li>
 <li><span class="spec-call"><a href="#IsValidImplementationFieldType()" data-name="IsValidImplementationFieldType">IsValidImplementationFieldType</a>(<var data-name="fieldType">fieldType</var>, <var data-name="implementedFieldType">implementedFieldType</var>)</span> must be <span class="spec-keyword">true</span>.</li>
@@ -2899,9 +2899,9 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 </div>
 <div class="spec-algo" id="IsValidImplementationFieldType()">
 <span class="spec-call"><a href="#IsValidImplementationFieldType()" data-name="IsValidImplementationFieldType">IsValidImplementationFieldType</a>(<var data-name="fieldType">fieldType</var>, <var data-name="implementedFieldType">implementedFieldType</var>)</span><ol>
-<li>If <var data-name="fieldType">fieldType</var> is a Non&#8208;Null type:<ol>
+<li>If <var data-name="fieldType">fieldType</var> is a Non-Null type:<ol>
 <li>Let <var data-name="nullableType">nullableType</var> be the unwrapped nullable type of <var data-name="fieldType">fieldType</var>.</li>
-<li>Let <var data-name="implementedNullableType">implementedNullableType</var> be the unwrapped nullable type of <var data-name="implementedFieldType">implementedFieldType</var> if it is a Non&#8208;Null type, otherwise let it be <var data-name="implementedFieldType">implementedFieldType</var> directly.</li>
+<li>Let <var data-name="implementedNullableType">implementedNullableType</var> be the unwrapped nullable type of <var data-name="implementedFieldType">implementedFieldType</var> if it is a Non-Null type, otherwise let it be <var data-name="implementedFieldType">implementedFieldType</var> directly.</li>
 <li>Return <span class="spec-call"><a href="#IsValidImplementationFieldType()" data-name="IsValidImplementationFieldType">IsValidImplementationFieldType</a>(<var data-name="nullableType">nullableType</var>, <var data-name="implementedNullableType">implementedNullableType</var>)</span>.</li>
 </ol>
 </li>
@@ -2982,9 +2982,9 @@ Numeric integer values larger than 32&#8208;bit should either use String or a cu
 <li>The named type must already be defined and must be an Object type.</li>
 <li>The fields of an Object type extension must have unique names; no two fields may share the same name.</li>
 <li>Any fields of an Object type extension must not be already defined on the original Object type.</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Object type.</li>
+<li>Any non-repeatable directives provided must not already apply to the original Object type.</li>
 <li>Any interfaces provided must not be already implemented by the original Object type.</li>
-<li>The resulting extended object type must be a super&#8208;set of all interfaces it implements.</li>
+<li>The resulting extended object type must be a super-set of all interfaces it implements.</li>
 </ol>
 </section>
 </section>
@@ -3118,7 +3118,7 @@ interface Named implements Node &amp; Named {
 </ol>
 </li>
 <li>An interface type may declare that it implements one or more unique interfaces, but may not implement itself.</li>
-<li>An interface type must be a super&#8208;set of all interfaces it implements:<ol>
+<li>An interface type must be a super-set of all interfaces it implements:<ol>
 <li>Let this interface type be <var data-name="implementingType">implementingType</var>.</li>
 <li>For each interface declared implemented as <var data-name="implementedType">implementedType</var>, <span class="spec-call"><a href="#IsValidImplementation()" data-name="IsValidImplementation">IsValidImplementation</a>(<var data-name="implementingType">implementingType</var>, <var data-name="implementedType">implementedType</var>)</span> must be <span class="spec-keyword">true</span>.</li>
 </ol>
@@ -3157,9 +3157,9 @@ interface Named implements Node &amp; Named {
 <li>The named type must already be defined and must be an Interface type.</li>
 <li>The fields of an Interface type extension must have unique names; no two fields may share the same name.</li>
 <li>Any fields of an Interface type extension must not be already defined on the original Interface type.</li>
-<li>Any Object or Interface type which implemented the original Interface type must also be a super&#8208;set of the fields of the Interface type extension (which may be due to Object type extension).</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Interface type.</li>
-<li>The resulting extended Interface type must be a super&#8208;set of all Interfaces it implements.</li>
+<li>Any Object or Interface type which implemented the original Interface type must also be a super-set of the fields of the Interface type extension (which may be due to Object type extension).</li>
+<li>Any non-repeatable directives provided must not already apply to the original Interface type.</li>
+<li>The resulting extended Interface type must be a super-set of all Interfaces it implements.</li>
 </ol>
 </section>
 </section>
@@ -3174,7 +3174,7 @@ interface Named implements Node &amp; Named {
 <div class="spec-rhs"><span class="spec-t">=</span><span class="spec-quantified"><span class="spec-t">|</span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><a href="#NamedType" data-name="NamedType">NamedType</a></span></div>
 </div>
 <p>GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types. They also differ from interfaces in that Object types declare what interfaces they implement, but are not aware of what unions contain them.</p>
-<p>With interfaces and objects, only those fields defined on the type can be queried directly; to query other fields on an interface, typed fragments must be used. This is the same as for unions, but unions do not define any fields, so <strong>no</strong> fields may be queried on this type without the use of type refining fragments or inline fragments (with the exception of the meta&#8208;field <var data-name="__typename">__typename</var>).</p>
+<p>With interfaces and objects, only those fields defined on the type can be queried directly; to query other fields on an interface, typed fragments must be used. This is the same as for unions, but unions do not define any fields, so <strong>no</strong> fields may be queried on this type without the use of type refining fragments or inline fragments (with the exception of the meta-field <var data-name="__typename">__typename</var>).</p>
 <p>For example, we might define the following types:</p>
 <pre id="example-255de" class="spec-example" data-language="graphql"><a href="#example-255de">Example № 74</a><code><span class="token keyword">union</span> <span class="token class-name">SearchResult</span> <span class="token operator">=</span> Photo <span class="token operator">|</span> Person
 
@@ -3248,7 +3248,7 @@ interface Named implements Node &amp; Named {
 <li>The member types of a Union type extension must all be Object base types; Scalar, Interface and Union types must not be member types of a Union. Similarly, wrapping types must not be member types of a Union.</li>
 <li>All member types of a Union type extension must be unique.</li>
 <li>All member types of a Union type extension must not already be a member of the original Union type.</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Union type.</li>
+<li>Any non-repeatable directives provided must not already apply to the original Union type.</li>
 </ol>
 </section>
 </section>
@@ -3281,7 +3281,7 @@ interface Named implements Node &amp; Named {
 <section id="sec-Enums.Input-Coercion" class="subsec">
 <h6><a href="#sec-Enums.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
 <p>GraphQL has a constant literal to represent enum input values. GraphQL string literals must not be accepted as an enum input and instead raise a query error.</p>
-<p>Query variable transport serializations which have a different representation for non&#8208;string symbolic values (for example, <a href="https://github.com/edn-format/edn">EDN</a>) should only allow such values as enum input values. Otherwise, for most transport serializations that do not, strings may be interpreted as the enum input value with the same name.</p>
+<p>Query variable transport serializations which have a different representation for non-string symbolic values (for example, <a href="https://github.com/edn-format/edn">EDN</a>) should only allow such values as enum input values. Otherwise, for most transport serializations that do not, strings may be interpreted as the enum input value with the same name.</p>
 </section>
 <section id="sec-Enums.Type-Validation" class="subsec">
 <h6><a href="#sec-Enums.Type-Validation" title="link to this subsection">Type Validation</a></h6>
@@ -3304,7 +3304,7 @@ interface Named implements Node &amp; Named {
 <li>The named type must already be defined and must be an Enum type.</li>
 <li>All values of an Enum type extension must be unique.</li>
 <li>All values of an Enum type extension must not already be a value of the original Enum.</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Enum type.</li>
+<li>Any non-repeatable directives provided must not already apply to the original Enum type.</li>
 </ol>
 </section>
 </section>
@@ -3325,9 +3325,9 @@ interface Named implements Node &amp; Named {
   <span class="token attr-name">y</span><span class="token punctuation">:</span> Float
 <span class="token punctuation">}</span>
 </code></pre>
-<div id="note-9d139" class="spec-note">
-<a href="#note-9d139">Note</a>
-The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" data-name="ObjectTypeDefinition">ObjectTypeDefinition</a></span>) defined above is inappropriate for re&#8208;use here, because Object types can contain fields that define arguments or contain references to interfaces and unions, neither of which is appropriate for use as an input argument. For this reason, input objects have a separate type in the system.</div>
+<div id="note-7a6d2" class="spec-note">
+<a href="#note-7a6d2">Note</a>
+The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" data-name="ObjectTypeDefinition">ObjectTypeDefinition</a></span>) defined above is inappropriate for re-use here, because Object types can contain fields that define arguments or contain references to interfaces and unions, neither of which is appropriate for use as an input argument. For this reason, input objects have a separate type in the system.</div>
 <section id="sec-Input-Objects.Result-Coercion" class="subsec">
 <h6><a href="#sec-Input-Objects.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
 <p>An input object is never a valid result. Input Object types cannot be the return type of an Object or Interface field.</p>
@@ -3337,12 +3337,12 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 <p>The value for an input object should be an input object literal or an unordered map supplied by a variable, otherwise a query error must be thrown. In either case, the input object literal or unordered map must not contain any entries with names not defined by a field of this input object type, otherwise an error must be thrown.</p>
 <p>The result of coercion is an unordered map with an entry for each field both defined by the input object type and for which a value exists. The resulting map is constructed with the following rules:</p>
 <ul>
-<li>If no value is provided for a defined input object field and that field definition provides a default value, the default value should be used. If no default value is provided and the input object field&rsquo;s type is non&#8208;null, an error should be thrown. Otherwise, if the field is not required, then no entry is added to the coerced unordered map.</li>
-<li>If the value <span class="spec-keyword">null</span> was provided for an input object field, and the field&rsquo;s type is not a non&#8208;null type, an entry in the coerced unordered map is given the value <span class="spec-keyword">null</span>. In other words, there is a semantic difference between the explicitly provided value <span class="spec-keyword">null</span> versus having not provided a value.</li>
+<li>If no value is provided for a defined input object field and that field definition provides a default value, the default value should be used. If no default value is provided and the input object field&rsquo;s type is non-null, an error should be thrown. Otherwise, if the field is not required, then no entry is added to the coerced unordered map.</li>
+<li>If the value <span class="spec-keyword">null</span> was provided for an input object field, and the field&rsquo;s type is not a non-null type, an entry in the coerced unordered map is given the value <span class="spec-keyword">null</span>. In other words, there is a semantic difference between the explicitly provided value <span class="spec-keyword">null</span> versus having not provided a value.</li>
 <li>If a literal value is provided for an input object field, an entry in the coerced unordered map is given the result of coercing that value according to the input coercion rules for the type of that field.</li>
-<li>If a variable is provided for an input object field, the runtime value of that variable must be used. If the runtime value is <span class="spec-keyword">null</span> and the field type is non&#8208;null, a field error must be thrown. If no runtime value is provided, the variable definition&rsquo;s default value should be used. If the variable definition does not provide a default value, the input object field definition&rsquo;s default value should be used.</li>
+<li>If a variable is provided for an input object field, the runtime value of that variable must be used. If the runtime value is <span class="spec-keyword">null</span> and the field type is non-null, a field error must be thrown. If no runtime value is provided, the variable definition&rsquo;s default value should be used. If the variable definition does not provide a default value, the input object field definition&rsquo;s default value should be used.</li>
 </ul>
-<p>Following are examples of input coercion for an input object type with a <code>String</code> field <code>a</code> and a required (non&#8208;null) <code>Int!</code> field <code>b</code>:</p>
+<p>Following are examples of input coercion for an input object type with a <code>String</code> field <code>a</code> and a required (non-null) <code>Int!</code> field <code>b</code>:</p>
 <pre id="example-704b8" class="spec-example" data-language="graphql"><a href="#example-704b8">Example № 80</a><code><span class="token keyword">input</span> ExampleInputObject <span class="token punctuation">{</span>
   <span class="token attr-name">a</span><span class="token punctuation">:</span> String
   <span class="token attr-name">b</span><span class="token punctuation">:</span> Int<span class="token operator">!</span>
@@ -3356,7 +3356,7 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 </tr></thead>
 <tbody>
 <tr>
-<td><code>{ a: &quot;abc&quot;, b: 123 }</code></td><td><code>{}</code></td><td><code>{ a: &quot;abc&quot;, b: 123 }</code></td></tr>
+<td><code>{ a: "abc", b: 123 }</code></td><td><code>{}</code></td><td><code>{ a: "abc", b: 123 }</code></td></tr>
 <tr>
 <td><code>{ a: null, b: 123 }</code></td><td><code>{}</code></td><td><code>{ a: null, b: 123 }</code></td></tr>
 <tr>
@@ -3370,23 +3370,23 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 <tr>
 <td><code>$var</code></td><td><code>{ var: { b: 123 } }</code></td><td><code>{ b: 123 }</code></td></tr>
 <tr>
-<td><code>&quot;abc123&quot;</code></td><td><code>{}</code></td><td>Error: Incorrect value</td></tr>
+<td><code>"abc123"</code></td><td><code>{}</code></td><td>Error: Incorrect value</td></tr>
 <tr>
-<td><code>$var</code></td><td><code>{ var: &quot;abc123&quot; }</code></td><td>Error: Incorrect value</td></tr>
+<td><code>$var</code></td><td><code>{ var: "abc123" }</code></td><td>Error: Incorrect value</td></tr>
 <tr>
-<td><code>{ a: &quot;abc&quot;, b: &quot;123&quot; }</code></td><td><code>{}</code></td><td>Error: Incorrect value for field <var data-name="b">b</var></td></tr>
+<td><code>{ a: "abc", b: "123" }</code></td><td><code>{}</code></td><td>Error: Incorrect value for field <var data-name="b">b</var></td></tr>
 <tr>
-<td><code>{ a: &quot;abc&quot; }</code></td><td><code>{}</code></td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
+<td><code>{ a: "abc" }</code></td><td><code>{}</code></td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
 <tr>
 <td><code>{ b: $var }</code></td><td><code>{}</code></td><td>Error: Missing required field <var data-name="b">b</var>.</td></tr>
 <tr>
-<td><code>$var</code></td><td><code>{ var: { a: &quot;abc&quot; } }</code></td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
+<td><code>$var</code></td><td><code>{ var: { a: "abc" } }</code></td><td>Error: Missing required field <var data-name="b">b</var></td></tr>
 <tr>
-<td><code>{ a: &quot;abc&quot;, b: null }</code></td><td><code>{}</code></td><td>Error: <var data-name="b">b</var> must be non&#8208;null.</td></tr>
+<td><code>{ a: "abc", b: null }</code></td><td><code>{}</code></td><td>Error: <var data-name="b">b</var> must be non-null.</td></tr>
 <tr>
-<td><code>{ b: $var }</code></td><td><code>{ var: null }</code></td><td>Error: <var data-name="b">b</var> must be non&#8208;null.</td></tr>
+<td><code>{ b: $var }</code></td><td><code>{ var: null }</code></td><td>Error: <var data-name="b">b</var> must be non-null.</td></tr>
 <tr>
-<td><code>{ b: 123, c: &quot;xyz&quot; }</code></td><td><code>{}</code></td><td>Error: Unexpected field <var data-name="c">c</var></td></tr>
+<td><code>{ b: 123, c: "xyz" }</code></td><td><code>{}</code></td><td>Error: Unexpected field <var data-name="c">c</var></td></tr>
 </tbody>
 </table>
 </section>
@@ -3416,7 +3416,7 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 <li>The named type must already be defined and must be a Input Object type.</li>
 <li>All fields of an Input Object type extension must have unique names.</li>
 <li>All fields of an Input Object type extension must not already be a field of the original Input Object.</li>
-<li>Any non&#8208;repeatable directives provided must not already apply to the original Input Object type.</li>
+<li>Any non-repeatable directives provided must not already apply to the original Input Object type.</li>
 </ol>
 </section>
 </section>
@@ -3427,11 +3427,11 @@ The GraphQL Object type (<span class="spec-nt"><a href="#ObjectTypeDefinition" d
 <p>To denote that a field uses a List type the item type is wrapped in square brackets like this: <code>pets: [Pet]</code>. Nesting lists is allowed: <code>matrix: [[Int]]</code>.</p>
 <section id="sec-Type-System.List.Result-Coercion" class="subsec">
 <h6><a href="#sec-Type-System.List.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
-<p>GraphQL services must return an ordered list as the result of a list type. Each item in the list must be the result of a result coercion of the item type. If a reasonable coercion is not possible it must raise a field error. In particular, if a non&#8208;list is returned, the coercion should fail, as this indicates a mismatch in expectations between the type system and the implementation.</p>
-<p>If a list&rsquo;s item type is nullable, then errors occurring during preparation or coercion of an individual item in the list must result in a the value <span class="spec-keyword">null</span> at that position in the list along with an error added to the response. If a list&rsquo;s item type is non&#8208;null, an error occurring at an individual item in the list must result in a field error for the entire list.</p>
-<div id="note-a51a1" class="spec-note">
-<a href="#note-a51a1">Note</a>
-For more information on the error handling process, see &ldquo;Errors and Non&#8208;Nullability&rdquo; within the Execution section.</div>
+<p>GraphQL services must return an ordered list as the result of a list type. Each item in the list must be the result of a result coercion of the item type. If a reasonable coercion is not possible it must raise a field error. In particular, if a non-list is returned, the coercion should fail, as this indicates a mismatch in expectations between the type system and the implementation.</p>
+<p>If a list&rsquo;s item type is nullable, then errors occurring during preparation or coercion of an individual item in the list must result in a the value <span class="spec-keyword">null</span> at that position in the list along with an error added to the response. If a list&rsquo;s item type is non-null, an error occurring at an individual item in the list must result in a field error for the entire list.</p>
+<div id="note-b21b6" class="spec-note">
+<a href="#note-b21b6">Note</a>
+For more information on the error handling process, see &ldquo;Errors and Non-Nullability&rdquo; within the Execution section.</div>
 </section>
 <section id="sec-Type-System.List.Input-Coercion" class="subsec">
 <h6><a href="#sec-Type-System.List.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
@@ -3449,7 +3449,7 @@ For more information on the error handling process, see &ldquo;Errors and Non&#8
 <tr>
 <td><code>[Int]</code></td><td><code>[1, 2, 3]</code></td><td><code>[1, 2, 3]</code></td></tr>
 <tr>
-<td><code>[Int]</code></td><td><code>[1, &quot;b&quot;, true]</code></td><td>Error: Incorrect item value</td></tr>
+<td><code>[Int]</code></td><td><code>[1, "b", true]</code></td><td>Error: Incorrect item value</td></tr>
 <tr>
 <td><code>[Int]</code></td><td><code>1</code></td><td><code>[1]</code></td></tr>
 <tr>
@@ -3468,52 +3468,52 @@ For more information on the error handling process, see &ldquo;Errors and Non&#8
 </section>
 <section id="sec-Type-System.Non-Null" secid="3.12">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-System.Non-Null">3.12</a></span>Non-Null</h2>
-<p>By default, all types in GraphQL are nullable; the <span class="spec-keyword">null</span> value is a valid response for all of the above types. To declare a type that disallows null, the GraphQL Non&#8208;Null type can be used. This type wraps an underlying type, and this type acts identically to that wrapped type, with the exception that <span class="spec-keyword">null</span> is not a valid response for the wrapping type. A trailing exclamation mark is used to denote a field that uses a Non&#8208;Null type like this: <code>name: String!</code>.</p>
+<p>By default, all types in GraphQL are nullable; the <span class="spec-keyword">null</span> value is a valid response for all of the above types. To declare a type that disallows null, the GraphQL Non-Null type can be used. This type wraps an underlying type, and this type acts identically to that wrapped type, with the exception that <span class="spec-keyword">null</span> is not a valid response for the wrapping type. A trailing exclamation mark is used to denote a field that uses a Non-Null type like this: <code>name: String!</code>.</p>
 <section id="sec-Type-System.Non-Null.Nullable-vs-Optional" class="subsec">
 <h6><a href="#sec-Type-System.Non-Null.Nullable-vs-Optional" title="link to this subsection">Nullable vs. Optional</a></h6>
-<p>Fields are <em>always</em> optional within the context of a query, a field may be omitted and the query is still valid. However fields that return Non&#8208;Null types will never return the value <span class="spec-keyword">null</span> if queried.</p>
-<p>Inputs (such as field arguments), are always optional by default. However a non&#8208;null input type is required. In addition to not accepting the value <span class="spec-keyword">null</span>, it also does not accept omission. For the sake of simplicity nullable types are always optional and non&#8208;null types are always required.</p>
+<p>Fields are <em>always</em> optional within the context of a query, a field may be omitted and the query is still valid. However fields that return Non-Null types will never return the value <span class="spec-keyword">null</span> if queried.</p>
+<p>Inputs (such as field arguments), are always optional by default. However a non-null input type is required. In addition to not accepting the value <span class="spec-keyword">null</span>, it also does not accept omission. For the sake of simplicity nullable types are always optional and non-null types are always required.</p>
 </section>
 <section id="sec-Type-System.Non-Null.Result-Coercion" class="subsec">
 <h6><a href="#sec-Type-System.Non-Null.Result-Coercion" title="link to this subsection">Result Coercion</a></h6>
-<p>In all of the above result coercions, <span class="spec-keyword">null</span> was considered a valid value. To coerce the result of a Non&#8208;Null type, the coercion of the wrapped type should be performed. If that result was not <span class="spec-keyword">null</span>, then the result of coercing the Non&#8208;Null type is that result. If that result was <span class="spec-keyword">null</span>, then a field error must be raised.</p>
-<div id="note-fb3a2" class="spec-note">
-<a href="#note-fb3a2">Note</a>
-When a field error is raised on a non&#8208;null value, the error propagates to the parent field. For more information on this process, see &ldquo;Errors and Non&#8208;Nullability&rdquo; within the Execution section.</div>
+<p>In all of the above result coercions, <span class="spec-keyword">null</span> was considered a valid value. To coerce the result of a Non-Null type, the coercion of the wrapped type should be performed. If that result was not <span class="spec-keyword">null</span>, then the result of coercing the Non-Null type is that result. If that result was <span class="spec-keyword">null</span>, then a field error must be raised.</p>
+<div id="note-ad65b" class="spec-note">
+<a href="#note-ad65b">Note</a>
+When a field error is raised on a non-null value, the error propagates to the parent field. For more information on this process, see &ldquo;Errors and Non-Nullability&rdquo; within the Execution section.</div>
 </section>
 <section id="sec-Type-System.Non-Null.Input-Coercion" class="subsec">
 <h6><a href="#sec-Type-System.Non-Null.Input-Coercion" title="link to this subsection">Input Coercion</a></h6>
-<p>If an argument or input&#8208;object field of a Non&#8208;Null type is not provided, is provided with the literal value <span class="spec-keyword">null</span>, or is provided with a variable that was either not provided a value at runtime, or was provided the value <span class="spec-keyword">null</span>, then a query error must be raised.</p>
-<p>If the value provided to the Non&#8208;Null type is provided with a literal value other than <span class="spec-keyword">null</span>, or a Non&#8208;Null variable value, it is coerced using the input coercion for the wrapped type.</p>
-<p>A non&#8208;null argument cannot be omitted:</p>
+<p>If an argument or input-object field of a Non-Null type is not provided, is provided with the literal value <span class="spec-keyword">null</span>, or is provided with a variable that was either not provided a value at runtime, or was provided the value <span class="spec-keyword">null</span>, then a query error must be raised.</p>
+<p>If the value provided to the Non-Null type is provided with a literal value other than <span class="spec-keyword">null</span>, or a Non-Null variable value, it is coerced using the input coercion for the wrapped type.</p>
+<p>A non-null argument cannot be omitted:</p>
 <pre id="example-32bbf" class="spec-counter-example" data-language="graphql"><a href="#example-32bbf">Counter Example № 81</a><code><span class="token punctuation">{</span>
   fieldWithNonNullArg
 <span class="token punctuation">}</span>
 </code></pre>
-<p>The value <span class="spec-keyword">null</span> cannot be provided to a non&#8208;null argument:</p>
+<p>The value <span class="spec-keyword">null</span> cannot be provided to a non-null argument:</p>
 <pre id="example-da489" class="spec-counter-example" data-language="graphql"><a href="#example-da489">Counter Example № 82</a><code><span class="token punctuation">{</span>
   fieldWithNonNullArg<span class="token punctuation">(</span><span class="token attr-name">nonNullArg</span><span class="token punctuation">:</span> null<span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>A variable of a nullable type cannot be provided to a non&#8208;null argument:</p>
+<p>A variable of a nullable type cannot be provided to a non-null argument:</p>
 <pre id="example-6d129" class="spec-example" data-language="graphql"><a href="#example-6d129">Example № 83</a><code><span class="token keyword">query</span> withNullableVariable<span class="token punctuation">(</span><span class="token variable">$var</span><span class="token punctuation">:</span> String<span class="token punctuation">)</span> <span class="token punctuation">{</span>
   fieldWithNonNullArg<span class="token punctuation">(</span><span class="token attr-name">nonNullArg</span><span class="token punctuation">:</span> <span class="token variable">$var</span><span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<div id="note-5ebe7" class="spec-note">
-<a href="#note-5ebe7">Note</a>
-The Validation section defines providing a nullable variable type to a non&#8208;null input type as invalid.</div>
+<div id="note-97a45" class="spec-note">
+<a href="#note-97a45">Note</a>
+The Validation section defines providing a nullable variable type to a non-null input type as invalid.</div>
 </section>
 <section id="sec-Type-System.Non-Null.Type-Validation" class="subsec">
 <h6><a href="#sec-Type-System.Non-Null.Type-Validation" title="link to this subsection">Type Validation</a></h6>
 <ol>
-<li>A Non&#8208;Null type must not wrap another Non&#8208;Null type.</li>
+<li>A Non-Null type must not wrap another Non-Null type.</li>
 </ol>
 </section>
 <section id="sec-Combining-List-and-Non-Null" secid="3.12.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Combining-List-and-Non-Null">3.12.1</a></span>Combining List and Non-Null</h3>
-<p>The List and Non&#8208;Null wrapping types can compose, representing more complex types. The rules for result coercion and input coercion of Lists and Non&#8208;Null types apply in a recursive fashion.</p>
-<p>For example if the inner item type of a List is Non&#8208;Null (e.g. <code>[T!]</code>), then that List may not contain any <span class="spec-keyword">null</span> items. However if the inner type of a Non&#8208;Null is a List (e.g. <code>[T]!</code>), then <span class="spec-keyword">null</span> is not accepted however an empty list is accepted.</p>
+<p>The List and Non-Null wrapping types can compose, representing more complex types. The rules for result coercion and input coercion of Lists and Non-Null types apply in a recursive fashion.</p>
+<p>For example if the inner item type of a List is Non-Null (e.g. <code>[T!]</code>), then that List may not contain any <span class="spec-keyword">null</span> items. However if the inner type of a Non-Null is a List (e.g. <code>[T]!</code>), then <span class="spec-keyword">null</span> is not accepted however an empty list is accepted.</p>
 <p>Following are examples of result coercion with various types and values:</p>
 <table>
 <thead><tr>
@@ -3720,7 +3720,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 <section id="sec-Introspection" secid="4">
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Introspection">4</a></span>Introspection</h1>
-<p>A GraphQL service supports introspection over its schema. This schema is queried using GraphQL itself, creating a powerful platform for tool&#8208;building.</p>
+<p>A GraphQL service supports introspection over its schema. This schema is queried using GraphQL itself, creating a powerful platform for tool-building.</p>
 <p>Take an example query for a trivial app. In this case there is a User type with three fields: id, name, and birthday.</p>
 <p>For example, given a service with the following type definition:</p>
 <pre id="example-3005e" class="spec-example" data-language="graphql"><a href="#example-3005e">Example № 92</a><code><span class="token keyword">type</span> <span class="token class-name">User</span> <span class="token punctuation">{</span>
@@ -3765,26 +3765,26 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </code></pre>
 <section id="sec-Reserved-Names" secid="4.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Reserved-Names">4.1</a></span>Reserved Names</h2>
-<p>Types and fields required by the GraphQL introspection system that are used in the same context as user&#8208;defined types and fields are prefixed with <span class="spec-string">"__"</span> two underscores. This in order to avoid naming collisions with user&#8208;defined GraphQL types. Conversely, GraphQL type system authors must not define any types, fields, arguments, or any other type system artifact with two leading underscores.</p>
+<p>Types and fields required by the GraphQL introspection system that are used in the same context as user-defined types and fields are prefixed with <span class="spec-string">"__"</span> two underscores. This in order to avoid naming collisions with user-defined GraphQL types. Conversely, GraphQL type system authors must not define any types, fields, arguments, or any other type system artifact with two leading underscores.</p>
 </section>
 <section id="sec-Documentation" secid="4.2">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Documentation">4.2</a></span>Documentation</h2>
-<p>All types in the introspection system provide a <code>description</code> field of type <code>String</code> to allow type designers to publish documentation in addition to capabilities. A GraphQL service may return the <code>description</code> field using Markdown syntax (as specified by <a href="https://commonmark.org/">CommonMark</a>). Therefore it is recommended that any tool that displays <code>description</code> use a CommonMark&#8208;compliant Markdown renderer.</p>
+<p>All types in the introspection system provide a <code>description</code> field of type <code>String</code> to allow type designers to publish documentation in addition to capabilities. A GraphQL service may return the <code>description</code> field using Markdown syntax (as specified by <a href="https://commonmark.org/">CommonMark</a>). Therefore it is recommended that any tool that displays <code>description</code> use a CommonMark-compliant Markdown renderer.</p>
 </section>
 <section id="sec-Deprecation" secid="4.3">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Deprecation">4.3</a></span>Deprecation</h2>
 <p>To support the management of backwards compatibility, GraphQL fields and enum values can indicate whether or not they are deprecated (<code>isDeprecated: Boolean</code>) and a description of why it is deprecated (<code>deprecationReason: String</code>).</p>
-<p>Tools built using GraphQL introspection should respect deprecation by discouraging deprecated use through information hiding or developer&#8208;facing warnings.</p>
+<p>Tools built using GraphQL introspection should respect deprecation by discouraging deprecated use through information hiding or developer-facing warnings.</p>
 </section>
 <section id="sec-Type-Name-Introspection" secid="4.4">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Type-Name-Introspection">4.4</a></span>Type Name Introspection</h2>
-<p>GraphQL supports type name introspection at any point within a query by the meta&#8208;field <code>__typename: String!</code> when querying against any Object, Interface, or Union. It returns the name of the object type currently being queried.</p>
+<p>GraphQL supports type name introspection at any point within a query by the meta-field <code>__typename: String!</code> when querying against any Object, Interface, or Union. It returns the name of the object type currently being queried.</p>
 <p>This is most often used when querying against Interface or Union types to identify which actual type of the possible types has been returned.</p>
 <p>This field is implicit and does not appear in the fields list in any defined type.</p>
 </section>
 <section id="sec-Schema-Introspection" secid="4.5">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Schema-Introspection">4.5</a></span>Schema Introspection</h2>
-<p>The schema introspection system is accessible from the meta&#8208;fields <code>__schema</code> and <code>__type</code> which are accessible from the type of the root of a query operation.</p>
+<p>The schema introspection system is accessible from the meta-fields <code>__schema</code> and <code>__type</code> which are accessible from the type of the root of a query operation.</p>
 <pre data-language="graphql"><code><span class="token attr-name">__schema</span><span class="token punctuation">:</span> __Schema<span class="token operator">!</span>
 <span class="token attr-name">__type</span><span class="token punctuation">(</span><span class="token attr-name">name</span><span class="token punctuation">:</span> String<span class="token operator">!</span><span class="token punctuation">)</span><span class="token punctuation">:</span> __Type
 </code></pre>
@@ -3890,7 +3890,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 <section id="sec-The-__Type-Type" secid="4.5.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-The-__Type-Type">4.5.1</a></span>The __Type Type</h3>
 <p><code>__Type</code> is at the core of the type introspection system. It represents scalars, interfaces, object types, unions, enums, input objects types in the system.</p>
-<p><code>__Type</code> also represents type modifiers, which are used to modify a type that it refers to (<code>ofType: __Type</code>). This is how we represent lists, non&#8208;nullable types, and the combinations thereof.</p>
+<p><code>__Type</code> also represents type modifiers, which are used to modify a type that it refers to (<code>ofType: __Type</code>). This is how we represent lists, non-nullable types, and the combinations thereof.</p>
 </section>
 <section id="sec-Type-Kinds" secid="4.5.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds">4.5.2</a></span>Type Kinds</h3>
@@ -3915,7 +3915,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 <li><code>kind</code> must return <code>__TypeKind.OBJECT</code>.</li>
 <li><code>name</code> must return a String.</li>
 <li><code>description</code> may return a String or <span class="spec-keyword">null</span>.</li>
-<li><code>fields</code>: The set of fields query&#8208;able on this type.<ul>
+<li><code>fields</code>: The set of fields query-able on this type.<ul>
 <li>Accepts the argument <code>includeDeprecated</code> which defaults to <span class="spec-keyword">false</span>. If <span class="spec-keyword">true</span>, deprecated fields are also returned.</li>
 </ul>
 </li>
@@ -3998,10 +3998,10 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 <section id="sec-Type-Kinds.Non-Null" secid="4.5.2.8">
 <h4><span class="spec-secid" title="link to this section"><a href="#sec-Type-Kinds.Non-Null">4.5.2.8</a></span>Non-Null</h4>
 <p>GraphQL types are nullable. The value <span class="spec-keyword">null</span> is a valid response for field type.</p>
-<p>A Non&#8208;null type is a type modifier: it wraps another type instance in the <code>ofType</code> field. Non&#8208;null types do not allow <span class="spec-keyword">null</span> as a response, and indicate required inputs for arguments and input object fields.</p>
+<p>A Non-null type is a type modifier: it wraps another type instance in the <code>ofType</code> field. Non-null types do not allow <span class="spec-keyword">null</span> as a response, and indicate required inputs for arguments and input object fields.</p>
 <ul>
 <li><code>kind</code> must return <code>__TypeKind.NON_NULL</code>.</li>
-<li><code>ofType</code>: Any type except Non&#8208;null.</li>
+<li><code>ofType</code>: Any type except Non-null.</li>
 <li>All other fields must return <span class="spec-keyword">null</span>.</li>
 </ul>
 </section>
@@ -4057,9 +4057,9 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 <section id="sec-Validation" secid="5">
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Validation">5</a></span>Validation</h1>
-<p>GraphQL does not just verify if a request is syntactically correct, but also ensures that it is unambiguous and mistake&#8208;free in the context of a given GraphQL schema.</p>
+<p>GraphQL does not just verify if a request is syntactically correct, but also ensures that it is unambiguous and mistake-free in the context of a given GraphQL schema.</p>
 <p>An invalid request is still technically executable, and will always produce a stable result as defined by the algorithms in the Execution section, however that result may be ambiguous, surprising, or unexpected relative to a request containing validation errors, so execution should only occur for valid requests.</p>
-<p>Typically validation is performed in the context of a request immediately before execution, however a GraphQL service may execute a request without explicitly validating it if that exact same request is known to have been validated before. For example: the request may be validated during development, provided it does not later change, or a service may validate a request once and memoize the result to avoid validating the same request again in the future. Any client&#8208;side or development&#8208;time tool should report validation errors and not allow the formulation or execution of requests known to be invalid at that given point in time.</p>
+<p>Typically validation is performed in the context of a request immediately before execution, however a GraphQL service may execute a request without explicitly validating it if that exact same request is known to have been validated before. For example: the request may be validated during development, provided it does not later change, or a service may validate a request once and memoize the result to avoid validating the same request again in the future. Any client-side or development-time tool should report validation errors and not allow the formulation or execution of requests known to be invalid at that given point in time.</p>
 <section id="sec-Validation.Type-system-evolution" class="subsec">
 <h6><a href="#sec-Validation.Type-system-evolution" title="link to this subsection">Type system evolution</a></h6>
 <p>As GraphQL type system schema evolves over time by adding new types and new fields, it is possible that a request which was previously valid could later become invalid. Any change that can cause a previously valid request to become invalid is considered a <em>breaking change</em>. GraphQL services and schema maintainers are encouraged to avoid breaking changes, however in order to be more resilient to these breaking changes, sophisticated GraphQL systems may still allow for the execution of requests which <em>at some point</em> were known to be free of any validation errors, and have not changed since.</p>
@@ -4229,7 +4229,7 @@ Neither <code>@skip</code> nor <code>@include</code> has precedence over the oth
 </section>
 <section id="sec-Lone-Anonymous-Operation.Explanatory-Text" class="subsec">
 <h6><a href="#sec-Lone-Anonymous-Operation.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
-<p>GraphQL allows a short&#8208;hand form for defining query operations when only that one operation exists in the document.</p>
+<p>GraphQL allows a short-hand form for defining query operations when only that one operation exists in the document.</p>
 <p>For example the following document is valid:</p>
 <pre id="example-be853" class="spec-example" data-language="graphql"><a href="#example-be853">Example № 101</a><code><span class="token punctuation">{</span>
   dog <span class="token punctuation">{</span>
@@ -4354,7 +4354,7 @@ While each subscription must have exactly one root field, a document may contain
   <span class="token attr-name">barkVolume</span><span class="token punctuation">:</span> kawVolume
 <span class="token punctuation">}</span>
 </code></pre>
-<p>For interfaces, direct field selection can only be done on fields. Fields of concrete implementors are not relevant to the validity of the given interface&#8208;typed selection set.</p>
+<p>For interfaces, direct field selection can only be done on fields. Fields of concrete implementors are not relevant to the validity of the given interface-typed selection set.</p>
 <p>For example, the following is valid:</p>
 <pre id="example-d34e0" class="spec-example" data-language="graphql"><a href="#example-d34e0">Example № 109</a><code><span class="token keyword">fragment</span> <span class="token fragment function">interfaceFieldSelection</span> <span class="token keyword">on</span> <span class="token class-name">Pet</span> <span class="token punctuation">{</span>
   name
@@ -4365,7 +4365,7 @@ While each subscription must have exactly one root field, a document may contain
   nickname
 <span class="token punctuation">}</span>
 </code></pre>
-<p>Because unions do not define fields, fields may not be directly selected from a union&#8208;typed selection set, with the exception of the meta&#8208;field <var data-name="__typename">__typename</var>. Fields from a union&#8208;typed selection set must only be queried indirectly via a fragment.</p>
+<p>Because unions do not define fields, fields may not be directly selected from a union-typed selection set, with the exception of the meta-field <var data-name="__typename">__typename</var>. Fields from a union-typed selection set must only be queried indirectly via a fragment.</p>
 <p>For example the following is valid:</p>
 <pre id="example-245fa" class="spec-example" data-language="graphql"><a href="#example-245fa">Example № 111</a><code><span class="token keyword">fragment</span> <span class="token fragment function">inDirectFieldSelectionOnUnion</span> <span class="token keyword">on</span> <span class="token class-name">CatOrDog</span> <span class="token punctuation">{</span>
   __typename
@@ -4413,7 +4413,7 @@ While each subscription must have exactly one root field, a document may contain
 <span class="spec-call"><a href="#SameResponseShape()" data-name="SameResponseShape">SameResponseShape</a>(<var data-name="fieldA">fieldA</var>, <var data-name="fieldB">fieldB</var>)</span><ol>
 <li>Let <var data-name="typeA">typeA</var> be the return type of <var data-name="fieldA">fieldA</var>.</li>
 <li>Let <var data-name="typeB">typeB</var> be the return type of <var data-name="fieldB">fieldB</var>.</li>
-<li>If <var data-name="typeA">typeA</var> or <var data-name="typeB">typeB</var> is Non&#8208;Null.<ol>
+<li>If <var data-name="typeA">typeA</var> or <var data-name="typeB">typeB</var> is Non-Null.<ol>
 <li>If <var data-name="typeA">typeA</var> or <var data-name="typeB">typeB</var> is nullable, return false.</li>
 <li>Let <var data-name="typeA">typeA</var> be the nullable type of <var data-name="typeA">typeA</var></li>
 <li>Let <var data-name="typeB">typeB</var> be the nullable type of <var data-name="typeB">typeB</var></li>
@@ -4445,7 +4445,7 @@ While each subscription must have exactly one root field, a document may contain
 <h6><a href="#sec-Field-Selection-Merging.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
 <p>If multiple field selections with the same response names are encountered during execution, the field and arguments to execute and the resulting value should be unambiguous. Therefore any two field selections which might both be encountered for the same object are only valid if they are equivalent.</p>
 <p>During execution, the simultaneous execution of fields with the same response name is accomplished by <span class="spec-call"><a href="#MergeSelectionSets()" data-name="MergeSelectionSets">MergeSelectionSets</a>()</span> and <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span>.</p>
-<p>For simple hand&#8208;written GraphQL, this rule is obviously a clear developer error, however nested fragments can make this difficult to detect manually.</p>
+<p>For simple hand-written GraphQL, this rule is obviously a clear developer error, however nested fragments can make this difficult to detect manually.</p>
 <p>The following selections correctly merge:</p>
 <pre id="example-4e10c" class="spec-example" data-language="graphql"><a href="#example-4e10c">Example № 113</a><code><span class="token keyword">fragment</span> <span class="token fragment function">mergeIdenticalFields</span> <span class="token keyword">on</span> <span class="token class-name">Dog</span> <span class="token punctuation">{</span>
   name
@@ -4666,7 +4666,7 @@ While each subscription must have exactly one root field, a document may contain
 <li>For each <var data-name="argumentDefinition">argumentDefinition</var> in <var data-name="argumentDefinitions">argumentDefinitions</var>:<ul>
 <li>Let <var data-name="type">type</var> be the expected type of <var data-name="argumentDefinition">argumentDefinition</var>.</li>
 <li>Let <var data-name="defaultValue">defaultValue</var> be the default value of <var data-name="argumentDefinition">argumentDefinition</var>.</li>
-<li>If <var data-name="type">type</var> is Non&#8208;Null and <var data-name="defaultValue">defaultValue</var> does not exist:<ul>
+<li>If <var data-name="type">type</var> is Non-Null and <var data-name="defaultValue">defaultValue</var> does not exist:<ul>
 <li>Let <var data-name="argumentName">argumentName</var> be the name of <var data-name="argumentDefinition">argumentDefinition</var>.</li>
 <li>Let <var data-name="argument">argument</var> be the argument in <var data-name="arguments">arguments</var> named <var data-name="argumentName">argumentName</var></li>
 <li><var data-name="argument">argument</var> must exist.</li>
@@ -4679,7 +4679,7 @@ While each subscription must have exactly one root field, a document may contain
 </ul>
 <section id="sec-Required-Arguments.Explanatory-Text" class="subsec">
 <h6><a href="#sec-Required-Arguments.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
-<p>Arguments can be required. An argument is required if the argument type is non&#8208;null and does not have a default value. Otherwise, the argument is optional.</p>
+<p>Arguments can be required. An argument is required if the argument type is non-null and does not have a default value. Otherwise, the argument is optional.</p>
 <p>For example the following are valid:</p>
 <pre id="example-503bd" class="spec-example" data-language="graphql"><a href="#example-503bd">Example № 128</a><code><span class="token keyword">fragment</span> <span class="token fragment function">goodBooleanArg</span> <span class="token keyword">on</span> <span class="token class-name">Arguments</span> <span class="token punctuation">{</span>
   booleanArgField<span class="token punctuation">(</span><span class="token attr-name">booleanArg</span><span class="token punctuation">:</span> <span class="token boolean">true</span><span class="token punctuation">)</span>
@@ -4700,7 +4700,7 @@ While each subscription must have exactly one root field, a document may contain
   nonNullBooleanArgField
 <span class="token punctuation">}</span>
 </code></pre>
-<p>Providing the explicit value <span class="spec-keyword">null</span> is also not valid since required arguments always have a non&#8208;null type.</p>
+<p>Providing the explicit value <span class="spec-keyword">null</span> is also not valid since required arguments always have a non-null type.</p>
 <pre id="example-0bc81" class="spec-counter-example" data-language="graphql"><a href="#example-0bc81">Counter Example № 131</a><code><span class="token keyword">fragment</span> <span class="token fragment function">missingRequiredArg</span> <span class="token keyword">on</span> <span class="token class-name">Arguments</span> <span class="token punctuation">{</span>
   nonNullBooleanArgField<span class="token punctuation">(</span><span class="token attr-name">nonNullBooleanArg</span><span class="token punctuation">:</span> null<span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
@@ -4819,7 +4819,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 <section id="sec-Fragments-On-Composite-Types.Explanatory-Text" class="subsec">
 <h6><a href="#sec-Fragments-On-Composite-Types.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
-<p>Fragments can only be declared on unions, interfaces, and objects. They are invalid on scalars. They can only be applied on non&#8208;leaf fields. This rule applies to both inline and named fragments.</p>
+<p>Fragments can only be declared on unions, interfaces, and objects. They are invalid on scalars. They can only be applied on non-leaf fields. This rule applies to both inline and named fragments.</p>
 <p>The following fragment declarations are valid:</p>
 <pre id="example-3c8d4" class="spec-example" data-language="graphql"><a href="#example-3c8d4">Example № 136</a><code><span class="token keyword">fragment</span> <span class="token fragment function">fragOnObject</span> <span class="token keyword">on</span> <span class="token class-name">Dog</span> <span class="token punctuation">{</span>
   name
@@ -5161,7 +5161,7 @@ While each subscription must have exactly one root field, a document may contain
   findDog<span class="token punctuation">(</span><span class="token attr-name">complex</span><span class="token punctuation">:</span> <span class="token variable">$search</span><span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>Non&#8208;coercible values (such as a String into an Int) are invalid. The following examples are invalid:</p>
+<p>Non-coercible values (such as a String into an Int) are invalid. The following examples are invalid:</p>
 <pre id="example-3a7c1" class="spec-counter-example" data-language="graphql"><a href="#example-3a7c1">Counter Example № 153</a><code><span class="token keyword">fragment</span> <span class="token fragment function">stringIntoInt</span> <span class="token keyword">on</span> <span class="token class-name">Arguments</span> <span class="token punctuation">{</span>
   intArgField<span class="token punctuation">(</span><span class="token attr-name">intArg</span><span class="token punctuation">:</span> <span class="token string">"123"</span><span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
@@ -5191,7 +5191,7 @@ While each subscription must have exactly one root field, a document may contain
   findDog<span class="token punctuation">(</span><span class="token attr-name">complex</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token attr-name">name</span><span class="token punctuation">:</span> <span class="token string">"Fido"</span> <span class="token punctuation">}</span><span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>While the following example input&#8208;object uses a field &ldquo;favoriteCookieFlavor&rdquo; which is not defined on the expected type:</p>
+<p>While the following example input-object uses a field &ldquo;favoriteCookieFlavor&rdquo; which is not defined on the expected type:</p>
 <pre id="example-1a5f6" class="spec-counter-example" data-language="graphql"><a href="#example-1a5f6">Counter Example № 155</a><code><span class="token punctuation">{</span>
   findDog<span class="token punctuation">(</span><span class="token attr-name">complex</span><span class="token punctuation">:</span> <span class="token punctuation">{</span> <span class="token attr-name">favoriteCookieFlavor</span><span class="token punctuation">:</span> <span class="token string">"Bacon"</span> <span class="token punctuation">}</span><span class="token punctuation">)</span>
 <span class="token punctuation">}</span>
@@ -5235,7 +5235,7 @@ While each subscription must have exactly one root field, a document may contain
 <li>For each <var data-name="fieldDefinition">fieldDefinition</var> in <var data-name="fieldDefinitions">fieldDefinitions</var>:<ul>
 <li>Let <var data-name="type">type</var> be the expected type of <var data-name="fieldDefinition">fieldDefinition</var>.</li>
 <li>Let <var data-name="defaultValue">defaultValue</var> be the default value of <var data-name="fieldDefinition">fieldDefinition</var>.</li>
-<li>If <var data-name="type">type</var> is Non&#8208;Null and <var data-name="defaultValue">defaultValue</var> does not exist:<ul>
+<li>If <var data-name="type">type</var> is Non-Null and <var data-name="defaultValue">defaultValue</var> does not exist:<ul>
 <li>Let <var data-name="fieldName">fieldName</var> be the name of <var data-name="fieldDefinition">fieldDefinition</var>.</li>
 <li>Let <var data-name="field">field</var> be the input field in <var data-name="fields">fields</var> named <var data-name="fieldName">fieldName</var></li>
 <li><var data-name="field">field</var> must exist.</li>
@@ -5249,7 +5249,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 <section id="sec-Input-Object-Required-Fields.Explanatory-Text" class="subsec">
 <h6><a href="#sec-Input-Object-Required-Fields.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
-<p>Input object fields may be required. Much like a field may have required arguments, an input object may have required fields. An input field is required if it has a non&#8208;null type and does not have a default value. Otherwise, the input object field is optional.</p>
+<p>Input object fields may be required. Much like a field may have required arguments, an input object may have required fields. An input field is required if it has a non-null type and does not have a default value. Otherwise, the input object field is optional.</p>
 </section>
 </section>
 </section>
@@ -5454,7 +5454,7 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 <section id="sec-All-Variable-Uses-Defined.Explanatory-Text" class="subsec">
 <h6><a href="#sec-All-Variable-Uses-Defined.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
-<p>Variables are scoped on a per&#8208;operation basis. That means that any variable used within the context of an operation must be defined at the top level of that operation</p>
+<p>Variables are scoped on a per-operation basis. That means that any variable used within the context of an operation must be defined at the top level of that operation</p>
 <p>For example:</p>
 <pre id="example-a5099" class="spec-example" data-language="graphql"><a href="#example-a5099">Example № 165</a><code><span class="token keyword">query</span> variableIsDefined<span class="token punctuation">(</span><span class="token variable">$atOtherHomes</span><span class="token punctuation">:</span> Boolean<span class="token punctuation">)</span> <span class="token punctuation">{</span>
   dog <span class="token punctuation">{</span>
@@ -5630,7 +5630,7 @@ While each subscription must have exactly one root field, a document may contain
 <span class="spec-call"><a href="#IsVariableUsageAllowed()" data-name="IsVariableUsageAllowed">IsVariableUsageAllowed</a>(<var data-name="variableDefinition">variableDefinition</var>, <var data-name="variableUsage">variableUsage</var>)</span><ol>
 <li>Let <var data-name="variableType">variableType</var> be the expected type of <var data-name="variableDefinition">variableDefinition</var>.</li>
 <li>Let <var data-name="locationType">locationType</var> be the expected type of the <span class="spec-nt"><a href="#Argument" data-name="Argument">Argument</a></span>, <span class="spec-nt"><a href="#ObjectField" data-name="ObjectField">ObjectField</a></span>, or <span class="spec-nt"><a href="#ListValue" data-name="ListValue">ListValue</a></span> entry where <var data-name="variableUsage">variableUsage</var> is located.</li>
-<li>If <var data-name="locationType">locationType</var> is a non&#8208;null type AND <var data-name="variableType">variableType</var> is NOT a non&#8208;null type:<ol>
+<li>If <var data-name="locationType">locationType</var> is a non-null type AND <var data-name="variableType">variableType</var> is NOT a non-null type:<ol>
 <li>Let <var data-name="hasNonNullVariableDefaultValue">hasNonNullVariableDefaultValue</var> be <span class="spec-keyword">true</span> if a default value exists for <var data-name="variableDefinition">variableDefinition</var> and is not the value <span class="spec-keyword">null</span>.</li>
 <li>Let <var data-name="hasLocationDefaultValue">hasLocationDefaultValue</var> be <span class="spec-keyword">true</span> if a default value exists for the <span class="spec-nt"><a href="#Argument" data-name="Argument">Argument</a></span> or <span class="spec-nt"><a href="#ObjectField" data-name="ObjectField">ObjectField</a></span> where <var data-name="variableUsage">variableUsage</var> is located.</li>
 <li>If <var data-name="hasNonNullVariableDefaultValue">hasNonNullVariableDefaultValue</var> is NOT <span class="spec-keyword">true</span> AND <var data-name="hasLocationDefaultValue">hasLocationDefaultValue</var> is NOT <span class="spec-keyword">true</span>, return <span class="spec-keyword">false</span>.</li>
@@ -5643,14 +5643,14 @@ While each subscription must have exactly one root field, a document may contain
 </div>
 <div class="spec-algo" id="AreTypesCompatible()">
 <span class="spec-call"><a href="#AreTypesCompatible()" data-name="AreTypesCompatible">AreTypesCompatible</a>(<var data-name="variableType">variableType</var>, <var data-name="locationType">locationType</var>)</span><ol>
-<li>If <var data-name="locationType">locationType</var> is a non&#8208;null type:<ol>
-<li>If <var data-name="variableType">variableType</var> is NOT a non&#8208;null type, return <span class="spec-keyword">false</span>.</li>
+<li>If <var data-name="locationType">locationType</var> is a non-null type:<ol>
+<li>If <var data-name="variableType">variableType</var> is NOT a non-null type, return <span class="spec-keyword">false</span>.</li>
 <li>Let <var data-name="nullableLocationType">nullableLocationType</var> be the unwrapped nullable type of <var data-name="locationType">locationType</var>.</li>
 <li>Let <var data-name="nullableVariableType">nullableVariableType</var> be the unwrapped nullable type of <var data-name="variableType">variableType</var>.</li>
 <li>Return <span class="spec-call"><a href="#AreTypesCompatible()" data-name="AreTypesCompatible">AreTypesCompatible</a>(<var data-name="nullableVariableType">nullableVariableType</var>, <var data-name="nullableLocationType">nullableLocationType</var>)</span>.</li>
 </ol>
 </li>
-<li>Otherwise, if <var data-name="variableType">variableType</var> is a non&#8208;null type:<ol>
+<li>Otherwise, if <var data-name="variableType">variableType</var> is a non-null type:<ol>
 <li>Let <var data-name="nullableVariableType">nullableVariableType</var> be the nullable type of <var data-name="variableType">variableType</var>.</li>
 <li>Return <span class="spec-call"><a href="#AreTypesCompatible()" data-name="AreTypesCompatible">AreTypesCompatible</a>(<var data-name="nullableVariableType">nullableVariableType</var>, <var data-name="locationType">locationType</var>)</span>.</li>
 </ol>
@@ -5670,7 +5670,7 @@ While each subscription must have exactly one root field, a document may contain
 <section id="sec-All-Variable-Usages-are-Allowed.Explanatory-Text" class="subsec">
 <h6><a href="#sec-All-Variable-Usages-are-Allowed.Explanatory-Text" title="link to this subsection">Explanatory Text</a></h6>
 <p>Variable usages must be compatible with the arguments they are passed to.</p>
-<p>Validation failures occur when variables are used in the context of types that are complete mismatches, or if a nullable type in a variable is passed to a non&#8208;null argument type.</p>
+<p>Validation failures occur when variables are used in the context of types that are complete mismatches, or if a nullable type in a variable is passed to a non-null argument type.</p>
 <p>Types must match:</p>
 <pre id="example-2028e" class="spec-counter-example" data-language="graphql"><a href="#example-2028e">Counter Example № 176</a><code><span class="token keyword">query</span> intCannotGoIntoBoolean<span class="token punctuation">(</span><span class="token variable">$intArg</span><span class="token punctuation">:</span> Int<span class="token punctuation">)</span> <span class="token punctuation">{</span>
   arguments <span class="token punctuation">{</span>
@@ -5686,21 +5686,21 @@ While each subscription must have exactly one root field, a document may contain
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>Nullability must also be respected. In general a nullable variable cannot be passed to a non&#8208;null argument.</p>
+<p>Nullability must also be respected. In general a nullable variable cannot be passed to a non-null argument.</p>
 <pre id="example-ed727" class="spec-counter-example" data-language="graphql"><a href="#example-ed727">Counter Example № 178</a><code><span class="token keyword">query</span> booleanArgQuery<span class="token punctuation">(</span><span class="token variable">$booleanArg</span><span class="token punctuation">:</span> Boolean<span class="token punctuation">)</span> <span class="token punctuation">{</span>
   arguments <span class="token punctuation">{</span>
     nonNullBooleanArgField<span class="token punctuation">(</span><span class="token attr-name">nonNullBooleanArg</span><span class="token punctuation">:</span> <span class="token variable">$booleanArg</span><span class="token punctuation">)</span>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>For list types, the same rules around nullability apply to both outer types and inner types. A nullable list cannot be passed to a non&#8208;null list, and a list of nullable values cannot be passed to a list of non&#8208;null values. The following is valid:</p>
+<p>For list types, the same rules around nullability apply to both outer types and inner types. A nullable list cannot be passed to a non-null list, and a list of nullable values cannot be passed to a list of non-null values. The following is valid:</p>
 <pre id="example-c5959" class="spec-example" data-language="graphql"><a href="#example-c5959">Example № 179</a><code><span class="token keyword">query</span> nonNullListToList<span class="token punctuation">(</span><span class="token variable">$nonNullBooleanList</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>Boolean<span class="token punctuation">]</span><span class="token operator">!</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   arguments <span class="token punctuation">{</span>
     booleanListArgField<span class="token punctuation">(</span><span class="token attr-name">booleanListArg</span><span class="token punctuation">:</span> <span class="token variable">$nonNullBooleanList</span><span class="token punctuation">)</span>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>However, a nullable list cannot be passed to a non&#8208;null list:</p>
+<p>However, a nullable list cannot be passed to a non-null list:</p>
 <pre id="example-64255" class="spec-counter-example" data-language="graphql"><a href="#example-64255">Counter Example № 180</a><code><span class="token keyword">query</span> listToNonNullList<span class="token punctuation">(</span><span class="token variable">$booleanList</span><span class="token punctuation">:</span> <span class="token punctuation">[</span>Boolean<span class="token punctuation">]</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   arguments <span class="token punctuation">{</span>
     nonNullBooleanListField<span class="token punctuation">(</span><span class="token attr-name">nonNullBooleanListArg</span><span class="token punctuation">:</span> <span class="token variable">$booleanList</span><span class="token punctuation">)</span>
@@ -5711,24 +5711,24 @@ While each subscription must have exactly one root field, a document may contain
 </section>
 <section id="sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist" class="subsec">
 <h6><a href="#sec-All-Variable-Usages-are-Allowed.Allowing-optional-variables-when-default-values-exist" title="link to this subsection">Allowing optional variables when default values exist</a></h6>
-<p>A notable exception to typical variable type compatibility is allowing a variable definition with a nullable type to be provided to a non&#8208;null location as long as either that variable or that location provides a default value.</p>
-<p>In the example below, an optional variable <code>$booleanArg</code> is allowed to be used in the non&#8208;null argument <code>optionalBooleanArg</code> because the field argument is optional since it provides a default value in the schema.</p>
+<p>A notable exception to typical variable type compatibility is allowing a variable definition with a nullable type to be provided to a non-null location as long as either that variable or that location provides a default value.</p>
+<p>In the example below, an optional variable <code>$booleanArg</code> is allowed to be used in the non-null argument <code>optionalBooleanArg</code> because the field argument is optional since it provides a default value in the schema.</p>
 <pre id="example-0877c" class="spec-example" data-language="graphql"><a href="#example-0877c">Example № 181</a><code><span class="token keyword">query</span> booleanArgQueryWithDefault<span class="token punctuation">(</span><span class="token variable">$booleanArg</span><span class="token punctuation">:</span> Boolean<span class="token punctuation">)</span> <span class="token punctuation">{</span>
   arguments <span class="token punctuation">{</span>
     optionalNonNullBooleanArgField<span class="token punctuation">(</span><span class="token attr-name">optionalBooleanArg</span><span class="token punctuation">:</span> <span class="token variable">$booleanArg</span><span class="token punctuation">)</span>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>In the example below, an optional variable <code>$booleanArg</code> is allowed to be used in the non&#8208;null argument (<code>nonNullBooleanArg</code>) because the variable provides a default value in the query. This behavior is explicitly supported for compatibility with earlier editions of this specification. GraphQL authoring tools may wish to report this as a warning with the suggestion to replace <code>Boolean</code> with <code>Boolean!</code> to avoid ambiguity.</p>
+<p>In the example below, an optional variable <code>$booleanArg</code> is allowed to be used in the non-null argument (<code>nonNullBooleanArg</code>) because the variable provides a default value in the query. This behavior is explicitly supported for compatibility with earlier editions of this specification. GraphQL authoring tools may wish to report this as a warning with the suggestion to replace <code>Boolean</code> with <code>Boolean!</code> to avoid ambiguity.</p>
 <pre id="example-d24d9" class="spec-example" data-language="graphql"><a href="#example-d24d9">Example № 182</a><code><span class="token keyword">query</span> booleanArgQueryWithDefault<span class="token punctuation">(</span><span class="token variable">$booleanArg</span><span class="token punctuation">:</span> Boolean <span class="token operator">=</span> <span class="token boolean">true</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   arguments <span class="token punctuation">{</span>
     nonNullBooleanArgField<span class="token punctuation">(</span><span class="token attr-name">nonNullBooleanArg</span><span class="token punctuation">:</span> <span class="token variable">$booleanArg</span><span class="token punctuation">)</span>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<div id="note-1c146" class="spec-note">
-<a href="#note-1c146">Note</a>
-The value <span class="spec-keyword">null</span> could still be provided to such a variable at runtime. A non&#8208;null argument must produce a field error if provided a <span class="spec-keyword">null</span> value. </div>
+<div id="note-e4471" class="spec-note">
+<a href="#note-e4471">Note</a>
+The value <span class="spec-keyword">null</span> could still be provided to such a variable at runtime. A non-null argument must produce a field error if provided a <span class="spec-keyword">null</span> value. </div>
 </section>
 </section>
 </section>
@@ -5808,7 +5808,7 @@ The value <span class="spec-keyword">null</span> could still be provided to such
 <li>Add an entry to <var data-name="coercedValues">coercedValues</var> named <var data-name="variableName">variableName</var> with the value <var data-name="defaultValue">defaultValue</var>.</li>
 </ol>
 </li>
-<li>Otherwise if <var data-name="variableType">variableType</var> is a Non&#8208;Nullable type, and either <var data-name="hasValue">hasValue</var> is not <span class="spec-keyword">true</span> or <var data-name="value">value</var> is <span class="spec-keyword">null</span>, throw a query error.</li>
+<li>Otherwise if <var data-name="variableType">variableType</var> is a Non-Nullable type, and either <var data-name="hasValue">hasValue</var> is not <span class="spec-keyword">true</span> or <var data-name="value">value</var> is <span class="spec-keyword">null</span>, throw a query error.</li>
 <li>Otherwise if <var data-name="hasValue">hasValue</var> is true:<ol>
 <li>If <var data-name="value">value</var> is <span class="spec-keyword">null</span>:<ol>
 <li>Add an entry to <var data-name="coercedValues">coercedValues</var> named <var data-name="variableName">variableName</var> with the value <span class="spec-keyword">null</span>.</li>
@@ -5853,7 +5853,7 @@ This algorithm is very similar to <span class="spec-call"><a href="#CoerceArgume
 <section id="sec-Mutation" secid="6.2.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Mutation">6.2.2</a></span>Mutation</h3>
 <p>If the operation is a mutation, the result of the operation is the result of executing the mutation&rsquo;s top level selection set on the mutation root object type. This selection set should be executed serially.</p>
-<p>It is expected that the top level fields in a mutation operation perform side&#8208;effects on the underlying data system. Serial execution of the provided mutations ensures against race conditions during these side&#8208;effects.</p>
+<p>It is expected that the top level fields in a mutation operation perform side-effects on the underlying data system. Serial execution of the provided mutations ensures against race conditions during these side-effects.</p>
 <div class="spec-algo" id="ExecuteMutation()">
 <span class="spec-call"><a href="#ExecuteMutation()" data-name="ExecuteMutation">ExecuteMutation</a>(<var data-name="mutation">mutation</var>, <var data-name="schema">schema</var>, <var data-name="variableValues">variableValues</var>, <var data-name="initialValue">initialValue</var>)</span><ol>
 <li>Let <var data-name="mutationType">mutationType</var> be the root Mutation type in <var data-name="schema">schema</var>.</li>
@@ -5897,10 +5897,10 @@ In large scale subscription systems, the <span class="spec-call"><a href="#Subsc
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
-<p>The &ldquo;new message posted to chat room&rdquo; could use a &ldquo;Pub&#8208;Sub&rdquo; system where the chat room ID is the &ldquo;topic&rdquo; and each &ldquo;publish&rdquo; contains the sender and text.</p>
+<p>The &ldquo;new message posted to chat room&rdquo; could use a &ldquo;Pub-Sub&rdquo; system where the chat room ID is the &ldquo;topic&rdquo; and each &ldquo;publish&rdquo; contains the sender and text.</p>
 <section id="sec-Subscription.Event-Streams" class="subsec">
 <h6><a href="#sec-Subscription.Event-Streams" title="link to this subsection">Event Streams</a></h6>
-<p>An event stream represents a sequence of discrete events over time which can be observed. As an example, a &ldquo;Pub&#8208;Sub&rdquo; system may produce an event stream when &ldquo;subscribing to a topic&rdquo;, with an event occurring on that event stream for each &ldquo;publish&rdquo; to that topic. Event streams may produce an infinite sequence of events or may complete at any point. Event streams may complete in response to an error or simply because no more events will occur. An observer may at any point decide to stop observing an event stream by cancelling it, after which it must receive no more events from that event stream.</p>
+<p>An event stream represents a sequence of discrete events over time which can be observed. As an example, a &ldquo;Pub-Sub&rdquo; system may produce an event stream when &ldquo;subscribing to a topic&rdquo;, with an event occurring on that event stream for each &ldquo;publish&rdquo; to that topic. Event streams may produce an infinite sequence of events or may complete at any point. Event streams may complete in response to an error or simply because no more events will occur. An observer may at any point decide to stop observing an event stream by cancelling it, after which it must receive no more events from that event stream.</p>
 </section>
 <section id="sec-Subscription.Supporting-Subscriptions-at-Scale" class="subsec">
 <h6><a href="#sec-Subscription.Supporting-Subscriptions-at-Scale" title="link to this subsection">Supporting Subscriptions at Scale</a></h6>
@@ -5913,7 +5913,7 @@ In large scale subscription systems, the <span class="spec-call"><a href="#Subsc
 </section>
 <section id="sec-Source-Stream" secid="6.2.3.1">
 <h4><span class="spec-secid" title="link to this section"><a href="#sec-Source-Stream">6.2.3.1</a></span>Source Stream</h4>
-<p>A Source Stream represents the sequence of events, each of which will trigger a GraphQL execution corresponding to that event. Like field value resolution, the logic to create a Source Stream is application&#8208;specific.</p>
+<p>A Source Stream represents the sequence of events, each of which will trigger a GraphQL execution corresponding to that event. Like field value resolution, the logic to create a Source Stream is application-specific.</p>
 <div class="spec-algo" id="CreateSourceEventStream()">
 <span class="spec-call"><a href="#CreateSourceEventStream()" data-name="CreateSourceEventStream">CreateSourceEventStream</a>(<var data-name="subscription">subscription</var>, <var data-name="schema">schema</var>, <var data-name="variableValues">variableValues</var>, <var data-name="initialValue">initialValue</var>)</span><ol>
 <li>Let <var data-name="subscriptionType">subscriptionType</var> be the root Subscription type in <var data-name="schema">schema</var>.</li>
@@ -6003,13 +6003,13 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 <var data-name="resultMap">resultMap</var> is ordered by which fields appear first in the query. This is explained in greater detail in the Field Collection section below.</div>
 <section id="sec-Executing-Selection-Sets.Errors-and-Non-Null-Fields" class="subsec">
 <h6><a href="#sec-Executing-Selection-Sets.Errors-and-Non-Null-Fields" title="link to this subsection">Errors and Non-Null Fields</a></h6>
-<p>If during <span class="spec-call"><a href="#ExecuteSelectionSet()" data-name="ExecuteSelectionSet">ExecuteSelectionSet</a>()</span> a field with a non&#8208;null <var data-name="fieldType">fieldType</var> throws a field error then that error must propagate to this entire selection set, either resolving to <span class="spec-keyword">null</span> if allowed or further propagated to a parent field.</p>
+<p>If during <span class="spec-call"><a href="#ExecuteSelectionSet()" data-name="ExecuteSelectionSet">ExecuteSelectionSet</a>()</span> a field with a non-null <var data-name="fieldType">fieldType</var> throws a field error then that error must propagate to this entire selection set, either resolving to <span class="spec-keyword">null</span> if allowed or further propagated to a parent field.</p>
 <p>If this occurs, any sibling fields which have not yet executed or have not yet yielded a value may be cancelled to avoid unnecessary work.</p>
-<p>See the <a href="#sec-Errors-and-Non-Nullability">Errors and Non&#8208;Nullability</a> section of Field Execution for more about this behavior.</p>
+<p>See the <a href="#sec-Errors-and-Non-Nullability">Errors and Non-Nullability</a> section of Field Execution for more about this behavior.</p>
 </section>
 <section id="sec-Normal-and-Serial-Execution" secid="6.3.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Normal-and-Serial-Execution">6.3.1</a></span>Normal and Serial Execution</h3>
-<p>Normally the executor can execute the entries in a grouped field set in whatever order it chooses (normally in parallel). Because the resolution of fields other than top&#8208;level mutation fields must always be side effect&#8208;free and idempotent, the execution order must not affect the result, and hence the service has the freedom to execute the field entries in whatever order it deems optimal.</p>
+<p>Normally the executor can execute the entries in a grouped field set in whatever order it chooses (normally in parallel). Because the resolution of fields other than top-level mutation fields must always be side effect-free and idempotent, the execution order must not affect the result, and hence the service has the freedom to execute the field entries in whatever order it deems optimal.</p>
 <p>For example, given the following grouped field set to be executed normally:</p>
 <pre id="example-65e7d" class="spec-example" data-language="graphql"><a href="#example-65e7d">Example № 185</a><code><span class="token punctuation">{</span>
   birthday <span class="token punctuation">{</span>
@@ -6035,8 +6035,8 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 </code></pre>
 <p>The executor must, in serial:</p>
 <ul>
-<li>Run <span class="spec-call"><a href="#ExecuteField()" data-name="ExecuteField">ExecuteField</a>()</span> for <code>changeBirthday</code>, which during <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>()</span> will execute the <code>{ month }</code> sub&#8208;selection set normally.</li>
-<li>Run <span class="spec-call"><a href="#ExecuteField()" data-name="ExecuteField">ExecuteField</a>()</span> for <code>changeAddress</code>, which during <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>()</span> will execute the <code>{ street }</code> sub&#8208;selection set normally.</li>
+<li>Run <span class="spec-call"><a href="#ExecuteField()" data-name="ExecuteField">ExecuteField</a>()</span> for <code>changeBirthday</code>, which during <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>()</span> will execute the <code>{ month }</code> sub-selection set normally.</li>
+<li>Run <span class="spec-call"><a href="#ExecuteField()" data-name="ExecuteField">ExecuteField</a>()</span> for <code>changeAddress</code>, which during <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>()</span> will execute the <code>{ street }</code> sub-selection set normally.</li>
 </ul>
 <p>As an illustrative example, let&rsquo;s assume we have a mutation field <code>changeTheNumber</code> that returns an object containing one field, <code>theNumber</code>. If we execute the following selection set serially:</p>
 <pre id="example-c91a3" class="spec-example" data-language="graphql"><a href="#example-c91a3">Example № 187</a><code><span class="token punctuation">{</span>
@@ -6054,11 +6054,11 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 <p>The executor will execute the following serially:</p>
 <ul>
 <li>Resolve the <code>changeTheNumber(newNumber: 1)</code> field</li>
-<li>Execute the <code>{ theNumber }</code> sub&#8208;selection set of <code>first</code> normally</li>
+<li>Execute the <code>{ theNumber }</code> sub-selection set of <code>first</code> normally</li>
 <li>Resolve the <code>changeTheNumber(newNumber: 3)</code> field</li>
-<li>Execute the <code>{ theNumber }</code> sub&#8208;selection set of <code>second</code> normally</li>
+<li>Execute the <code>{ theNumber }</code> sub-selection set of <code>second</code> normally</li>
 <li>Resolve the <code>changeTheNumber(newNumber: 2)</code> field</li>
-<li>Execute the <code>{ theNumber }</code> sub&#8208;selection set of <code>third</code> normally</li>
+<li>Execute the <code>{ theNumber }</code> sub-selection set of <code>third</code> normally</li>
 </ul>
 <p>A correct executor must generate the following result for that selection set:</p>
 <pre id="example-1d82c" class="spec-example" data-language="json"><a href="#example-1d82c">Example № 188</a><code><span class="token punctuation">{</span>
@@ -6092,7 +6092,7 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
   b
 <span class="token punctuation">}</span>
 </code></pre>
-<p>The depth&#8208;first&#8208;search order of the field groups produced by <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span> is maintained through execution, ensuring that fields appear in the executed response in a stable and predictable order.</p>
+<p>The depth-first-search order of the field groups produced by <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span> is maintained through execution, ensuring that fields appear in the executed response in a stable and predictable order.</p>
 <div class="spec-algo" id="CollectFields()">
 <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>(<var data-name="objectType">objectType</var>, <var data-name="selectionSet">selectionSet</var>, <var data-name="variableValues">variableValues</var>, <var data-name="visitedFragments">visitedFragments</var>)</span><ol>
 <li>If <var data-name="visitedFragments">visitedFragments</var> is not provided, initialize it to the empty set.</li>
@@ -6120,7 +6120,7 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 <li>If no such <var data-name="fragment">fragment</var> exists, continue with the next <var data-name="selection">selection</var> in <var data-name="selectionSet">selectionSet</var>.</li>
 <li>Let <var data-name="fragmentType">fragmentType</var> be the type condition on <var data-name="fragment">fragment</var>.</li>
 <li>If <span class="spec-call"><a href="#DoesFragmentTypeApply()" data-name="DoesFragmentTypeApply">DoesFragmentTypeApply</a>(<var data-name="objectType">objectType</var>, <var data-name="fragmentType">fragmentType</var>)</span> is false, continue with the next <var data-name="selection">selection</var> in <var data-name="selectionSet">selectionSet</var>.</li>
-<li>Let <var data-name="fragmentSelectionSet">fragmentSelectionSet</var> be the top&#8208;level selection set of <var data-name="fragment">fragment</var>.</li>
+<li>Let <var data-name="fragmentSelectionSet">fragmentSelectionSet</var> be the top-level selection set of <var data-name="fragment">fragment</var>.</li>
 <li>Let <var data-name="fragmentGroupedFieldSet">fragmentGroupedFieldSet</var> be the result of calling <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>(<var data-name="objectType">objectType</var>, <var data-name="fragmentSelectionSet">fragmentSelectionSet</var>, <var data-name="variableValues">variableValues</var>, <var data-name="visitedFragments">visitedFragments</var>)</span>.</li>
 <li>For each <var data-name="fragmentGroup">fragmentGroup</var> in <var data-name="fragmentGroupedFieldSet">fragmentGroupedFieldSet</var>:<ol>
 <li>Let <var data-name="responseKey">responseKey</var> be the response key shared by all fields in <var data-name="fragmentGroup">fragmentGroup</var>.</li>
@@ -6133,7 +6133,7 @@ The <span class="spec-call"><a href="#ExecuteSubscriptionEvent()" data-name="Exe
 <li>If <var data-name="selection">selection</var> is an <span class="spec-nt"><a href="#InlineFragment" data-name="InlineFragment">InlineFragment</a></span>:<ol>
 <li>Let <var data-name="fragmentType">fragmentType</var> be the type condition on <var data-name="selection">selection</var>.</li>
 <li>If <var data-name="fragmentType">fragmentType</var> is not <span class="spec-keyword">null</span> and <span class="spec-call"><a href="#DoesFragmentTypeApply()" data-name="DoesFragmentTypeApply">DoesFragmentTypeApply</a>(<var data-name="objectType">objectType</var>, <var data-name="fragmentType">fragmentType</var>)</span> is false, continue with the next <var data-name="selection">selection</var> in <var data-name="selectionSet">selectionSet</var>.</li>
-<li>Let <var data-name="fragmentSelectionSet">fragmentSelectionSet</var> be the top&#8208;level selection set of <var data-name="selection">selection</var>.</li>
+<li>Let <var data-name="fragmentSelectionSet">fragmentSelectionSet</var> be the top-level selection set of <var data-name="selection">selection</var>.</li>
 <li>Let <var data-name="fragmentGroupedFieldSet">fragmentGroupedFieldSet</var> be the result of calling <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>(<var data-name="objectType">objectType</var>, <var data-name="fragmentSelectionSet">fragmentSelectionSet</var>, <var data-name="variableValues">variableValues</var>, <var data-name="visitedFragments">visitedFragments</var>)</span>.</li>
 <li>For each <var data-name="fragmentGroup">fragmentGroup</var> in <var data-name="fragmentGroupedFieldSet">fragmentGroupedFieldSet</var>:<ol>
 <li>Let <var data-name="responseKey">responseKey</var> be the response key shared by all fields in <var data-name="fragmentGroup">fragmentGroup</var>.</li>
@@ -6208,7 +6208,7 @@ The steps in <span class="spec-call"><a href="#CollectFields()" data-name="Colle
 <li>Add an entry to <var data-name="coercedValues">coercedValues</var> named <var data-name="argumentName">argumentName</var> with the value <var data-name="defaultValue">defaultValue</var>.</li>
 </ol>
 </li>
-<li>Otherwise if <var data-name="argumentType">argumentType</var> is a Non&#8208;Nullable type, and either <var data-name="hasValue">hasValue</var> is not <span class="spec-keyword">true</span> or <var data-name="value">value</var> is <span class="spec-keyword">null</span>, throw a field error.</li>
+<li>Otherwise if <var data-name="argumentType">argumentType</var> is a Non-Nullable type, and either <var data-name="hasValue">hasValue</var> is not <span class="spec-keyword">true</span> or <var data-name="value">value</var> is <span class="spec-keyword">null</span>, throw a field error.</li>
 <li>Otherwise if <var data-name="hasValue">hasValue</var> is true:<ol>
 <li>If <var data-name="value">value</var> is <span class="spec-keyword">null</span>:<ol>
 <li>Add an entry to <var data-name="coercedValues">coercedValues</var> named <var data-name="argumentName">argumentName</var> with the value <span class="spec-keyword">null</span>.</li>
@@ -6254,7 +6254,7 @@ It is common for <var data-name="resolver">resolver</var> to be asynchronous due
 <p>After resolving the value for a field, it is completed by ensuring it adheres to the expected return type. If the return type is another Object type, then the field execution process continues recursively.</p>
 <div class="spec-algo" id="CompleteValue()">
 <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>(<var data-name="fieldType">fieldType</var>, <var data-name="fields">fields</var>, <var data-name="result">result</var>, <var data-name="variableValues">variableValues</var>)</span><ol>
-<li>If the <var data-name="fieldType">fieldType</var> is a Non&#8208;Null type:<ol>
+<li>If the <var data-name="fieldType">fieldType</var> is a Non-Null type:<ol>
 <li>Let <var data-name="innerType">innerType</var> be the inner type of <var data-name="fieldType">fieldType</var>.</li>
 <li>Let <var data-name="completedResult">completedResult</var> be the result of calling <span class="spec-call"><a href="#CompleteValue()" data-name="CompleteValue">CompleteValue</a>(<var data-name="innerType">innerType</var>, <var data-name="fields">fields</var>, <var data-name="result">result</var>, <var data-name="variableValues">variableValues</var>)</span>.</li>
 <li>If <var data-name="completedResult">completedResult</var> is <span class="spec-keyword">null</span>, throw a field error.</li>
@@ -6290,9 +6290,9 @@ It is common for <var data-name="resolver">resolver</var> to be asynchronous due
 <section id="sec-Value-Completion.Resolving-Abstract-Types" class="subsec">
 <h6><a href="#sec-Value-Completion.Resolving-Abstract-Types" title="link to this subsection">Resolving Abstract Types</a></h6>
 <p>When completing a field with an abstract return type, that is an Interface or Union return type, first the abstract type must be resolved to a relevant Object type. This determination is made by the internal system using whatever means appropriate.</p>
-<div id="note-0d705" class="spec-note">
-<a href="#note-0d705">Note</a>
-A common method of determining the Object type for an <var data-name="objectValue">objectValue</var> in object&#8208;oriented environments, such as Java or C#, is to use the class name of the <var data-name="objectValue">objectValue</var>.</div>
+<div id="note-5ee58" class="spec-note">
+<a href="#note-5ee58">Note</a>
+A common method of determining the Object type for an <var data-name="objectValue">objectValue</var> in object-oriented environments, such as Java or C#, is to use the class name of the <var data-name="objectValue">objectValue</var>.</div>
 <div class="spec-algo" id="ResolveAbstractType()">
 <span class="spec-call"><a href="#ResolveAbstractType()" data-name="ResolveAbstractType">ResolveAbstractType</a>(<var data-name="abstractType">abstractType</var>, <var data-name="objectValue">objectValue</var>)</span><ol>
 <li>Return the result of calling the internal method provided by the type system for determining the Object type of <var data-name="abstractType">abstractType</var> given the value <var data-name="objectValue">objectValue</var>.</li>
@@ -6301,8 +6301,8 @@ A common method of determining the Object type for an <var data-name="objectValu
 </section>
 <section id="sec-Value-Completion.Merging-Selection-Sets" class="subsec">
 <h6><a href="#sec-Value-Completion.Merging-Selection-Sets" title="link to this subsection">Merging Selection Sets</a></h6>
-<p>When more than one field of the same name is executed in parallel, their selection sets are merged together when completing the value in order to continue execution of the sub&#8208;selection sets.</p>
-<p>An example query illustrating parallel fields with the same name with sub&#8208;selections.</p>
+<p>When more than one field of the same name is executed in parallel, their selection sets are merged together when completing the value in order to continue execution of the sub-selection sets.</p>
+<p>An example query illustrating parallel fields with the same name with sub-selections.</p>
 <pre id="example-77852" class="spec-example" data-language="graphql"><a href="#example-77852">Example № 190</a><code><span class="token punctuation">{</span>
   me <span class="token punctuation">{</span>
     firstName
@@ -6340,7 +6340,7 @@ A common method of determining the Object type for an <var data-name="objectValu
 </section>
 <section id="sec-Response" secid="7">
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Response">7</a></span>Response</h1>
-<p>When a GraphQL service receives a request, it must return a well&#8208;formed response. The service&rsquo;s response describes the result of executing the requested operation if successful, and describes any errors encountered during the request.</p>
+<p>When a GraphQL service receives a request, it must return a well-formed response. The service&rsquo;s response describes the result of executing the requested operation if successful, and describes any errors encountered during the request.</p>
 <p>A response may contain both a partial response as well as encountered errors in the case that a field error occurred on a field which was replaced with <span class="spec-keyword">null</span>.</p>
 <section id="sec-Response-Format" secid="7.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Response-Format">7.1</a></span>Response Format</h2>
@@ -6360,7 +6360,7 @@ When <code>errors</code> is present in the response, it may be helpful for it to
 </section>
 <section id="sec-Errors" secid="7.1.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Errors">7.1.2</a></span>Errors</h3>
-<p>The <code>errors</code> entry in the response is a non&#8208;empty list of errors, where each error is a map.</p>
+<p>The <code>errors</code> entry in the response is a non-empty list of errors, where each error is a map.</p>
 <p>If no errors were encountered during the requested operation, the <code>errors</code> entry should not be present in the result.</p>
 <p>If the <code>data</code> entry in the response is not present, the <code>errors</code> entry in the response must not be empty. It must contain at least one error. The errors it contains should indicate why no data was able to be returned.</p>
 <p>If the <code>data</code> entry in the response is present (including if it is the value <span class="spec-keyword">null</span>), the <code>errors</code> entry in the response may contain any errors that occurred during execution. If errors occurred during execution, it should contain those errors.</p>
@@ -6369,7 +6369,7 @@ When <code>errors</code> is present in the response, it may be helpful for it to
 <p>Every error must contain an entry with the key <code>message</code> with a string description of the error intended for the developer as a guide to understand and correct the error.</p>
 <p>If an error can be associated to a particular point in the requested GraphQL document, it should contain an entry with the key <code>locations</code> with a list of locations, where each location is a map with the keys <code>line</code> and <code>column</code>, both positive numbers starting from <code>1</code> which describe the beginning of an associated syntax element.</p>
 <p>If an error can be associated to a particular field in the GraphQL result, it must contain an entry with the key <code>path</code> that details the path of the response field which experienced the error. This allows clients to identify whether a <code>null</code> result is intentional or caused by a runtime error.</p>
-<p>This field should be a list of path segments starting at the root of the response and ending with the field associated with the error. Path segments that represent fields should be strings, and path segments that represent list indices should be 0&#8208;indexed integers. If the error happens in an aliased field, the path to the error should use the aliased name, since it represents a path in the response, not in the query.</p>
+<p>This field should be a list of path segments starting at the root of the response and ending with the field associated with the error. Path segments that represent fields should be strings, and path segments that represent list indices should be 0-indexed integers. If the error happens in an aliased field, the path to the error should use the aliased name, since it represents a path in the response, not in the query.</p>
 <p>For example, if fetching one of the friends&rsquo; names fails in the following query:</p>
 <pre id="example-bc485" class="spec-example" data-language="graphql"><a href="#example-bc485">Example № 191</a><code><span class="token punctuation">{</span>
   hero<span class="token punctuation">(</span><span class="token attr-name">episode</span><span class="token punctuation">:</span> <span class="token variable">$episode</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
@@ -6455,9 +6455,9 @@ When <code>errors</code> is present in the response, it may be helpful for it to
 <span class="token punctuation">}</span>
 </code></pre>
 <p>GraphQL services should not provide any additional entries to the error format since they could conflict with additional entries that may be added in future versions of this specification.</p>
-<div id="note-936fa" class="spec-note">
-<a href="#note-936fa">Note</a>
-Previous versions of this spec did not describe the <code>extensions</code> entry for error formatting. While non&#8208;specified entries are not violations, they are still discouraged.</div>
+<div id="note-5c13b" class="spec-note">
+<a href="#note-5c13b">Note</a>
+Previous versions of this spec did not describe the <code>extensions</code> entry for error formatting. While non-specified entries are not violations, they are still discouraged.</div>
 <pre id="example-9008d" class="spec-counter-example" data-language="json"><a href="#example-9008d">Counter Example № 195</a><code><span class="token punctuation">{</span>
   <span class="token property">"errors"</span><span class="token operator">:</span> <span class="token punctuation">[</span>
     <span class="token punctuation">{</span>
@@ -6526,8 +6526,8 @@ For consistency and ease of notation, examples of responses are given in JSON fo
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Serialized-Map-Ordering">7.2.2</a></span>Serialized Map Ordering</h3>
 <p>Since the result of evaluating a selection set is ordered, the serialized Map of results should preserve this order by writing the map entries in the same order as those fields were requested as defined by query execution. Producing a serialized response where fields are represented in the same order in which they appear in the request improves human readability during debugging and enables more efficient parsing of responses if the order of properties can be anticipated.</p>
 <p>Serialization formats which represent an ordered map should preserve the order of requested fields as defined by <span class="spec-call"><a href="#CollectFields()" data-name="CollectFields">CollectFields</a>()</span> in the Execution section. Serialization formats which only represent unordered maps but where order is still implicit in the serialization&rsquo;s textual order (such as JSON) should preserve the order of requested fields textually.</p>
-<p>For example, if the request was <code>{ name, age }</code>, a GraphQL service responding in JSON should respond with <code>{ &quot;name&quot;: &quot;Mark&quot;, &quot;age&quot;: 30 }</code> and should not respond with <code>{ &quot;age&quot;: 30, &quot;name&quot;: &quot;Mark&quot; }</code>.</p>
-<p>While JSON Objects are specified as an <a href="https://tools.ietf.org/html/rfc7159#section-4">unordered collection of key&#8208;value pairs</a> the pairs are represented in an ordered manner. In other words, while the JSON strings <code>{ &quot;name&quot;: &quot;Mark&quot;, &quot;age&quot;: 30 }</code> and <code>{ &quot;age&quot;: 30, &quot;name&quot;: &quot;Mark&quot; }</code> encode the same value, they also have observably different property orderings.</p>
+<p>For example, if the request was <code>{ name, age }</code>, a GraphQL service responding in JSON should respond with <code>{ "name": "Mark", "age": 30 }</code> and should not respond with <code>{ "age": 30, "name": "Mark" }</code>.</p>
+<p>While JSON Objects are specified as an <a href="https://tools.ietf.org/html/rfc7159#section-4">unordered collection of key-value pairs</a> the pairs are represented in an ordered manner. In other words, while the JSON strings <code>{ "name": "Mark", "age": 30 }</code> and <code>{ "age": 30, "name": "Mark" }</code> encode the same value, they also have observably different property orderings.</p>
 <div id="note-4bb20" class="spec-note">
 <a href="#note-4bb20">Note</a>
 This does not violate the JSON spec, as clients may still interpret objects in the response as unordered Maps and arrive at a valid value. </div>
@@ -6540,10 +6540,10 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 <p>This appendix seeks to explain these notations in greater detail to avoid ambiguity.</p>
 <section id="sec-Context-Free-Grammar" secid="A.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Context-Free-Grammar">A.1</a></span>Context-Free Grammar</h2>
-<p>A context&#8208;free grammar consists of a number of productions. Each production has an abstract symbol called a &ldquo;non&#8208;terminal&rdquo; as its left&#8208;hand side, and zero or more possible sequences of non&#8208;terminal symbols and or terminal characters as its right&#8208;hand side.</p>
-<p>Starting from a single goal non&#8208;terminal symbol, a context&#8208;free grammar describes a language: the set of possible sequences of characters that can be described by repeatedly replacing any non&#8208;terminal in the goal sequence with one of the sequences it is defined by, until all non&#8208;terminal symbols have been replaced by terminal characters.</p>
-<p>Terminals are represented in this document in a monospace font in two forms: a specific Unicode character or sequence of Unicode characters (ie. <span class="spec-t">=</span> or <span class="spec-t">terminal</span>), and prose typically describing a specific Unicode code&#8208;point <span class="spec-string">"Space (U+0020)"</span>. Sequences of Unicode characters only appear in syntactic grammars and represent a <span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span> token of that specific sequence.</p>
-<p>Non&#8208;terminal production rules are represented in this document using the following notation for a non&#8208;terminal with a single definition:</p>
+<p>A context-free grammar consists of a number of productions. Each production has an abstract symbol called a &ldquo;non-terminal&rdquo; as its left-hand side, and zero or more possible sequences of non-terminal symbols and or terminal characters as its right-hand side.</p>
+<p>Starting from a single goal non-terminal symbol, a context-free grammar describes a language: the set of possible sequences of characters that can be described by repeatedly replacing any non-terminal in the goal sequence with one of the sequences it is defined by, until all non-terminal symbols have been replaced by terminal characters.</p>
+<p>Terminals are represented in this document in a monospace font in two forms: a specific Unicode character or sequence of Unicode characters (ie. <span class="spec-t">=</span> or <span class="spec-t">terminal</span>), and prose typically describing a specific Unicode code-point <span class="spec-string">"Space (U+0020)"</span>. Sequences of Unicode characters only appear in syntactic grammars and represent a <span class="spec-nt"><a href="#Name" data-name="Name">Name</a></span> token of that specific sequence.</p>
+<p>Non-terminal production rules are represented in this document using the following notation for a non-terminal with a single definition:</p>
 <div class="spec-production" id="NonTerminalWithSingleDefinition">
 <span class="spec-nt"><a href="#NonTerminalWithSingleDefinition" data-name="NonTerminalWithSingleDefinition">NonTerminalWithSingleDefinition</a></span><div class="spec-rhs"><span class="spec-nt"><span data-name="NonTerminal">NonTerminal</span></span><span class="spec-t">terminal</span></div>
 </div>
@@ -6561,18 +6561,18 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 <section id="sec-Lexical-and-Syntactical-Grammar" secid="A.2">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Lexical-and-Syntactical-Grammar">A.2</a></span>Lexical and Syntactical Grammar</h2>
 <p>The GraphQL language is defined in a syntactic grammar where terminal symbols are tokens. Tokens are defined in a lexical grammar which matches patterns of source characters. The result of parsing a source text sequence of Unicode characters first produces a sequence of lexical tokens according to the lexical grammar which then produces abstract syntax tree (AST) according to the syntactical grammar.</p>
-<p>A lexical grammar production describes non&#8208;terminal &ldquo;tokens&rdquo; by patterns of terminal Unicode characters. No &ldquo;whitespace&rdquo; or other ignored characters may appear between any terminal Unicode characters in the lexical grammar production. A lexical grammar production is distinguished by a two colon <code>::</code> definition.</p>
+<p>A lexical grammar production describes non-terminal &ldquo;tokens&rdquo; by patterns of terminal Unicode characters. No &ldquo;whitespace&rdquo; or other ignored characters may appear between any terminal Unicode characters in the lexical grammar production. A lexical grammar production is distinguished by a two colon <code>::</code> definition.</p>
 <div class="spec-production d2" id="Word">
 <span class="spec-nt"><a href="#Word" data-name="Word">Word</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Letter" data-name="Letter">Letter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span></div>
 </div>
-<p>A Syntactical grammar production describes non&#8208;terminal &ldquo;rules&rdquo; by patterns of terminal Tokens. <span class="spec-nt"><a href="#WhiteSpace" data-name="WhiteSpace">WhiteSpace</a></span> and other <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> sequences may appear before or after any terminal <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span>. A syntactical grammar production is distinguished by a one colon <code>:</code> definition.</p>
+<p>A Syntactical grammar production describes non-terminal &ldquo;rules&rdquo; by patterns of terminal Tokens. <span class="spec-nt"><a href="#WhiteSpace" data-name="WhiteSpace">WhiteSpace</a></span> and other <span class="spec-nt"><a href="#Ignored" data-name="Ignored">Ignored</a></span> sequences may appear before or after any terminal <span class="spec-nt"><a href="#Token" data-name="Token">Token</a></span>. A syntactical grammar production is distinguished by a one colon <code>:</code> definition.</p>
 <div class="spec-production" id="Sentence">
 <span class="spec-nt"><a href="#Sentence" data-name="Sentence">Sentence</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><a href="#Word" data-name="Word">Word</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">.</span></div>
 </div>
 </section>
 <section id="sec-Grammar-Notation" secid="A.3">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Notation">A.3</a></span>Grammar Notation</h2>
-<p>This specification uses some additional notation to describe common patterns, such as optional or repeated patterns, or parameterized alterations of the definition of a non&#8208;terminal. This section explains these short&#8208;hand notations and their expanded definitions in the context&#8208;free grammar.</p>
+<p>This specification uses some additional notation to describe common patterns, such as optional or repeated patterns, or parameterized alterations of the definition of a non-terminal. This section explains these short-hand notations and their expanded definitions in the context-free grammar.</p>
 <section id="sec-Grammar-Notation.Constraints" class="subsec">
 <h6><a href="#sec-Grammar-Notation.Constraints" title="link to this subsection">Constraints</a></h6>
 <p>A grammar production may specify that certain expansions are not permitted by using the phrase &ldquo;but not&rdquo; and then indicating the expansions to be excluded.</p>
@@ -6651,13 +6651,13 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 <p>This specification describes the semantic value of many grammar productions in the form of a list of algorithmic steps.</p>
 <p>For example, this describes how a parser should interpret a string literal:</p>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">""</span></div>
 <ol>
 <li>Return an empty Unicode character sequence.</li>
 </ol>
 </div>
 <div class="spec-semantic d2">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">"</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">"</span></div>
 <ol>
 <li>Return the Unicode character sequence of all <span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span> Unicode character values.</li>
 </ol>
@@ -6665,7 +6665,7 @@ This does not violate the JSON spec, as clients may still interpret objects in t
 </section>
 <section id="sec-Algorithms" secid="A.5">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">A.5</a></span>Algorithms</h2>
-<p>This specification describes some algorithms used by the static and runtime semantics, they&rsquo;re defined in the form of a function&#8208;like syntax with the algorithm&rsquo;s name and the arguments it accepts along with a list of algorithmic steps to take in the order listed. Each step may establish references to other values, check various conditions, call other algorithms, and eventually return a value representing the outcome of the algorithm for the provided arguments.</p>
+<p>This specification describes some algorithms used by the static and runtime semantics, they&rsquo;re defined in the form of a function-like syntax with the algorithm&rsquo;s name and the arguments it accepts along with a list of algorithmic steps to take in the order listed. Each step may establish references to other values, check various conditions, call other algorithms, and eventually return a value representing the outcome of the algorithm for the provided arguments.</p>
 <p>For example, the following example describes an algorithm named <span class="spec-nt"><span data-name="Fibonacci">Fibonacci</span></span> which accepts a single argument <var data-name="number">number</var>. The algoritm&rsquo;s steps produce the next number in the Fibonacci sequence:</p>
 <div class="spec-algo" id="Fibonacci()">
 <span class="spec-call"><a href="#Fibonacci()" data-name="Fibonacci">Fibonacci</a>(<var data-name="number">number</var>)</span><ol>
@@ -6811,12 +6811,12 @@ Algorithms described in this document are written to be easy to understand. Impl
 </table></div></div>
 </div>
 <div class="spec-production d2" id="StringValue">
-<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">&quot;&quot;</span><span class="spec-lookahead not"><span class="spec-t">&quot;</span></span></div>
-<div class="spec-rhs"><span class="spec-t">&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">&quot;</span></div>
-<div class="spec-rhs"><span class="spec-t">&quot;&quot;&quot;</span><span class="spec-quantified"><span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">&quot;&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#StringValue" data-name="StringValue">StringValue</a></span><div class="spec-rhs"><span class="spec-t">""</span><span class="spec-lookahead not"><span class="spec-t">"</span></span></div>
+<div class="spec-rhs"><span class="spec-t">"</span><span class="spec-quantified"><span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-t">"</span></div>
+<div class="spec-rhs"><span class="spec-t">"""</span><span class="spec-quantified"><span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-t">"""</span></div>
 </div>
 <div class="spec-production d2" id="StringCharacter">
-<span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">&quot;</span><span class="spec-t">\</span><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
+<span class="spec-nt"><a href="#StringCharacter" data-name="StringCharacter">StringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">"</span><span class="spec-t">\</span><span class="spec-nt"><a href="#LineTerminator" data-name="LineTerminator">LineTerminator</a></span></span></span></div>
 <div class="spec-rhs"><span class="spec-t">\u</span><span class="spec-nt"><a href="#EscapedUnicode" data-name="EscapedUnicode">EscapedUnicode</a></span></div>
 <div class="spec-rhs"><span class="spec-t">\</span><span class="spec-nt"><a href="#EscapedCharacter" data-name="EscapedCharacter">EscapedCharacter</a></span></div>
 </div>
@@ -6826,12 +6826,12 @@ Algorithms described in this document are written to be easy to understand. Impl
 <div class="spec-production d2" id="EscapedCharacter">
 <span class="spec-nt"><a href="#EscapedCharacter" data-name="EscapedCharacter">EscapedCharacter</a></span><div class="spec-oneof"><div class="spec-oneof-grid"><table>
 <tr>
-<td class="spec-rhs"><span class="spec-t">&quot;</span></td><td class="spec-rhs"><span class="spec-t">\</span></td><td class="spec-rhs"><span class="spec-t">/</span></td><td class="spec-rhs"><span class="spec-t">b</span></td><td class="spec-rhs"><span class="spec-t">f</span></td><td class="spec-rhs"><span class="spec-t">n</span></td><td class="spec-rhs"><span class="spec-t">r</span></td><td class="spec-rhs"><span class="spec-t">t</span></td></tr>
+<td class="spec-rhs"><span class="spec-t">"</span></td><td class="spec-rhs"><span class="spec-t">\</span></td><td class="spec-rhs"><span class="spec-t">/</span></td><td class="spec-rhs"><span class="spec-t">b</span></td><td class="spec-rhs"><span class="spec-t">f</span></td><td class="spec-rhs"><span class="spec-t">n</span></td><td class="spec-rhs"><span class="spec-t">r</span></td><td class="spec-rhs"><span class="spec-t">t</span></td></tr>
 </table></div></div>
 </div>
 <div class="spec-production d2" id="BlockStringCharacter">
-<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">&quot;&quot;&quot;</span><span class="spec-t">\&quot;&quot;&quot;</span></span></span></div>
-<div class="spec-rhs"><span class="spec-t">\&quot;&quot;&quot;</span></div>
+<span class="spec-nt"><a href="#BlockStringCharacter" data-name="BlockStringCharacter">BlockStringCharacter</a></span><div class="spec-rhs"><span class="spec-constrained"><span class="spec-nt"><a href="#SourceCharacter" data-name="SourceCharacter">SourceCharacter</a></span><span class="spec-butnot"><span class="spec-t">"""</span><span class="spec-t">\"""</span></span></span></div>
+<div class="spec-rhs"><span class="spec-t">\"""</span></div>
 </div>
 <div id="note-5ad29" class="spec-note">
 <a href="#note-5ad29">Note</a>

--- a/test/productions/ast.json
+++ b/test/productions/ast.json
@@ -774,7 +774,7 @@
                 "contents": [
                   {
                     "type": "Text",
-                    "value": "Step\n"
+                    "value": "Step "
                   }
                 ]
               }

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -10,7 +10,7 @@
       "contents": [
         {
           "type": "Text",
-          "value": "Renders Markdown with some additions into an HTML format commonly used for\nwriting technical specification documents. Markdown additions include code\nsyntax highlighting, edit annotations, and the definition of algorithms and\ngrammar productions."
+          "value": "Renders Markdown with some additions into an HTML format commonly used for writing technical specification documents. Markdown additions include code syntax highlighting, edit annotations, and the definition of algorithms and grammar productions."
         }
       ]
     },
@@ -23,7 +23,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Spec Markdown is first and foremost Markdown. As such, it follows Markdown's\nphilosophy of intending to be as easy to read and easy to write as is feasible."
+              "value": "Spec Markdown is first and foremost Markdown. As such, it follows Markdown’s philosophy of intending to be as easy to read and easy to write as is feasible."
             }
           ]
         },
@@ -32,7 +32,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "In order to interoperate with other tools which use Markdown, Spec Markdown\ntries to add as little additional syntax as possible, instead preferring\nconventions. This means any documents written with Spec Markdown in mind should\nrender adequately by other Markdown renderers."
+              "value": "In order to interoperate with other tools which use Markdown, Spec Markdown tries to add as little additional syntax as possible, instead preferring conventions. This means any documents written with Spec Markdown in mind should render adequately by other Markdown renderers."
             }
           ]
         },
@@ -41,7 +41,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "To support the rendering additions of Spec Markdown, some features of Markdown\nmay be limited or removed. As an example, Spec Markdown is strict about the\norder and locations of headers in a document."
+              "value": "To support the rendering additions of Spec Markdown, some features of Markdown may be limited or removed. As an example, Spec Markdown is strict about the order and locations of headers in a document."
             }
           ]
         },
@@ -50,7 +50,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "This is not a normative spec for Spec Markdown, but just documentation of\nthis tool. Of course, written in Spec Markdown!"
+              "value": "This is not a normative spec for Spec Markdown, but just documentation of this tool. Of course, written in Spec Markdown!"
             }
           ]
         }
@@ -66,7 +66,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "To use Spec Markdown, just write Markdown files. There are some conventions used\nby Spec Markdown which you can read about in "
+              "value": "To use Spec Markdown, just write Markdown files. There are some conventions used by Spec Markdown which you can read about in "
             },
             {
               "type": "Link",
@@ -97,7 +97,7 @@
             },
             {
               "type": "Text",
-              "value": "\nutility."
+              "value": " utility."
             }
           ]
         },
@@ -147,7 +147,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Spec Markdown also provides utilities for generating and operating on an\nintermediate representation of the markdown, which you can explore in\n"
+              "value": "Spec Markdown also provides utilities for generating and operating on an intermediate representation of the markdown, which you can explore in "
             },
             {
               "type": "Link",
@@ -191,7 +191,7 @@
             },
             {
               "type": "Text",
-              "value": ".\nMore specifically, it's based on "
+              "value": ". More specifically, it’s based on "
             },
             {
               "type": "Link",
@@ -214,7 +214,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "This section explains the syntax and capabilities of Markdown that Spec Markdown\nsupports and augments."
+              "value": "This section explains the syntax and capabilities of Markdown that Spec Markdown supports and augments."
             }
           ]
         },
@@ -228,7 +228,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Markdown allows you to write text which uses &, <, and >. The output HTML will\nautomatically use the "
+                  "value": "Markdown allows you to write text which uses &, <, and >. The output HTML will automatically use the "
                 },
                 {
                   "type": "InlineCode",
@@ -269,7 +269,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ",\nit will appear in the HTML output as &copy;."
+                  "value": ", it will appear in the HTML output as &copy;."
                 }
               ]
             },
@@ -283,7 +283,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Markdown makes use of certain characters to format text, in order to render one\nexplicitly, place a backslash before it."
+                      "value": "Markdown makes use of certain characters to format text, in order to render one explicitly, place a backslash before it."
                     }
                   ]
                 },
@@ -292,7 +292,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "You can type *literal asterisks* instead of emphasis by typing\n"
+                      "value": "You can type *literal asterisks* instead of emphasis by typing "
                     },
                     {
                       "type": "InlineCode",
@@ -362,7 +362,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Markdown allows for inline stylistic and structual formatting. Inline\nformatting is allowed in paragraphs, list items, and table cells."
+                  "value": "Markdown allows for inline stylistic and structual formatting. Inline formatting is allowed in paragraphs, list items, and table cells."
                 }
               ]
             },
@@ -376,7 +376,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Markdown is not a replacement for HTML and instead leverages HTML by allowing\nits use inline within paragraphs, links, etc."
+                      "value": "Markdown is not a replacement for HTML and instead leverages HTML by allowing its use inline within paragraphs, links, etc."
                     }
                   ]
                 },
@@ -487,7 +487,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\nparenthesis to describe the URL the text will link to."
+                      "value": " parenthesis to describe the URL the text will link to."
                     }
                   ]
                 },
@@ -529,7 +529,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "-->"
+                          "value": "→"
                         },
                         {
                           "type": "Italic",
@@ -542,7 +542,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": "<--"
+                          "value": "←"
                         }
                       ],
                       "url": "https://www.facebook.com"
@@ -792,7 +792,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " indicate inline code, text inside back-ticks is not\nformatted, allowing for special characters to be used in inline code without\nescapes."
+                      "value": " indicate inline code, text inside back-ticks is not formatted, allowing for special characters to be used in inline code without escapes."
                     }
                   ]
                 },
@@ -895,7 +895,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Also, consider using images for support of more complex features like\ngraph diagrams. For example, with Graviso:"
+                      "value": "Also, consider using images for support of more complex features like graph diagrams. For example, with Graviso:"
                     }
                   ]
                 },
@@ -949,7 +949,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Markdown allows for block-level structual formatting. Every block is seperated\nby at least two new lines. Spec Markdown makes use of Markdown's blocks to\nproduce more specific structural formatting."
+                  "value": "Markdown allows for block-level structual formatting. Every block is seperated by at least two new lines. Spec Markdown makes use of Markdown’s blocks to produce more specific structural formatting."
                 }
               ]
             },
@@ -963,7 +963,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Markdown is not a replacement for HTML and instead leverages HTML by allowing\nits use as complete blocks when separated from surrounding content by blank\nlines."
+                      "value": "Markdown is not a replacement for HTML and instead leverages HTML by allowing its use as complete blocks when separated from surrounding content by blank lines."
                     }
                   ]
                 },
@@ -1067,7 +1067,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Regular Markdown supports two styles of headers, Setext and atx, however Spec\nMarkdown generally only supports atx style headers."
+                      "value": "Regular Markdown supports two styles of headers, Setext and atx, however Spec Markdown generally only supports atx style headers."
                     }
                   ]
                 },
@@ -1109,7 +1109,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " characters refers to the depth of the section. To produce an,\n"
+                      "value": " characters refers to the depth of the section. To produce an, "
                     },
                     {
                       "type": "InlineCode",
@@ -1125,7 +1125,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". Optionally, a header may be \"closed\" by any number of "
+                      "value": ". Optionally, a header may be “closed” by any number of "
                     },
                     {
                       "type": "InlineCode",
@@ -1133,7 +1133,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ncharacters."
+                      "value": " characters."
                     }
                   ]
                 },
@@ -1150,7 +1150,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and that each section\ncontained within is only one level deeper. An <h1> section may only contain\n<h2> sections."
+                      "value": " and that each section contained within is only one level deeper. An <h1> section may only contain <h2> sections."
                     }
                   ]
                 }
@@ -1166,7 +1166,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Paragraphs are the most simple Markdown blocks. Lines are appended together to\nform a single <p> tag. Any inline syntax is allowed within a paragraph."
+                      "value": "Paragraphs are the most simple Markdown blocks. Lines are appended together to form a single <p> tag. Any inline syntax is allowed within a paragraph."
                     }
                   ]
                 }
@@ -1190,7 +1190,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " or\nunordered bullet, "
+                      "value": " or unordered bullet, "
                     },
                     {
                       "type": "InlineCode",
@@ -1327,7 +1327,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " to\nrender a checkbox. This can be useful for keeping your tasks inline with\nin-progress draft specifications."
+                          "value": " to render a checkbox. This can be useful for keeping your tasks inline with in-progress draft specifications."
                         }
                       ]
                     },
@@ -1422,7 +1422,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A block of code is formed by either indenting by 4 spaces, or wrapping with\n"
+                      "value": "A block of code is formed by either indenting by 4 spaces, or wrapping with "
                     },
                     {
                       "type": "HTMLTag",
@@ -1475,7 +1475,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Spec markdown does not yet support Markdown's "
+                      "value": "Spec markdown does not yet support Markdown’s "
                     },
                     {
                       "type": "InlineCode",
@@ -1499,7 +1499,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Spec Markdown does not yet support Markdown's "
+                      "value": "Spec Markdown does not yet support Markdown’s "
                     },
                     {
                       "type": "InlineCode",
@@ -1523,7 +1523,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Spec Markdown does not yet automatically link urls.\n"
+                      "value": "Spec Markdown does not yet automatically link urls. "
                     }
                   ]
                 }
@@ -1543,7 +1543,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Spec Markdown makes some additions to Markdown to support cases relevant to\nwriting technical specs and documentation. It attempts to be as minimally\ninvasive as possible, leveraging existing Markdown formatting features whenever\npossible so Spec Markdown documents may render adequately as regular Markdown."
+              "value": "Spec Markdown makes some additions to Markdown to support cases relevant to writing technical specs and documentation. It attempts to be as minimally invasive as possible, leveraging existing Markdown formatting features whenever possible so Spec Markdown documents may render adequately as regular Markdown."
             }
           ]
         },
@@ -1552,7 +1552,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Spec Markdown also makes restrictions to the overall format of the Markdown\ndocument in order to derive a structure to the entire document."
+              "value": "Spec Markdown also makes restrictions to the overall format of the Markdown document in order to derive a structure to the entire document."
             }
           ]
         },
@@ -1566,7 +1566,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Everything unique in a Spec Markdown file has a link created for it. Sections\neach have a link, as do named "
+                  "value": "Everything unique in a Spec Markdown file has a link created for it. Sections each have a link, as do named "
                 },
                 {
                   "type": "Link",
@@ -1580,7 +1580,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " and\n"
+                  "value": " and "
                 },
                 {
                   "type": "Link",
@@ -1594,7 +1594,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": ". You'll find that "
+                  "value": ". You’ll find that "
                 },
                 {
                   "type": "Link",
@@ -1608,7 +1608,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " and\n"
+                  "value": " and "
                 },
                 {
                   "type": "Link",
@@ -1622,7 +1622,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " are also given stable links based on their contents,\njust in case things move around."
+                  "value": " are also given stable links based on their contents, just in case things move around."
                 }
               ]
             },
@@ -1644,7 +1644,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " in a Spec Markdown file. Just highlight\nany bit of text and a link will be created just for that selection, making\nreferencing specific parts of your document easy. Try it here!"
+                  "value": " in a Spec Markdown file. Just highlight any bit of text and a link will be created just for that selection, making referencing specific parts of your document easy. Try it here!"
                 }
               ]
             }
@@ -1660,7 +1660,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A Spec Markdown document must start with a header which will be used as the\ntitle of the document. Any content between this and the next header will become\nthe introduction to the document."
+                  "value": "A Spec Markdown document must start with a header which will be used as the title of the document. Any content between this and the next header will become the introduction to the document."
                 }
               ]
             },
@@ -1686,7 +1686,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "For backwards-compatibility, a setext style header can be used for a\ndocument title."
+                  "value": "For backwards-compatibility, a setext style header can be used for a document title."
                 }
               ]
             }
@@ -1702,7 +1702,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "A Spec Markdown document is separated into a sequence and hierarchy of sections.\nThose sections can then be used as navigation points and can be used to create\na table of contents. A section is started by a header and ends at either the\nnext header of similar or greater precedence or the end of the document. A\nsection can contain other sections if their headers are of lower precedence."
+                  "value": "A Spec Markdown document is separated into a sequence and hierarchy of sections. Those sections can then be used as navigation points and can be used to create a table of contents. A section is started by a header and ends at either the next header of similar or greater precedence or the end of the document. A section can contain other sections if their headers are of lower precedence."
                 }
               ]
             },
@@ -1716,7 +1716,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Regular Markdown supports two styles of headers, Setext and atx, however Spec\nMarkdown only supports atx style headers as section headers."
+                      "value": "Regular Markdown supports two styles of headers, Setext and atx, however Spec Markdown only supports atx style headers as section headers."
                     }
                   ]
                 },
@@ -1758,7 +1758,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " headers appear at the top of a\ndocument, and that only a "
+                      "value": " headers appear at the top of a document, and that only a "
                     },
                     {
                       "type": "InlineCode",
@@ -1774,7 +1774,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " header) can be contained\nwith the section started by a "
+                      "value": " header) can be contained with the section started by a "
                     },
                     {
                       "type": "InlineCode",
@@ -1798,7 +1798,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "While sections are numbered and appear in the table of contents, a subsection\nis similar but not numbered or in the table of contents."
+                      "value": "While sections are numbered and appear in the table of contents, a subsection is similar but not numbered or in the table of contents."
                     }
                   ]
                 },
@@ -1811,7 +1811,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "The subsection's content appears below the subsection header."
+                          "value": "The subsection’s content appears below the subsection header."
                         }
                       ]
                     }
@@ -1826,7 +1826,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "Sections may contain multiple subsections, but subsections cannot contain\nsections or subsections."
+                          "value": "Sections may contain multiple subsections, but subsections cannot contain sections or subsections."
                         }
                       ]
                     }
@@ -1844,7 +1844,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A table of contents is automatically generated from the hierarchy of sections in\nthe Spec Markdown document."
+                      "value": "A table of contents is automatically generated from the hierarchy of sections in the Spec Markdown document."
                     }
                   ]
                 }
@@ -1860,7 +1860,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "A number is associated with each section, starting with 1. In a hierarchy of\nsections, the parent sections are joined with dots. This provides an unambiguous\nlocation identifier for a given section in a document."
+                      "value": "A number is associated with each section, starting with 1. In a hierarchy of sections, the parent sections are joined with dots. This provides an unambiguous location identifier for a given section in a document."
                     }
                   ]
                 },
@@ -1869,7 +1869,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "You can specify these section numbers directly in your Markdown documents if you\nwish by writing them directly after the "
+                      "value": "You can specify these section numbers directly in your Markdown documents if you wish by writing them directly after the "
                     },
                     {
                       "type": "InlineCode",
@@ -1896,7 +1896,7 @@
                       "contents": [
                         {
                           "type": "Text",
-                          "value": "If the section number is written in the document, the last number will be used\nas the number for that section. This is useful when writing a proposal against\nan existing spec and wish to reference a particular section."
+                          "value": "If the section number is written in the document, the last number will be used as the number for that section. This is useful when writing a proposal against an existing spec and wish to reference a particular section."
                         }
                       ]
                     },
@@ -1937,7 +1937,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " instead of a\nnumber, that will begin an Appendix section."
+                          "value": " instead of a number, that will begin an Appendix section."
                         }
                       ]
                     },
@@ -1965,7 +1965,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "The Spec Markdown renderer will replace easy to type characters like quotes and\ndashes with their appropriate typographic entities. These replacements will not\noccur within blocks of code."
+                  "value": "The Spec Markdown renderer will replace easy to type characters like quotes and dashes with their appropriate typographic entities. These replacements will not occur within blocks of code."
                 }
               ]
             },
@@ -1979,7 +1979,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Prose text has \"smart quotes\", hyphens, en-dashes and em-dashes--you shouldn't\nhave to think about it, they'll just work."
+                      "value": "Prose text has “smart quotes”, hyphens, en-dashes and em-dashes—you shouldn’t have to think about it, they’ll just work."
                     }
                   ]
                 },
@@ -2015,7 +2015,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "\"She told me that 'he isn't here right "
+                      "value": "“She told me that ‘he isn’t here right "
                     },
                     {
                       "type": "Italic",
@@ -2028,7 +2028,24 @@
                     },
                     {
                       "type": "Text",
-                      "value": "' - so I left.\""
+                      "value": "’ – so I left.”"
+                    }
+                  ]
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Escaped "
+                    },
+                    {
+                      "type": "InlineCode",
+                      "code": "\\\"quotes \\'and single\\-quotes\\'\\\""
+                    },
+                    {
+                      "type": "Text",
+                      "value": " becomes: \\“quotes \\‘and single-quotes'\"."
                     }
                   ]
                 }
@@ -2044,7 +2061,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Math operators like >=, <=, and ~= can be written as "
+                      "value": "Math operators like ≥, ≤, and ≈ can be written as "
                     },
                     {
                       "type": "InlineCode",
@@ -2071,6 +2088,23 @@
                       "value": "."
                     }
                   ]
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Escaped "
+                    },
+                    {
+                      "type": "InlineCode",
+                      "code": "\\>= \\<= \\~="
+                    },
+                    {
+                      "type": "Text",
+                      "value": " becomes: >= <= ~=."
+                    }
+                  ]
                 }
               ]
             },
@@ -2084,7 +2118,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Smart arrows -> and <- and <-> can be written as "
+                      "value": "Smart arrows → and ← and ↔ can be written as "
                     },
                     {
                       "type": "InlineCode",
@@ -2117,7 +2151,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Fat smart arrows => and <== and <=> can be written as "
+                      "value": "Fat smart arrows ⇒ and ⇐ and ⇔ can be written as "
                     },
                     {
                       "type": "InlineCode",
@@ -2142,6 +2176,23 @@
                     {
                       "type": "Text",
                       "value": "."
+                    }
+                  ]
+                },
+                {
+                  "type": "Paragraph",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "Escaped "
+                    },
+                    {
+                      "type": "InlineCode",
+                      "code": "\\-> \\<- \\<-> \\=> \\<== \\<=>"
+                    },
+                    {
+                      "type": "Text",
+                      "value": " becomes: -> <- <-> => <== <=>."
                     }
                   ]
                 }
@@ -2246,7 +2297,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Notes can be written inline with a spec document, and are often helpful to\nsupply non-normative explanatory text or caveats in a differently formatted\nstyle. Case insensitive, the "
+                  "value": "Notes can be written inline with a spec document, and are often helpful to supply non-normative explanatory text or caveats in a differently formatted style. Case insensitive, the "
                 },
                 {
                   "type": "InlineCode",
@@ -2263,7 +2314,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Notes automatically have short links generated for them. If the contents of the\nnote changes, so will the link URL. However if a note moves around, or content\naround the note changes the existing links will still point to the right place,\nvery useful for consistently evolving specifications!"
+                  "value": "Notes automatically have short links generated for them. If the contents of the note changes, so will the link URL. However if a note moves around, or content around the note changes the existing links will still point to the right place, very useful for consistently evolving specifications!"
                 }
               ]
             },
@@ -2305,7 +2356,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "It's often helpful to write a draft of a document and leave \"to-do\" comments in\nnot-yet-completed sections. Case insensitive, the "
+                  "value": "It’s often helpful to write a draft of a document and leave “to-do” comments in not-yet-completed sections. Case insensitive, the "
                 },
                 {
                   "type": "InlineCode",
@@ -2380,7 +2431,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Spec Markdown will apply syntax highlighting to blocks of code if a\ngithub-flavored-markdown style language is supplied."
+                  "value": "Spec Markdown will apply syntax highlighting to blocks of code if a github-flavored-markdown style language is supplied."
                 }
               ]
             },
@@ -2436,7 +2487,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "You may also prefix your highlight function with \"raw\" if you want to avoid\nother tools, such as Prettier, from interpreting a code block."
+                  "value": "You may also prefix your highlight function with “raw” if you want to avoid other tools, such as Prettier, from interpreting a code block."
                 }
               ]
             },
@@ -2471,7 +2522,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Spec Markdown helps you write examples, visually indicaticating the difference\nfrom normative code blocks, and generating permalinks to those examples. Just\nwrite "
+                      "value": "Spec Markdown helps you write examples, visually indicaticating the difference from normative code blocks, and generating permalinks to those examples. Just write "
                     },
                     {
                       "type": "InlineCode",
@@ -2525,7 +2576,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Examples can also be syntax highlighted, by placing the language directly before\nwriting "
+                      "value": "Examples can also be syntax highlighted, by placing the language directly before writing "
                     },
                     {
                       "type": "InlineCode",
@@ -2583,7 +2634,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", which\nare examples of things you should not do. These are visually indicated as\ndifferent from normative code blocks and other examples. Just write\n"
+                      "value": ", which are examples of things you should not do. These are visually indicated as different from normative code blocks and other examples. Just write "
                     },
                     {
                       "type": "InlineCode",
@@ -2646,7 +2697,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "When compiled, an import reference will be inlined into the same document. An\nimport reference looks like a link to a \".md\" file as a single paragraph."
+                  "value": "When compiled, an import reference will be inlined into the same document. An import reference looks like a link to a “.md” file as a single paragraph."
                 }
               ]
             },
@@ -2671,7 +2722,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " characters to describe at\nwhat section level the import should apply. By default an import reference will\nbe imported as a child of the current section."
+                  "value": " characters to describe at what section level the import should apply. By default an import reference will be imported as a child of the current section."
                 }
               ]
             }
@@ -2744,7 +2795,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " or\n"
+                  "value": " or "
                 },
                 {
                   "type": "InlineCode",
@@ -2784,7 +2835,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\non their own line with empty lines on either side:"
+                  "value": " on their own line with empty lines on either side:"
                 }
               ]
             },
@@ -2891,7 +2942,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "imports and section headers cannot be included in a added or removed\nsection to preserve the ability to render a table of contents."
+                  "value": "imports and section headers cannot be included in a added or removed section to preserve the ability to render a table of contents."
                 }
               ]
             }
@@ -2907,7 +2958,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Specifications for procedures or algorithms can be defined in terms of nested\nmarkdown lists. These lists can be of any kind, but will always have ordered\nformatting. The bullet labeling for algorithms is specific will cycle between\ndecimal, lower-alpha, and lower-roman."
+                  "value": "Specifications for procedures or algorithms can be defined in terms of nested markdown lists. These lists can be of any kind, but will always have ordered formatting. The bullet labeling for algorithms is specific will cycle between decimal, lower-alpha, and lower-roman."
                 }
               ]
             },
@@ -3065,7 +3116,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " characters or sequence of\ncharacters, which are then referenced by "
+                  "value": " characters or sequence of characters, which are then referenced by "
                 },
                 {
                   "type": "Italic",
@@ -3078,7 +3129,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " rules. The definition\nof a non-terminal is referred to as a "
+                  "value": " rules. The definition of a non-terminal is referred to as a "
                 },
                 {
                   "type": "Italic",
@@ -3113,7 +3164,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " token indicates an \"is defined as\" production for a non-terminal,\nwhere a single definition can be written directly after the "
+                      "value": " token indicates an “is defined as” production for a non-terminal, where a single definition can be written directly after the "
                     },
                     {
                       "type": "InlineCode",
@@ -3191,7 +3242,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " has definition options, they are written immediately after as a\nMarkdown list."
+                      "value": " has definition options, they are written immediately after as a Markdown list."
                     }
                   ]
                 },
@@ -3309,7 +3360,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": "\ntokens, and may also include conditionals and constraints."
+                      "value": " tokens, and may also include conditionals and constraints."
                     }
                   ]
                 },
@@ -3318,7 +3369,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Definition lists aren't required to be indented:"
+                      "value": "Definition lists aren’t required to be indented:"
                     }
                   ]
                 },
@@ -3417,7 +3468,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Often languages wish to specify different types of grammar productions, such as\nlexical or syntactical, or if certain characters line whitespace or newlines are\npermitted between symbols in the right-hand-side. Spec-md allows this this\ndistinction based on the number of colons:"
+                      "value": "Often languages wish to specify different types of grammar productions, such as lexical or syntactical, or if certain characters line whitespace or newlines are permitted between symbols in the right-hand-side. Spec-md allows this this distinction based on the number of colons:"
                     }
                   ]
                 },
@@ -3519,7 +3570,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If each definition option is a single token, it can be expressed as a \"one of\"\nexpression instead of a markdown list."
+                      "value": "If each definition option is a single token, it can be expressed as a “one of” expression instead of a markdown list."
                     }
                   ]
                 },
@@ -3605,7 +3656,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "\"one of\" can also be followed by a line break and multiple lines of tokens.\nTo improve legibility in other tools, each line may optionally begin with\na bullet."
+                      "value": "“one of” can also be followed by a line break and multiple lines of tokens. To improve legibility in other tools, each line may optionally begin with a bullet."
                     }
                   ]
                 },
@@ -3802,7 +3853,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Non-terminal tokens with a defined as a grammar production can be referred to\nin other grammar productions. Non-terminals must match the regular expression\n"
+                      "value": "Non-terminal tokens with a defined as a grammar production can be referred to in other grammar productions. Non-terminals must match the regular expression "
                     },
                     {
                       "type": "RegExp",
@@ -3810,7 +3861,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". That is, they must start with an uppercase letter, followed\nby any number of letters or underscores."
+                      "value": ". That is, they must start with an uppercase letter, followed by any number of letters or underscores."
                     }
                   ]
                 }
@@ -3826,7 +3877,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Grammars can describe arbitrary rules by using prose within a grammar\ndefinition by using "
+                      "value": "Grammars can describe arbitrary rules by using prose within a grammar definition by using "
                     },
                     {
                       "type": "InlineCode",
@@ -3896,7 +3947,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Terminal tokens refer to a character or sequence of characters. They can be\nwritten unadorned in the grammar definition."
+                      "value": "Terminal tokens refer to a character or sequence of characters. They can be written unadorned in the grammar definition."
                     }
                   ]
                 },
@@ -4037,7 +4088,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " to remove any\nambiguity from other meanings, for example to allow a terminal token to start\nwith an uppercase letter, or a slash "
+                      "value": " to remove any ambiguity from other meanings, for example to allow a terminal token to start with an uppercase letter, or a slash "
                     },
                     {
                       "type": "InlineCode",
@@ -4053,7 +4104,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", or later\ncontain a "
+                      "value": ", or later contain a "
                     },
                     {
                       "type": "InlineCode",
@@ -4131,7 +4182,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "When a grammar is intended to be interpretted as a single token and can be\nclearly written as a regular expression, you can do so directly."
+                      "value": "When a grammar is intended to be interpretted as a single token and can be clearly written as a regular expression, you can do so directly."
                     }
                   ]
                 },
@@ -4183,7 +4234,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Tokens can be followed by quantifiers to alter their meaning and as a short-hand\nfor common patterns of optionality and repetition."
+                      "value": "Tokens can be followed by quantifiers to alter their meaning and as a short-hand for common patterns of optionality and repetition."
                     }
                   ]
                 },
@@ -4218,7 +4269,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " and is a shorthand for two\npossible definitions, one including that token and one excluding it."
+                          "value": " and is a shorthand for two possible definitions, one including that token and one excluding it."
                         }
                       ]
                     },
@@ -4367,7 +4418,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " and is shorthand for a list\nof one or more of that token."
+                          "value": " and is shorthand for a list of one or more of that token."
                         }
                       ]
                     },
@@ -4522,7 +4573,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " as a shorthand for a\ncomma-separated list, in which case the previous example would be shorthand for:"
+                          "value": " as a shorthand for a comma-separated list, in which case the previous example would be shorthand for:"
                         }
                       ]
                     },
@@ -4634,7 +4685,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " and is shorthand for an\noptional list, which describes zero or more of that token."
+                          "value": " and is shorthand for an optional list, which describes zero or more of that token."
                         }
                       ]
                     },
@@ -4906,7 +4957,7 @@
                         },
                         {
                           "type": "Text",
-                          "value": " characters, so\nalways quote the terminal if the intent is to apply a quantifer."
+                          "value": " characters, so always quote the terminal if the intent is to apply a quantifer."
                         }
                       ]
                     },
@@ -5006,7 +5057,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "It can be a useful short-hand to provide conditional parameters when defining a\nnon-terminal token rather than defining two very similar non-terminals."
+                      "value": "It can be a useful short-hand to provide conditional parameters when defining a non-terminal token rather than defining two very similar non-terminals."
                     }
                   ]
                 },
@@ -5023,7 +5074,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and renders\nas "
+                      "value": " and renders as "
                     },
                     {
                       "type": "NonTerminal",
@@ -5039,7 +5090,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ". When used in definitions is shorthand for two symbol\ndefinitions: one appended with that parameter name, the other without."
+                      "value": ". When used in definitions is shorthand for two symbol definitions: one appended with that parameter name, the other without."
                     }
                   ]
                 },
@@ -5138,7 +5189,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The conditions are applied at the beginning of a definition for the\nnon-terminal by prefixing with "
+                      "value": "The conditions are applied at the beginning of a definition for the non-terminal by prefixing with "
                     },
                     {
                       "type": "InlineCode",
@@ -5154,7 +5205,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ") or\n"
+                      "value": ") or "
                     },
                     {
                       "type": "InlineCode",
@@ -5170,7 +5221,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ") to only include the definition when\nthe variant with the conditional parameter is or is not used, respectively."
+                      "value": ") to only include the definition when the variant with the conditional parameter is or is not used, respectively."
                     }
                   ]
                 },
@@ -5391,7 +5442,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "The same bracket suffix on a non-terminal within a rule is shorthand for\nusing that variant of the rule. If the parameter starts with "
+                      "value": "The same bracket suffix on a non-terminal within a rule is shorthand for using that variant of the rule. If the parameter starts with "
                     },
                     {
                       "type": "InlineCode",
@@ -5399,7 +5450,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ",\nthat form of the symbol is conditionally used only in the derived production\nwith the same parameter. If the parameter starts with "
+                      "value": ", that form of the symbol is conditionally used only in the derived production with the same parameter. If the parameter starts with "
                     },
                     {
                       "type": "InlineCode",
@@ -5407,7 +5458,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": ", that form of the\nsymbol is only used when in the derived production "
+                      "value": ", that form of the symbol is only used when in the derived production "
                     },
                     {
                       "type": "Italic",
@@ -5657,7 +5708,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Multiple conditional parameters can be used on both the production definition\nand on non-terminals within a rule, in which case it is short form for the\npermutation of all conditions:"
+                      "value": "Multiple conditional parameters can be used on both the production definition and on non-terminals within a rule, in which case it is short form for the permutation of all conditions:"
                     }
                   ]
                 },
@@ -5972,7 +6023,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Any token can be followed by \"but not\" or \"but not one of\" to place a further\nconstraint on the previous token:"
+                      "value": "Any token can be followed by “but not” or “but not one of” to place a further constraint on the previous token:"
                     }
                   ]
                 },
@@ -6039,7 +6090,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Optionally can mention \"one of\", this will be omitted when rendered. Commas can\nbe used instead of \"or\"."
+                      "value": "Optionally can mention “one of”, this will be omitted when rendered. Commas can be used instead of “or”."
                     }
                   ]
                 },
@@ -6137,7 +6188,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " can be used to define\na non-terminal as matching no terminal or non-terminal tokens."
+                      "value": " can be used to define a non-terminal as matching no terminal or non-terminal tokens."
                     }
                   ]
                 },
@@ -6181,7 +6232,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "Lookaheads can appear anywhere in a sequence of tokens, and describe additional\nconstraints on the following token."
+                      "value": "Lookaheads can appear anywhere in a sequence of tokens, and describe additional constraints on the following token."
                     }
                   ]
                 },
@@ -6443,7 +6494,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Once grammar is defined, it can be useful to define the semantics of the grammar\nin terms of algorithm steps. A single grammar definition followed by a list\nis interpretted as a grammar semantic:"
+                  "value": "Once grammar is defined, it can be useful to define the semantics of the grammar in terms of algorithm steps. A single grammar definition followed by a list is interpretted as a grammar semantic:"
                 }
               ]
             },
@@ -6720,7 +6771,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "Value literals allow any text to refer to a value which has semantic meaning\nin the specification by wrapping it in "
+                  "value": "Value literals allow any text to refer to a value which has semantic meaning in the specification by wrapping it in "
                 },
                 {
                   "type": "InlineCode",
@@ -6862,7 +6913,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " are rendered\nas constants instead of variables."
+                      "value": " are rendered as constants instead of variables."
                     }
                   ]
                 }
@@ -6916,7 +6967,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " to represent the\nnon-terminal token "
+                      "value": " to represent the non-terminal token "
                     },
                     {
                       "type": "NonTerminal",
@@ -6941,7 +6992,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " to represent the\nterminal token "
+                      "value": " to represent the terminal token "
                     },
                     {
                       "type": "Terminal",
@@ -6964,7 +7015,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " and\n"
+                      "value": " and "
                     },
                     {
                       "type": "InlineCode",
@@ -7072,7 +7123,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " key in a metadata file, you can have Algorithm calls\nand Non-terminal tokens which are not defined in this spec to link to where they\nare defined."
+                  "value": " key in a metadata file, you can have Algorithm calls and Non-terminal tokens which are not defined in this spec to link to where they are defined."
                 }
               ]
             },
@@ -7277,7 +7328,7 @@
                       },
                       {
                         "type": "Text",
-                        "value": ".\n"
+                        "value": ". "
                       }
                     ]
                   }
@@ -7308,7 +7359,7 @@
             },
             {
               "type": "Text",
-              "value": " as a shell executable is the easiest way\nto use Spec Markdown. The "
+              "value": " as a shell executable is the easiest way to use Spec Markdown. The "
             },
             {
               "type": "InlineCode",
@@ -7316,7 +7367,7 @@
             },
             {
               "type": "Text",
-              "value": " executable expects a filepath to a Markdown\ndocument as input and outputs HTML on stdout. Use "
+              "value": " executable expects a filepath to a Markdown document as input and outputs HTML on stdout. Use "
             },
             {
               "type": "InlineCode",
@@ -7349,7 +7400,7 @@
             },
             {
               "type": "Text",
-              "value": " as a node module, after which you might add the\n"
+              "value": " as a node module, after which you might add the "
             },
             {
               "type": "InlineCode",
@@ -7439,7 +7490,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " to a Markdown file and returns\n    a Promise which will resolve to an HTML string. This function is the primary\n    usage of the "
+                  "value": " to a Markdown file and returns a Promise which will resolve to an HTML string. This function is the primary usage of the "
                 },
                 {
                   "type": "InlineCode",
@@ -7466,7 +7517,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " takes a filepath and returns a Promise which will resolve\n    to an AST "
+                  "value": " takes a filepath and returns a Promise which will resolve to an AST "
                 },
                 {
                   "type": "Italic",
@@ -7479,7 +7530,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " representing the contents of the Spec\n    Markdown file, with all imports already inlined."
+                  "value": " representing the contents of the Spec Markdown file, with all imports already inlined."
                 }
               ]
             },
@@ -7510,7 +7561,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " produced by parse() and returns an HTML\n    string."
+                  "value": " produced by parse() and returns an HTML string."
                 }
               ]
             },
@@ -7557,7 +7608,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\n    in a depth-first-traversal calling the "
+                  "value": " in a depth-first-traversal calling the "
                 },
                 {
                   "type": "Variable",
@@ -7621,7 +7672,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\nas an optional second argument. These options allow for customization control\nover the returned HTML, more options may be added in the future."
+                  "value": " as an optional second argument. These options allow for customization control over the returned HTML, more options may be added in the future."
                 }
               ]
             },
@@ -7643,7 +7694,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " - a function which is called when blocks of code are\n    encountered, with the first argument as the string of code, the second\n    argument being the language specified. This function should return well\n    formed HTML, complete with escaped special characters."
+                      "value": " - a function which is called when blocks of code are encountered, with the first argument as the string of code, the second argument being the language specified. This function should return well formed HTML, complete with escaped special characters."
                     }
                   ]
                 },
@@ -7669,7 +7720,7 @@
                     },
                     {
                       "type": "Text",
-                      "value": " tag in the returned\n    HTML. Use this to introduce additional meta tags and scripts."
+                      "value": " tag in the returned HTML. Use this to introduce additional meta tags and scripts."
                     }
                   ]
                 }
@@ -7709,7 +7760,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": "\nof doing one thing and doing it well. Try out "
+                  "value": " of doing one thing and doing it well. Try out "
                 },
                 {
                   "type": "InlineCode",
@@ -7717,7 +7768,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " to continuously rebuild\nthe HTML output as you edit the markdown specification:"
+                  "value": " to continuously rebuild the HTML output as you edit the markdown specification:"
                 }
               ]
             },
@@ -7743,7 +7794,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "We want to make contributing to this project as easy and transparent as\npossible. Hopefully this document makes the process for contributing clear and\nanswers any questions you may have. If not, feel free to open an\n"
+              "value": "We want to make contributing to this project as easy and transparent as possible. Hopefully this document makes the process for contributing clear and answers any questions you may have. If not, feel free to open an "
             },
             {
               "type": "Link",
@@ -7771,7 +7822,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "All active development of Spec Markdown happens on GitHub. We actively welcome\nyour "
+                  "value": "All active development of Spec Markdown happens on GitHub. We actively welcome your "
                 },
                 {
                   "type": "Link",
@@ -7842,7 +7893,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If you've added code, add tests."
+                      "value": "If you’ve added code, add tests."
                     }
                   ]
                 },
@@ -7851,7 +7902,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": "If you've changed APIs, update the documentation."
+                      "value": "If you’ve changed APIs, update the documentation."
                     }
                   ]
                 },
@@ -7894,7 +7945,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " in good shape, with tests passing at all\ntimes. But in order to move fast, we might make API changes that your\napplication might not be compatible with. We will do our best to communicate\nthese changes and always "
+                  "value": " in good shape, with tests passing at all times. But in order to move fast, we might make API changes that your application might not be compatible with. We will do our best to communicate these changes and always "
                 },
                 {
                   "type": "Link",
@@ -7908,7 +7959,7 @@
                 },
                 {
                   "type": "Text",
-                  "value": " appropriately so you can\nlock into a specific version if need be. If any of this is worrysome to you,\njust use "
+                  "value": " appropriately so you can lock into a specific version if need be. If any of this is worrysome to you, just use "
                 },
                 {
                   "type": "Link",
@@ -7938,7 +7989,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "We use GitHub issues to track public bugs and requests. Please ensure your bug\ndescription is clear and has sufficient instructions to be able to reproduce the\nissue. The best way is to provide a reduced test case on jsFiddle or jsBin."
+                  "value": "We use GitHub issues to track public bugs and requests. Please ensure your bug description is clear and has sufficient instructions to be able to reproduce the issue. The best way is to provide a reduced test case on jsFiddle or jsBin."
                 }
               ]
             }
@@ -8033,7 +8084,7 @@
               "contents": [
                 {
                   "type": "Text",
-                  "value": "By contributing to Spec Markdown, you agree that your contributions will be\nlicensed under its MIT license.\n"
+                  "value": "By contributing to Spec Markdown, you agree that your contributions will be licensed under its MIT license. "
                 }
               ]
             }

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1159,7 +1159,7 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 </section>
 <section id="sec-Markdown" secid="2">
 <h1><span class="spec-secid" title="link to this section"><a href="#sec-Markdown">2</a></span>Markdown</h1>
-<p>Spec Markdown is first and foremost <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a>. More specifically, it&rsquo;s based on <a href="https://help.github.com/articles/github-flavored-markdown/">Github&#8208;flavored Markdown</a>.</p>
+<p>Spec Markdown is first and foremost <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a>. More specifically, it&rsquo;s based on <a href="https://help.github.com/articles/github-flavored-markdown/">Github-flavored Markdown</a>.</p>
 <p>This section explains the syntax and capabilities of Markdown that Spec Markdown supports and augments.</p>
 <section id="sec-Character-Encoding" secid="2.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Character-Encoding">2.1</a></span>Character Encoding</h2>
@@ -1171,10 +1171,10 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <p>You can type *literal asterisks* instead of emphasis by typing <code>\*literal asterisks\*</code>.</p>
 <p>Escaping does not apply within code.</p>
 <p>Spec Markdown allows backslash escapes for any ASCII punctuation character.</p>
-<pre><code>\!\&quot;\#\$\%\&amp;\&#x27;\(\)\*\+\,\-\.\/\:\;\&lt;\=\&gt;\?\@\[\\\]\^\_\`\{\|\}\~
+<pre><code>\!\"\#\$\%\&amp;\'\(\)\*\+\,\-\.\/\:\;\&lt;\=\&gt;\?\@\[\\\]\^\_\`\{\|\}\~
 </code></pre>
 <p>Produces the following:</p>
-<p>!&rdquo;#$%&&rsquo;()*+,-./:;&hArr;?@[\]^_`{|}~</p>
+<p>!"#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
 </section>
 </section>
 <section id="sec-Inline-formatting" secid="2.2">
@@ -1195,7 +1195,7 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <p>Produces the following:</p>
 <p>This is an <a href="https://www.facebook.com">&rarr;<em>example</em>&larr;</a> of a link.</p>
 <div class="spec-todo">
-Links do not yet support a reference style short&#8208;form.</div>
+Links do not yet support a reference style short-form.</div>
 <div class="spec-todo">
 Links do not yet support a title attribute.</div>
 </section>
@@ -1214,12 +1214,12 @@ Links do not yet support a title attribute.</div>
 </section>
 <section id="sec-Inline-Code" secid="2.2.4">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Code">2.2.4</a></span>Inline Code</h3>
-<p>Wrapping back&#8208;ticks <em>(`)</em> indicate inline code, text inside back&#8208;ticks is not formatted, allowing for special characters to be used in inline code without escapes.</p>
+<p>Wrapping back-ticks <em>(`)</em> indicate inline code, text inside back-ticks is not formatted, allowing for special characters to be used in inline code without escapes.</p>
 <pre><code>This is an `example` of some inline code.
 </code></pre>
 <p>Produces</p>
 <p>This is an <code>example</code> of some inline code.</p>
-<p>Inline code can also use double- or triple&#8208;backticks. Wrapping spaces are removed.</p>
+<p>Inline code can also use double- or triple-backticks. Wrapping spaces are removed.</p>
 <p><code>`` ` ``</code> Produces <code>`</code></p>
 </section>
 <section id="sec-Images" secid="2.2.5">
@@ -1250,13 +1250,13 @@ the title attribute is not yet supported</div>
 </section>
 <section id="sec-Blocks" secid="2.3">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Blocks">2.3</a></span>Blocks</h2>
-<p>Markdown allows for block&#8208;level structual formatting. Every block is seperated by at least two new lines. Spec Markdown makes use of Markdown&rsquo;s blocks to produce more specific structural formatting.</p>
+<p>Markdown allows for block-level structual formatting. Every block is seperated by at least two new lines. Spec Markdown makes use of Markdown&rsquo;s blocks to produce more specific structural formatting.</p>
 <section id="sec-Block-HTML" secid="2.3.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Block-HTML">2.3.1</a></span>Block HTML</h3>
 <p>Markdown is not a replacement for HTML and instead leverages HTML by allowing its use as complete blocks when separated from surrounding content by blank lines.</p>
-<div id="note-eb0b0" class="spec-note">
-<a href="#note-eb0b0">Note</a>
-Markdown formatting syntax is not processed within block&#8208;level HTML tags.</div>
+<div id="note-5b9d8" class="spec-note">
+<a href="#note-5b9d8">Note</a>
+Markdown formatting syntax is not processed within block-level HTML tags.</div>
 <p>For example, to add an HTML table to a Markdown article:</p>
 <pre><code>Unrelated previous paragraph followed by a blank line
 
@@ -1359,7 +1359,7 @@ Spec Markdown requires that documents start with <code>#</code> and that each se
 </ol>
 <section id="sec-Task-Lists" secid="2.3.4.1">
 <h4><span class="spec-secid" title="link to this section"><a href="#sec-Task-Lists">2.3.4.1</a></span>Task Lists</h4>
-<p>Spec Markdown also supports task lists. Start a list item with <code>[ ]</code> or <code>[x]</code> to render a checkbox. This can be useful for keeping your tasks inline with in&#8208;progress draft specifications.</p>
+<p>Spec Markdown also supports task lists. Start a list item with <code>[ ]</code> or <code>[x]</code> to render a checkbox. This can be useful for keeping your tasks inline with in-progress draft specifications.</p>
 <pre id="example-f34a9" class="spec-example"><a href="#example-f34a9">Example № 4</a><code>  1. this
   2. [ ] is
   3. [x] a
@@ -1427,9 +1427,9 @@ Introductory paragraph.
 
 # First Section Header
 </code></pre>
-<div id="note-f5587" class="spec-note">
-<a href="#note-f5587">Note</a>
-For backwards&#8208;compatibility, a setext style header can be used for a document title.</div>
+<div id="note-25668" class="spec-note">
+<a href="#note-25668">Note</a>
+For backwards-compatibility, a setext style header can be used for a document title.</div>
 </section>
 <section id="sec-Sections" secid="3.3">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Sections">3.3</a></span>Sections</h2>
@@ -1485,20 +1485,23 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 <p>The Spec Markdown renderer will replace easy to type characters like quotes and dashes with their appropriate typographic entities. These replacements will not occur within blocks of code.</p>
 <section id="sec-Quotes-and-Dashes" secid="3.4.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Quotes-and-Dashes">3.4.1</a></span>Quotes and Dashes</h3>
-<p>Prose text has &ldquo;smart quotes&rdquo;, hyphens, en&#8208;dashes and em&#8208;dashes&mdash;you shouldn&rsquo;t have to think about it, they&rsquo;ll just work.</p>
+<p>Prose text has &ldquo;smart quotes&rdquo;, hyphens, en-dashes and em-dashes&mdash;you shouldn&rsquo;t have to think about it, they&rsquo;ll just work.</p>
 <p>For example, a quote of a quote (with an inner apostrophe and emphasis for flair):</p>
-<p><code>&quot;She told me that &#x27;he isn&#x27;t here right *now*&#x27; - so I left.&quot;</code></p>
+<p><code>"She told me that 'he isn't here right *now*' - so I left."</code></p>
 <p>Will render as:</p>
-<p>&ldquo;She told me that&lsquo;he isn&rsquo;t here right <em>now</em>&rsquo; &ndash; so I left.&rdquo;</p>
+<p>&ldquo;She told me that &lsquo;he isn&rsquo;t here right <em>now</em>&rsquo; &ndash; so I left.&rdquo;</p>
+<p>Escaped <code>\"quotes \'and single\-quotes\'\"</code> becomes: \&ldquo;quotes \&lsquo;and single-quotes'".</p>
 </section>
 <section id="sec-Math" secid="3.4.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Math">3.4.2</a></span>Math</h3>
-<p>Math operators like &ge;, &le;, and &cong; can be written as <code>&gt;=</code>, <code>&lt;=</code>, and <code>~=</code>.</p>
+<p>Math operators like &ge;, &le;, and &asymp; can be written as <code>&gt;=</code>, <code>&lt;=</code>, and <code>~=</code>.</p>
+<p>Escaped <code>\&gt;= \&lt;= \~=</code> becomes: &gt;= &lt;= ~=.</p>
 </section>
 <section id="sec-Arrows" secid="3.4.3">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Arrows">3.4.3</a></span>Arrows</h3>
 <p>Smart arrows &rarr; and &larr; and &harr; can be written as <code>-&gt;</code>, <code>&lt;-</code> and <code>&lt;-&gt;</code>.</p>
 <p>Fat smart arrows &rArr; and &lArr; and &hArr; can be written as <code>=&gt;</code>, <code>&lt;==</code> and <code>&lt;=&gt;</code>.</p>
+<p>Escaped <code>\-&gt; \&lt;- \&lt;-&gt; \=&gt; \&lt;== \&lt;=&gt;</code> becomes: -&gt; &lt;- &lt;-&gt; =&gt; &lt;== &lt;=&gt;.</p>
 </section>
 <section id="sec-Tables" secid="3.4.4">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Tables">3.4.4</a></span>Tables</h3>
@@ -1524,7 +1527,7 @@ For backwards&#8208;compatibility, a setext style header can be used for a docum
 </section>
 <section id="sec-Note" secid="3.5">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Note">3.5</a></span>Note</h2>
-<p>Notes can be written inline with a spec document, and are often helpful to supply non&#8208;normative explanatory text or caveats in a differently formatted style. Case insensitive, the <code>:</code> is optional.</p>
+<p>Notes can be written inline with a spec document, and are often helpful to supply non-normative explanatory text or caveats in a differently formatted style. Case insensitive, the <code>:</code> is optional.</p>
 <p>Notes automatically have short links generated for them. If the contents of the note changes, so will the link URL. However if a note moves around, or content around the note changes the existing links will still point to the right place, very useful for consistently evolving specifications!</p>
 <pre><code>Note: Notes are awesome.
 </code></pre>
@@ -1535,7 +1538,7 @@ Notes are awesome.</div>
 </section>
 <section id="sec-Todo" secid="3.6">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Todo">3.6</a></span>Todo</h2>
-<p>It&rsquo;s often helpful to write a draft of a document and leave &ldquo;to&#8208;do&rdquo; comments in not&#8208;yet&#8208;completed sections. Case insensitive, the <code>:</code> is optional.</p>
+<p>It&rsquo;s often helpful to write a draft of a document and leave &ldquo;to-do&rdquo; comments in not-yet-completed sections. Case insensitive, the <code>:</code> is optional.</p>
 <pre><code>TODO: finish this section
 </code></pre>
 <p>Produces the following:</p>
@@ -1547,18 +1550,18 @@ You can also write <code>TK</code> in place of <code>TODO</code>, nerds.</div>
 </section>
 <section id="sec-Syntax-Highlighting" secid="3.7">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Syntax-Highlighting">3.7</a></span>Syntax Highlighting</h2>
-<p>Spec Markdown will apply syntax highlighting to blocks of code if a github&#8208;flavored&#8208;markdown style language is supplied.</p>
+<p>Spec Markdown will apply syntax highlighting to blocks of code if a github-flavored-markdown style language is supplied.</p>
 <p>You may provide a <code>highlight</code> function as an option to customize this behavior.</p>
 <p>To render this highlighted javascript:</p>
 <pre><code>```js
-const baz = foo(&quot;bar&quot;);
+const baz = foo("bar");
 ```</code></pre>
 <p>Produces the following:</p>
 <pre data-language="js"><code><span class="token keyword">const</span> baz <span class="token operator">=</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token string">"bar"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 </code></pre>
 <p>You may also prefix your highlight function with &ldquo;raw&rdquo; if you want to avoid other tools, such as Prettier, from interpreting a code block.</p>
 <pre><code>```raw js
-const baz = foo(&quot;bar&quot;);
+const baz = foo("bar");
 ```</code></pre>
 <p>Produces the following:</p>
 <pre data-language="js"><code><span class="token keyword">const</span> baz <span class="token operator">=</span> <span class="token function">foo</span><span class="token punctuation">(</span><span class="token string">"bar"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
@@ -1567,14 +1570,14 @@ const baz = foo(&quot;bar&quot;);
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Examples">3.7.1</a></span>Examples</h3>
 <p>Spec Markdown helps you write examples, visually indicaticating the difference from normative code blocks, and generating permalinks to those examples. Just write <code>example</code> after the <code>```</code>.</p>
 <pre><code>```example
-const great = useOf.example(&quot;code&quot;);
+const great = useOf.example("code");
 ```</code></pre>
 <p>Produces the following:</p>
-<pre id="example-33270" class="spec-example"><a href="#example-33270">Example № 6</a><code>const great = useOf.example(&quot;code&quot;);
+<pre id="example-33270" class="spec-example"><a href="#example-33270">Example № 6</a><code>const great = useOf.example("code");
 </code></pre>
 <p>Examples can also be syntax highlighted, by placing the language directly before writing <code>example</code>:</p>
 <pre><code>```js example
-const great = useOf.example(&quot;code&quot;);
+const great = useOf.example("code");
 ```</code></pre>
 <p>Produces the following:</p>
 <pre id="example-d7c75" class="spec-example" data-language="js"><a href="#example-d7c75">Example № 7</a><code><span class="token keyword">const</span> great <span class="token operator">=</span> useOf<span class="token punctuation">.</span><span class="token method function property-access">example</span><span class="token punctuation">(</span><span class="token string">"code"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
@@ -1582,7 +1585,7 @@ const great = useOf.example(&quot;code&quot;);
 </section>
 <section id="sec-Counter-Examples" secid="3.7.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Counter-Examples">3.7.2</a></span>Counter Examples</h3>
-<p>In addition to examples, Spec Markdown helps you write <em>counter&#8208;examples</em>, which are examples of things you should not do. These are visually indicated as different from normative code blocks and other examples. Just write <code>counter-example</code> after the <code>```</code> (and optional language).</p>
+<p>In addition to examples, Spec Markdown helps you write <em>counter-examples</em>, which are examples of things you should not do. These are visually indicated as different from normative code blocks and other examples. Just write <code>counter-example</code> after the <code>```</code> (and optional language).</p>
 <pre><code>```js counter-example
 const shit = dontSwear();
 ```</code></pre>
@@ -1638,7 +1641,7 @@ imports and section headers cannot be included in a added or removed section to 
 </section>
 <section id="sec-Algorithms" secid="3.11">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Algorithms">3.11</a></span>Algorithms</h2>
-<p>Specifications for procedures or algorithms can be defined in terms of nested markdown lists. These lists can be of any kind, but will always have ordered formatting. The bullet labeling for algorithms is specific will cycle between decimal, lower&#8208;alpha, and lower&#8208;roman.</p>
+<p>Specifications for procedures or algorithms can be defined in terms of nested markdown lists. These lists can be of any kind, but will always have ordered formatting. The bullet labeling for algorithms is specific will cycle between decimal, lower-alpha, and lower-roman.</p>
 <p>An algorithm definition also describes its arguments in terms of variables.</p>
 <pre><code>Algorithm(arg) :
   1. first
@@ -1668,11 +1671,11 @@ imports and section headers cannot be included in a added or removed section to 
 </section>
 <section id="sec-Grammar" secid="3.12">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Grammar">3.12</a></span>Grammar</h2>
-<p>Spec Markdown makes it easier to describe context&#8208;free grammatical productions.</p>
-<p>Grammars are defined by a sequence of <em>terminal</em> characters or sequence of characters, which are then referenced by <em>non&#8208;terminal</em> rules. The definition of a non&#8208;terminal is referred to as a <em>production</em>.</p>
+<p>Spec Markdown makes it easier to describe context-free grammatical productions.</p>
+<p>Grammars are defined by a sequence of <em>terminal</em> characters or sequence of characters, which are then referenced by <em>non-terminal</em> rules. The definition of a non-terminal is referred to as a <em>production</em>.</p>
 <section id="sec-Grammar-Production" secid="3.12.1">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Grammar-Production">3.12.1</a></span>Grammar Production</h3>
-<p>The <code>:</code> token indicates an &ldquo;is defined as&rdquo; production for a non&#8208;terminal, where a single definition can be written directly after the <code>:</code>.</p>
+<p>The <code>:</code> token indicates an &ldquo;is defined as&rdquo; production for a non-terminal, where a single definition can be written directly after the <code>:</code>.</p>
 <pre><code>PBJ : Bread PeanutButter Jelly Bread
 </code></pre>
 <p>Produces the following:</p>
@@ -1689,7 +1692,7 @@ imports and section headers cannot be included in a added or removed section to 
 <span class="spec-nt"><a href="#PBJ" data-name="PBJ">PBJ</a></span><div class="spec-rhs"><span class="spec-nt"><span data-name="Bread">Bread</span></span><span class="spec-nt"><span data-name="PeanutButter">PeanutButter</span></span><span class="spec-nt"><span data-name="Jelly">Jelly</span></span><span class="spec-nt"><span data-name="Bread">Bread</span></span></div>
 <div class="spec-rhs"><span class="spec-nt"><span data-name="Bread">Bread</span></span><span class="spec-nt"><span data-name="Jelly">Jelly</span></span><span class="spec-nt"><span data-name="PeanutButter">PeanutButter</span></span><span class="spec-nt"><span data-name="Bread">Bread</span></span></div>
 </div>
-<p>Each definition is a space seperated list of <em>terminal</em> or <em>non&#8208;terminal</em> tokens, and may also include conditionals and constraints.</p>
+<p>Each definition is a space seperated list of <em>terminal</em> or <em>non-terminal</em> tokens, and may also include conditionals and constraints.</p>
 <p>Definition lists aren&rsquo;t required to be indented:</p>
 <pre><code>PBJ :
 
@@ -1704,7 +1707,7 @@ imports and section headers cannot be included in a added or removed section to 
 </section>
 <section id="sec-Production-types" secid="3.12.2">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Production-types">3.12.2</a></span>Production types</h3>
-<p>Often languages wish to specify different types of grammar productions, such as lexical or syntactical, or if certain characters line whitespace or newlines are permitted between symbols in the right&#8208;hand&#8208;side. Spec&#8208;md allows this this distinction based on the number of colons:</p>
+<p>Often languages wish to specify different types of grammar productions, such as lexical or syntactical, or if certain characters line whitespace or newlines are permitted between symbols in the right-hand-side. Spec-md allows this this distinction based on the number of colons:</p>
 <pre><code>TypeOne : `type` `one`
 
 TypeTwo :: `type` `two`
@@ -1772,12 +1775,12 @@ TypeThree ::: `type` `three`
 </section>
 <section id="sec-Non-Terminal-Token" secid="3.12.4">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Non-Terminal-Token">3.12.4</a></span>Non Terminal Token</h3>
-<p>Non&#8208;terminal tokens with a defined as a grammar production can be referred to in other grammar productions. Non&#8208;terminals must match the regular expression <span class="spec-rx">/[A-Z][_a-zA-Z]*/</span>. That is, they must start with an uppercase letter, followed by any number of letters or underscores.</p>
+<p>Non-terminal tokens with a defined as a grammar production can be referred to in other grammar productions. Non-terminals must match the regular expression <span class="spec-rx">/[A-Z][_a-zA-Z]*/</span>. That is, they must start with an uppercase letter, followed by any number of letters or underscores.</p>
 </section>
 <section id="sec-Prose" secid="3.12.5">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Prose">3.12.5</a></span>Prose</h3>
-<p>Grammars can describe arbitrary rules by using prose within a grammar definition by using <code>&quot;quotes&quot;</code>.</p>
-<pre><code>Sandwich : Bread &quot;Any kind of topping&quot; Bread
+<p>Grammars can describe arbitrary rules by using prose within a grammar definition by using <code>"quotes"</code>.</p>
+<pre><code>Sandwich : Bread "Any kind of topping" Bread
 </code></pre>
 <p>Produces the following:</p>
 <div class="spec-production" id="Sandwich">
@@ -1800,7 +1803,7 @@ TypeThree ::: `type` `three`
 <div class="spec-production" id="WhileStatement">
 <span class="spec-nt"><a href="#WhileStatement" data-name="WhileStatement">WhileStatement</a></span><div class="spec-rhs"><span class="spec-t">while</span><span class="spec-t">(</span><span class="spec-nt"><span data-name="Expression">Expression</span></span><span class="spec-t">)</span><span class="spec-t">{</span><span class="spec-nt"><span data-name="Statements">Statements</span></span><span class="spec-t">}</span></div>
 </div>
-<p>Terminals can also be quoted with back&#8208;ticks <code>`</code> to remove any ambiguity from other meanings, for example to allow a terminal token to start with an uppercase letter, or a slash <code>/</code> or backslash <code>\</code>, or later contain a <code>]</code> or <code>}</code>.</p>
+<p>Terminals can also be quoted with back-ticks <code>`</code> to remove any ambiguity from other meanings, for example to allow a terminal token to start with an uppercase letter, or a slash <code>/</code> or backslash <code>\</code>, or later contain a <code>]</code> or <code>}</code>.</p>
 <pre><code>DivisionExpression : Expression `/` Expression
 </code></pre>
 <p>Produces</p>
@@ -1820,7 +1823,7 @@ TypeThree ::: `type` `three`
 </section>
 <section id="sec-Quantifiers" secid="3.12.8">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Quantifiers">3.12.8</a></span>Quantifiers</h3>
-<p>Tokens can be followed by quantifiers to alter their meaning and as a short&#8208;hand for common patterns of optionality and repetition.</p>
+<p>Tokens can be followed by quantifiers to alter their meaning and as a short-hand for common patterns of optionality and repetition.</p>
 <section id="sec-Quantifiers.Optional-Tokens" class="subsec">
 <h6><a href="#sec-Quantifiers.Optional-Tokens" title="link to this subsection">Optional Tokens</a></h6>
 <p>A subscript suffix <code>Token?</code> renders as <span class="spec-quantified"><span class="spec-nt"><span data-name="Token">Token</span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span> and is a shorthand for two possible definitions, one including that token and one excluding it.</p>
@@ -1853,7 +1856,7 @@ TypeThree ::: `type` `three`
 <span class="spec-nt"><a href="#Page_list" data-name="Page_list">Page_list</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#Page_list" data-name="Page_list">Page_list</a></span><span class="spec-nt"><span data-name="Page">Page</span></span></div>
 <div class="spec-rhs"><span class="spec-nt"><span data-name="Page">Page</span></span></div>
 </div>
-<p>Some specifications may wish to declare <span class="spec-quantified"><span class="spec-nt"><span data-name="Token">Token</span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span> as a shorthand for a comma&#8208;separated list, in which case the previous example would be shorthand for:</p>
+<p>Some specifications may wish to declare <span class="spec-quantified"><span class="spec-nt"><span data-name="Token">Token</span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span> as a shorthand for a comma-separated list, in which case the previous example would be shorthand for:</p>
 <div class="spec-production" id="Book">
 <span class="spec-nt"><a href="#Book" data-name="Book">Book</a></span><div class="spec-rhs"><span class="spec-nt"><span data-name="Cover">Cover</span></span><span class="spec-nt"><a href="#Page_list" data-name="Page_list">Page_list</a></span><span class="spec-nt"><span data-name="Cover">Cover</span></span></div>
 </div>
@@ -1883,7 +1886,7 @@ TypeThree ::: `type` `three`
 </section>
 <section id="sec-Quantifiers.Use-with-Non-Terminals" class="subsec">
 <h6><a href="#sec-Quantifiers.Use-with-Non-Terminals" title="link to this subsection">Use with Non-Terminals</a></h6>
-<p>Quantifiers also apply to non&#8208;terminal tokens with the same rules. For example:</p>
+<p>Quantifiers also apply to non-terminal tokens with the same rules. For example:</p>
 <pre data-language="markdown"><code>UnionMembers :
   <span class="token list punctuation">-</span> UnionMembers | NamedType
   - <span class="token code keyword">`|`</span>? NamedType
@@ -1893,7 +1896,7 @@ TypeThree ::: `type` `three`
 <span class="spec-nt"><a href="#UnionMembers" data-name="UnionMembers">UnionMembers</a></span><div class="spec-rhs"><span class="spec-nt"><a href="#UnionMembers" data-name="UnionMembers">UnionMembers</a></span><span class="spec-t">|</span><span class="spec-nt"><span data-name="NamedType">NamedType</span></span></div>
 <div class="spec-rhs"><span class="spec-quantified"><span class="spec-t">|</span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span><span class="spec-nt"><span data-name="NamedType">NamedType</span></span></div>
 </div>
-<p>However, unquoted non&#8208;terminals may use the <code>*</code>, <code>?</code> and <code>+</code> characters, so always quote the terminal if the intent is to apply a quantifer.</p>
+<p>However, unquoted non-terminals may use the <code>*</code>, <code>?</code> and <code>+</code> characters, so always quote the terminal if the intent is to apply a quantifer.</p>
 <pre id="example-10052" class="spec-counter-example" data-language="markdown"><a href="#example-10052">Counter Example № 9</a><code>UnionMembers :
   <span class="token list punctuation">-</span> UnionMembers | NamedType
   <span class="token list punctuation">-</span> |? NamedType
@@ -1907,9 +1910,9 @@ TypeThree ::: `type` `three`
 </section>
 <section id="sec-Conditional-Parameters" secid="3.12.9">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Conditional-Parameters">3.12.9</a></span>Conditional Parameters</h3>
-<p>It can be a useful short&#8208;hand to provide conditional parameters when defining a non&#8208;terminal token rather than defining two very similar non&#8208;terminals.</p>
+<p>It can be a useful short-hand to provide conditional parameters when defining a non-terminal token rather than defining two very similar non-terminals.</p>
 <p>A conditional parameter is written in braces <code>Token[Param]</code> and renders as <span class="spec-nt"><span data-name="Token">Token</span><span class="spec-params"><span class="spec-param">Param</span></span></span>. When used in definitions is shorthand for two symbol definitions: one appended with that parameter name, the other without.</p>
-<pre><code>Example[WithCondition] : &quot;Definition TBD&quot;
+<pre><code>Example[WithCondition] : "Definition TBD"
 </code></pre>
 <p>Produces the following:</p>
 <div class="spec-production" id="Example">
@@ -1922,7 +1925,7 @@ TypeThree ::: `type` `three`
 <div class="spec-production" id="Example_WithCondition">
 <span class="spec-nt"><a href="#Example_WithCondition" data-name="Example_WithCondition">Example_WithCondition</a></span><div class="spec-rhs"><span class="spec-prose">Definition TBD</span></div>
 </div>
-<p>The conditions are applied at the beginning of a definition for the non&#8208;terminal by prefixing with <code>[if Param]</code> (alternatively <code>[+Param]</code>) or <code>[if not Param]</code> (alternatively <code>[~Param]</code>) to only include the definition when the variant with the conditional parameter is or is not used, respectively.</p>
+<p>The conditions are applied at the beginning of a definition for the non-terminal by prefixing with <code>[if Param]</code> (alternatively <code>[+Param]</code>) or <code>[if not Param]</code> (alternatively <code>[~Param]</code>) to only include the definition when the variant with the conditional parameter is or is not used, respectively.</p>
 <pre><code>Example[WithCondition] :
   - A
   - [if WithCondition] B
@@ -1950,7 +1953,7 @@ TypeThree ::: `type` `three`
 <div class="spec-rhs"><span class="spec-nt"><span data-name="B">B</span></span></div>
 <div class="spec-rhs"><span class="spec-nt"><span data-name="D">D</span></span></div>
 </div>
-<p>The same bracket suffix on a non&#8208;terminal within a rule is shorthand for using that variant of the rule. If the parameter starts with <code>?</code>, that form of the symbol is conditionally used only in the derived production with the same parameter. If the parameter starts with <code>!</code>, that form of the symbol is only used when in the derived production <em>without</em> that parameter.</p>
+<p>The same bracket suffix on a non-terminal within a rule is shorthand for using that variant of the rule. If the parameter starts with <code>?</code>, that form of the symbol is conditionally used only in the derived production with the same parameter. If the parameter starts with <code>!</code>, that form of the symbol is only used when in the derived production <em>without</em> that parameter.</p>
 <pre><code>Example[WithCondition] :
   - Example
   - Example[WithCondition]
@@ -1977,7 +1980,7 @@ TypeThree ::: `type` `three`
 <div class="spec-rhs"><span class="spec-nt"><a href="#Example_WithCondition" data-name="Example_WithCondition">Example_WithCondition</a></span></div>
 <div class="spec-rhs"><span class="spec-nt"><a href="#Example" data-name="Example">Example</a></span></div>
 </div>
-<p>Multiple conditional parameters can be used on both the production definition and on non&#8208;terminals within a rule, in which case it is short form for the permutation of all conditions:</p>
+<p>Multiple conditional parameters can be used on both the production definition and on non-terminals within a rule, in which case it is short form for the permutation of all conditions:</p>
 <pre><code>Example[P, Q] :
   - [if P] `p`
   - [if Q] `q`
@@ -2032,7 +2035,7 @@ TypeThree ::: `type` `three`
 <section id="sec-Meta-Tokens" secid="3.12.11">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Meta-Tokens">3.12.11</a></span>Meta Tokens</h3>
 <p>Spec Markdown can specify some tokens which do not consume any characters.</p>
-<p>The empty set, written <code>[empty]</code> appears as <span class="spec-empty">[empty]</span> can be used to define a non&#8208;terminal as matching no terminal or non&#8208;terminal tokens.</p>
+<p>The empty set, written <code>[empty]</code> appears as <span class="spec-empty">[empty]</span> can be used to define a non-terminal as matching no terminal or non-terminal tokens.</p>
 <pre><code>Example : [empty]
 </code></pre>
 <p>Produces the following:</p>
@@ -2097,7 +2100,7 @@ TypeThree ::: `type` `three`
 <section id="sec-Value-Literals" secid="3.14">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Value-Literals">3.14</a></span>Value Literals</h2>
 <p>Value literals allow any text to refer to a value which has semantic meaning in the specification by wrapping it in <code>{ }</code> curly brace characters.</p>
-<pre><code>I can reference {foo}, {&quot;foo&quot;}, {null}, {true}.
+<pre><code>I can reference {foo}, {"foo"}, {null}, {true}.
 </code></pre>
 <p>Produces the following:</p>
 <p>I can reference <var data-name="foo">foo</var>, <span class="spec-string">"foo"</span>, <span class="spec-keyword">null</span>, <span class="spec-keyword">true</span>.</p>
@@ -2111,16 +2114,16 @@ TypeThree ::: `type` `three`
 </section>
 <section id="sec-Value-Literals.String-literal" class="subsec">
 <h6><a href="#sec-Value-Literals.String-literal" title="link to this subsection">String literal</a></h6>
-<p>Write <code>{&quot;foo&quot;}</code> to produce a string literal like <span class="spec-string">"foo"</span>.</p>
+<p>Write <code>{"foo"}</code> to produce a string literal like <span class="spec-string">"foo"</span>.</p>
 </section>
 <section id="sec-Value-Literals.Grammar-tokens" class="subsec">
 <h6><a href="#sec-Value-Literals.Grammar-tokens" title="link to this subsection">Grammar tokens</a></h6>
-<p>Any grammar token can be written inline, like <code>{Example}</code> to represent the non&#8208;terminal token <span class="spec-nt"><a href="#Example" data-name="Example">Example</a></span>, <code>{`terminal`}</code> to represent the terminal token <span class="spec-t">terminal</span>. Even meta tokens like <code>{[empty]}</code> for <span class="spec-empty">[empty]</span> and <code>{[lookahead !{ x, y }]}</code> for <span class="spec-lookahead set not"><span class="spec-t">x</span><span class="spec-t">y</span></span>.</p>
+<p>Any grammar token can be written inline, like <code>{Example}</code> to represent the non-terminal token <span class="spec-nt"><a href="#Example" data-name="Example">Example</a></span>, <code>{`terminal`}</code> to represent the terminal token <span class="spec-t">terminal</span>. Even meta tokens like <code>{[empty]}</code> for <span class="spec-empty">[empty]</span> and <code>{[lookahead !{ x, y }]}</code> for <span class="spec-lookahead set not"><span class="spec-t">x</span><span class="spec-t">y</span></span>.</p>
 </section>
 <section id="sec-Value-Literals.Algorithm-calls" class="subsec">
 <h6><a href="#sec-Value-Literals.Algorithm-calls" title="link to this subsection">Algorithm calls</a></h6>
 <p>A call to an algorithm can be expressed as a value literal:</p>
-<pre><code>{Algorithm(foo, &quot;string&quot;, null)}
+<pre><code>{Algorithm(foo, "string", null)}
 </code></pre>
 <p>Produces the following:</p>
 <p><span class="spec-call"><a href="#Algorithm()" data-name="Algorithm">Algorithm</a>(<var data-name="foo">foo</var>, <span class="spec-string">"string"</span>, <span class="spec-keyword">null</span>)</span></p>
@@ -2128,17 +2131,17 @@ TypeThree ::: `type` `three`
 </section>
 <section id="sec-Biblio" secid="3.15">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Biblio">3.15</a></span>Biblio</h2>
-<p>By supplying a <code>&quot;biblio&quot;</code> key in a metadata file, you can have Algorithm calls and Non&#8208;terminal tokens which are not defined in this spec to link to where they are defined.</p>
+<p>By supplying a <code>"biblio"</code> key in a metadata file, you can have Algorithm calls and Non-terminal tokens which are not defined in this spec to link to where they are defined.</p>
 <pre><code>spec-md -m metadata.json myspec.md
 </code></pre>
 <p>Where metadata.json includes:</p>
 <pre><code>{
-  &quot;biblio&quot;: {
-    &quot;http://people.mozilla.org/~jorendorff/es6-draft.html&quot;: {
-      &quot;Identifier&quot;: &quot;#sec-names-and-keywords&quot;,
-      &quot;PrimaryExpression&quot;: &quot;#sec-primary-expression&quot;,
-      &quot;ReturnIfAbrupt()&quot;: &quot;#sec-returnifabrupt&quot;,
-      &quot;Get()&quot;: &quot;#sec-get-o-p&quot;
+  "biblio": {
+    "http://people.mozilla.org/~jorendorff/es6-draft.html": {
+      "Identifier": "#sec-names-and-keywords",
+      "PrimaryExpression": "#sec-primary-expression",
+      "ReturnIfAbrupt()": "#sec-returnifabrupt",
+      "Get()": "#sec-get-o-p"
     }
   }
 }
@@ -2185,7 +2188,7 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <li><span class="spec-call"><span data-name="html">html</span>(<var data-name="filePath">filePath</var>, <var data-name="options">options</var>)</span> takes a <var data-name="filepath">filepath</var> to a Markdown file and returns a Promise which will resolve to an HTML string. This function is the primary usage of the <code>spec-md</code> module.</li>
 <li><span class="spec-call"><span data-name="parse">parse</span>(<var data-name="filePath">filePath</var>)</span> takes a filepath and returns a Promise which will resolve to an AST <em>(Abstract Syntax Tree)</em> representing the contents of the Spec Markdown file, with all imports already inlined.</li>
 <li><span class="spec-call"><span data-name="print">print</span>(<var data-name="ast">ast</var>, <var data-name="options">options</var>)</span> takes an <var data-name="ast">ast</var> produced by parse() and returns an HTML string.</li>
-<li><span class="spec-call"><span data-name="visit">visit</span>(<var data-name="ast">ast</var>, <var data-name="visitor">visitor</var>)</span> takes an <var data-name="ast">ast</var> and a <var data-name="visitor">visitor</var>. It walks over the <var data-name="ast">ast</var> in a depth&#8208;first&#8208;traversal calling the <var data-name="visitor">visitor</var> along the way.</li>
+<li><span class="spec-call"><span data-name="visit">visit</span>(<var data-name="ast">ast</var>, <var data-name="visitor">visitor</var>)</span> takes an <var data-name="ast">ast</var> and a <var data-name="visitor">visitor</var>. It walks over the <var data-name="ast">ast</var> in a depth-first-traversal calling the <var data-name="visitor">visitor</var> along the way.</li>
 </ul>
 <section id="sec-Print-Options" secid="A.1">
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Print-Options">A.1</a></span>Print Options</h2>
@@ -2199,7 +2202,7 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <h2><span class="spec-secid" title="link to this section"><a href="#sec-Hot-rebuilding-with-nodemon">A.2</a></span>Hot rebuilding with nodemon</h2>
 <p>The <code>spec-md</code> shell executable follows the <a href="http://www.faqs.org/docs/artu/ch01s06.html">Unix Philosophy</a> of doing one thing and doing it well. Try out <code>nodemon</code> to continuously rebuild the HTML output as you edit the markdown specification:</p>
 <pre data-language="sh"><code>npm install -g nodemon
-nodemon --exec &quot;spec-md &gt; ./path/to/output.html&quot; ./path/to/markdown.md
+nodemon --exec "spec-md &gt; ./path/to/output.html" ./path/to/markdown.md
 </code></pre>
 </section>
 </section>
@@ -2230,7 +2233,7 @@ nodemon --exec &quot;spec-md &gt; ./path/to/output.html&quot; ./path/to/markdown
 <ul>
 <li>2 spaces for indentation (no tabs)</li>
 <li>80 character line length strongly preferred.</li>
-<li>Prefer <code>&#x27;</code> over <code>&quot;</code></li>
+<li>Prefer <code>'</code> over <code>"</code></li>
 <li>Use semicolons;</li>
 <li>Trailing commas,</li>
 <li>Avd abbr wrds.</li>

--- a/test/sections/ast.json
+++ b/test/sections/ast.json
@@ -45,7 +45,7 @@
                             "contents": [
                               {
                                 "type": "Text",
-                                "value": "This has been imported\n"
+                                "value": "This has been imported "
                               }
                             ]
                           }
@@ -133,7 +133,7 @@
                                     },
                                     {
                                       "type": "Text",
-                                      "value": ".\n"
+                                      "value": ". "
                                     }
                                   ]
                                 }

--- a/test/simple-header/ast.json
+++ b/test/simple-header/ast.json
@@ -10,7 +10,7 @@
       "contents": [
         {
           "type": "Text",
-          "value": "This is a simple document with only a header.\n"
+          "value": "This is a simple document with only a header. "
         }
       ]
     }

--- a/test/smart-quotes/ast.json
+++ b/test/smart-quotes/ast.json
@@ -1,0 +1,183 @@
+{
+  "type": "Document",
+  "title": {
+    "type": "DocumentTitle",
+    "value": "Smart typography"
+  },
+  "contents": [
+    {
+      "type": "Section",
+      "secID": null,
+      "title": "Smart quotes and dashes",
+      "contents": [
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "Smart “quote’s quotes.”."
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "Smart single ‘quotes’."
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "A-hyphen and dash – and an inline—em-dash and spaced — em-dash. --- nice."
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "Quoted “"
+            },
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "link"
+                }
+              ],
+              "url": "https://spec-md.com"
+            },
+            {
+              "type": "Text",
+              "value": "” and “"
+            },
+            {
+              "type": "Italic",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "things"
+                }
+              ]
+            },
+            {
+              "type": "Text",
+              "value": "” and "
+            },
+            {
+              "type": "Italic",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "“things”"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "“Quoted line”"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Section",
+      "secID": null,
+      "title": "Arrows",
+      "contents": [
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "← ← ← <---- <-"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "→ → → ----> ->"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "↔ ↔ ↔ <----> <->"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "≤ ⇐ ⇐ <==== <=="
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "⇒ ⇒ ⇒ ====> =>"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "⇔ ⇔ ⇔ <====> <=>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Section",
+      "secID": null,
+      "title": "Math",
+      "contents": [
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "≈ ≥ ≤"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Text",
+              "value": "~= >= <= "
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/smart-quotes/input.md
+++ b/test/smart-quotes/input.md
@@ -1,0 +1,33 @@
+# Smart typography
+
+# Smart quotes and dashes
+
+Smart "quote's quotes.".
+
+Smart single 'quotes'.
+
+A-hyphen and dash - and an inline--em-dash and spaced -- em-dash. --- nice.
+
+Quoted "[link](https://spec-md.com)" and "*things*" and *"things"*
+
+"Quoted line"
+
+# Arrows
+
+<- <-- <--- <---- \<-
+
+-> --> ---> ----> \->
+
+<-> <--> <---> <----> \<->
+
+<= <== <=== <==== \<==
+
+=> ==> ===> ====> \=>
+
+<=> <==> <===> <====> \<=>
+
+# Math
+
+~= >= <=
+
+\~= \>= \<=

--- a/test/smart-quotes/output.html
+++ b/test/smart-quotes/output.html
@@ -2,7 +2,7 @@
 <!-- Built with spec-md https://spec-md.com -->
 <html>
 <head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1"><title>Escape _ Sequences</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"><title>Smart typography</title>
 <style>
 :root {
   color: #333333;
@@ -1025,47 +1025,48 @@ pre[class*="language-"] {
 </head>
 <body><article>
 <header>
-<h1>Escape _ Sequences</h1>
+<h1>Smart typography</h1>
 <nav class="spec-toc">
 <div class="title">Contents</div>
 <ol>
-<li><a href="#sec-Can-be-in-titles-"><span class="spec-secid">1</span>Can be &lt; in titles &gt;</a></li>
-<li><a href="#index"><span class="spec-secid">§</span>Index</a></li>
+<li><a href="#sec-Smart-quotes-and-dashes"><span class="spec-secid">1</span>Smart quotes and dashes</a></li>
+<li><a href="#sec-Arrows"><span class="spec-secid">2</span>Arrows</a></li>
+<li><a href="#sec-Math"><span class="spec-secid">3</span>Math</a></li>
 </ol>
 </nav>
 </header>
-<section id="sec-Can-be-in-titles-" secid="1">
-<h1><span class="spec-secid" title="link to this section"><a href="#sec-Can-be-in-titles-">1</a></span>Can be &lt; in titles &gt;</h1>
-<p>And in _ text.</p>
-<p><strong>And * sub-sections</strong></p>
-<div class="spec-production" id="Grammar">
-<span class="spec-nt"><a href="#Grammar" data-name="Grammar">Grammar</a></span><div class="spec-rhs"><span class="spec-t">&lt;</span><span class="spec-t">rules</span><span class="spec-t">&gt;</span><span class="spec-prose">and _ prose</span></div>
-</div>
-<div class="spec-algo" id="Algorithm_Names()">
-<span class="spec-call"><a href="#Algorithm_Names()" data-name="Algorithm_Names">Algorithm_Names</a>(<var data-name="and_param">and_param</var>, <var data-name="_names">_names</var>)</span><ol>
-<li>And * steps</li>
-<li>And <span class="spec-call"><span data-name="Call_with">Call_with</span>(<span class="spec-string">"string _ \" literal"</span>)</span></li>
-</ol>
-</div>
-<p>Plain <code>code literals don't allow \" escapes\</code></p>
-<div class="spec-production" id="LiteralBackticks">
-<span class="spec-nt"><a href="#LiteralBackticks" data-name="LiteralBackticks">LiteralBackticks</a></span><div class="spec-rhs"><span class="spec-t">`</span></div>
-<div class="spec-rhs"><span class="spec-t">``</span></div>
-<div class="spec-rhs"><span class="spec-t">```</span></div>
-</div>
-<div class="spec-production d2" id="EscapesInQuantifiers">
-<span class="spec-nt"><a href="#EscapesInQuantifiers" data-name="EscapesInQuantifiers">EscapesInQuantifiers</a></span><div class="spec-rhs"><span class="spec-quantified"><span class="spec-nt"><span data-name="OneOrMore">OneOrMore</span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span></span></span><span class="spec-quantified"><span class="spec-nt"><span data-name="ZeroOrMore">ZeroOrMore</span></span><span class="spec-quantifiers"><span class="spec-quantifier list">list</span><span class="spec-quantifier optional">opt</span></span></span><span class="spec-quantified"><span class="spec-nt"><span data-name="Optional">Optional</span></span><span class="spec-quantifiers"><span class="spec-quantifier optional">opt</span></span></span></div>
-</div>
+<section id="sec-Smart-quotes-and-dashes" secid="1">
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Smart-quotes-and-dashes">1</a></span>Smart quotes and dashes</h1>
+<p>Smart &ldquo;quote&rsquo;s quotes.&rdquo;.</p>
+<p>Smart single &lsquo;quotes&rsquo;.</p>
+<p>A-hyphen and dash &ndash; and an inline&mdash;em-dash and spaced &mdash; em-dash. --- nice.</p>
+<p>Quoted &ldquo;<a href="https://spec-md.com">link</a>&rdquo; and &ldquo;<em>things</em>&rdquo; and <em>&ldquo;things&rdquo;</em></p>
+<p>&ldquo;Quoted line&rdquo;</p>
 </section>
-<section id="index" secid="index" class="spec-index"><h1><span class="spec-secid" title="link to the index"><a href="#index">§</a></span>Index</h1><ol><li><a href="#Algorithm_Names()">Algorithm_Names</a></li><li><a href="#EscapesInQuantifiers">EscapesInQuantifiers</a></li><li><a href="#Grammar">Grammar</a></li><li><a href="#LiteralBackticks">LiteralBackticks</a></li></ol></section></article>
+<section id="sec-Arrows" secid="2">
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Arrows">2</a></span>Arrows</h1>
+<p>&larr; &larr; &larr; &lt;---- &lt;-</p>
+<p>&rarr; &rarr; &rarr; ----&gt; -&gt;</p>
+<p>&harr; &harr; &harr; &lt;----&gt; &lt;-&gt;</p>
+<p>&le; &lArr; &lArr; &lt;==== &lt;==</p>
+<p>&rArr; &rArr; &rArr; ====&gt; =&gt;</p>
+<p>&hArr; &hArr; &hArr; &lt;====&gt; &lt;=&gt;</p>
+</section>
+<section id="sec-Math" secid="3">
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Math">3</a></span>Math</h1>
+<p>&asymp; &ge; &le;</p>
+<p>~= &gt;= &lt;= </p>
+</section>
+</article>
 <footer>
 Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</footer>
 <input hidden class="spec-sidebar-toggle" type="checkbox" id="spec-sidebar-toggle" aria-hidden /><label for="spec-sidebar-toggle" aria-hidden><div class="spec-sidebar-button">&#x2630;</div></label>
 <div class="spec-sidebar" aria-hidden>
 <div class="spec-toc">
-<div class="title"><a href="#">Escape _ Sequences</a></div>
-<ol><li id="_sidebar_1"><a href="#sec-Can-be-in-titles-"><span class="spec-secid">1</span>Can be &lt; in titles &gt;</a></li>
-<li id="_sidebar_index"><a href="#index"><span class="spec-secid">§</span>Index</a></li>
+<div class="title"><a href="#">Smart typography</a></div>
+<ol><li id="_sidebar_1"><a href="#sec-Smart-quotes-and-dashes"><span class="spec-secid">1</span>Smart quotes and dashes</a></li>
+<li id="_sidebar_2"><a href="#sec-Arrows"><span class="spec-secid">2</span>Arrows</a></li>
+<li id="_sidebar_3"><a href="#sec-Math"><span class="spec-secid">3</span>Math</a></li>
 </ol>
 </div>
 <script>(function(){var e,t=[],n=document.querySelector('label[for="spec-sidebar-toggle"]');function o(e){e.preventDefault()}n.addEventListener("scroll",o),n.addEventListener("touchmove",o);for(var i=document.getElementsByTagName("section"),r=0;r<i.length;r++)i[r].getAttribute("secid")&&t.push(i[r]);var c=window.scrollY,l=!1;function d(n){for(var o,i=n+document.documentElement.clientHeight/4,r=t.length-1;r>=0;r--)if(t[r].offsetTop<i){o=t[r];break}var c=o&&o.getAttribute("secid");c!==e&&(e&&a(e,!1),c&&a(c,!0),e=c)}function a(e,t){document.getElementById("_sidebar_"+e).className=t?"viewing":"";for(var n=e.split(".");n.length;){var o=document.getElementById("_sidebar_toggle_"+n.join("."));o&&(o.checked=t),n.pop()}}window.addEventListener("scroll",(function(e){c=window.scrollY,l||(l=!0,window.requestAnimationFrame((function(){d(c),l=!1})))})),d(window.scrollY);})()</script>

--- a/test/tables/ast.json
+++ b/test/tables/ast.json
@@ -250,7 +250,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": "Alpha\n-----\na\n"
+              "value": "Alpha ----- a "
             }
           ]
         }

--- a/test/task-lists/ast.json
+++ b/test/task-lists/ast.json
@@ -197,7 +197,7 @@
             },
             {
               "type": "Text",
-              "value": "\n"
+              "value": " "
             }
           ]
         }


### PR DESCRIPTION
Moves text formatting from the printer to the parser and fixes a few rendering bugs.

* Missing space before open single quote
* Replace pure-hyphens with ascii-hyphens
* Replaces cong with asymp
* Fix smart quotes following inline formatting
* Fix edge cases where arrows aren't rendered correctly
* Allow escaping smart typography
* Correctly escape ampersands
* Correctly escape quotes only within html attrs
* Correctly encode all URIs

Fixes #52