### PR TITLE
POTENTIALLY BREAKING: Update Links and Images to be closer to Commonmark spec

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -19,6 +19,7 @@ runTests([
   testSource('readme-gh', 'README.md', '--githubSource https://github.com/leebyron/spec-md/blame/main'),
   testSource('sections'),
   testSource('simple-header'),
+  testSource('links'),
   testSource('headers'),
   testSource('smart-quotes'),
   testSource('tables'),

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -70,8 +70,6 @@ This is an [-->*example*<--](https://www.facebook.com) of a link.
 
 Todo: Links do not yet support a reference style short-form.
 
-Todo: Links do not yet support a title attribute.
-
 
 ### Emphasis
 
@@ -125,42 +123,6 @@ Inline code can also use double- or triple-backticks. Wrapping spaces are remove
 Produces the following:
 
 ![Specs](http://i.imgur.com/aV8o3rE.png)
-
-Also, consider using images for support of more complex features like
-graph diagrams. For example, with Graviso:
-
-```
-![How spec-md works](http://g.gravizo.com/svg?
-  digraph specmd {
-    markdown [shape=box];
-    ast [shape=box];
-    html [shape=box];
-    markdown -> parse [weight=8];
-    parse -> ast;
-    ast -> print;
-    edge [color=red];
-    print -> html;
-  }
-)
-```
-
-Produces the following:
-
-![How spec-md works](http://g.gravizo.com/svg?
-  digraph specmd {
-    markdown [shape=box];
-    ast [shape=box];
-    html [shape=box];
-    markdown -> parse [weight=8];
-    parse -> ast;
-    ast -> print;
-    edge [color=red];
-    print -> html;
-  }
-)
-
-TODO: the title attribute is not yet supported
-
 
 
 ## Blocks

--- a/src/print.js
+++ b/src/print.js
@@ -515,14 +515,19 @@ function printAll(list, options) {
           return '<code>' + escapeCode(node.code) + '</code>';
 
         case 'Link': {
-          const url = resolveLinkUrl(node.url, options);
-          return '<a href="' + encodeURI(url) + '">' + join(node.contents) + '</a>';
+          return (
+            '<a href="' + encodeURI(resolveLinkUrl(node.url, options)) + '"' +
+              (node.title ? ' title="' + escapeAttr(node.title) + '"' : '') + '>' +
+              join(node.contents) +
+            '</a>'
+          );
         }
 
         case 'Image':
           return (
             '<img src="' + encodeURI(node.url) + '"' +
               (node.alt ? ' alt="' + escapeAttr(node.alt) + '"' : '') +
+              (node.title ? ' title="' + escapeAttr(node.title) + '"' : '') +
             '/>'
           );
 
@@ -541,7 +546,7 @@ function printAll(list, options) {
         case 'TaskListItem':
           return (
             '<li class="task"' + dataSourceAttr(node, options) + '>\n' +
-              '<input type="checkbox" disabled' + (node.done ? ' checked' : '') +  '>\n' +
+              '<input type="checkbox" disabled' + (node.done ? ' checked' : '') +  '>' +
               join(node.contents) +
             '</li>\n'
           );

--- a/test/graphql-spec/ast.json
+++ b/test/graphql-spec/ast.json
@@ -50,7 +50,8 @@
                   "value": "release tag"
                 }
               ],
-              "url": "https://github.com/graphql/graphql-spec/releases"
+              "url": "https://github.com/graphql/graphql-spec/releases",
+              "title": null
             },
             {
               "type": "Text",
@@ -64,7 +65,8 @@
                   "value": "https://spec.graphql.org/draft"
                 }
               ],
-              "url": "https://spec.graphql.org/draft"
+              "url": "https://spec.graphql.org/draft",
+              "title": null
             },
             {
               "type": "Text",
@@ -114,7 +116,8 @@
                   "value": "openwebfoundation.org"
                 }
               ],
-              "url": "http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0"
+              "url": "http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0",
+              "title": null
             },
             {
               "type": "Text",
@@ -152,7 +155,8 @@
                   "value": "github.com/graphql/graphql-spec"
                 }
               ],
-              "url": "https://github.com/graphql/graphql-spec/tree/master/signed-agreements"
+              "url": "https://github.com/graphql/graphql-spec/tree/master/signed-agreements",
+              "title": null
             },
             {
               "type": "Text",
@@ -202,7 +206,8 @@
                   "value": "IETF RFC 2119"
                 }
               ],
-              "url": "https://tools.ietf.org/html/rfc2119"
+              "url": "https://tools.ietf.org/html/rfc2119",
+              "title": null
             },
             {
               "type": "Text",
@@ -261,7 +266,8 @@
                   "value": "Appendix A"
                 }
               ],
-              "url": "#sec-Appendix-Notation-Conventions"
+              "url": "#sec-Appendix-Notation-Conventions",
+              "title": null
             },
             {
               "type": "Text",
@@ -630,7 +636,8 @@
                   "value": "Appendix A"
                 }
               ],
-              "url": "#sec-Appendix-Notation-Conventions"
+              "url": "#sec-Appendix-Notation-Conventions",
+              "title": null
             },
             {
               "type": "Text",
@@ -828,7 +835,8 @@
                       "value": "maximal munch"
                     }
                   ],
-                  "url": "https://en.wikipedia.org/wiki/Maximal_munch"
+                  "url": "https://en.wikipedia.org/wiki/Maximal_munch",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -916,7 +924,8 @@
                       "value": "Unicode"
                     }
                   ],
-                  "url": "https://unicode.org/standard/standard.html"
+                  "url": "https://unicode.org/standard/standard.html",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8748,7 +8757,8 @@
                       "value": "custom directives"
                     }
                   ],
-                  "url": "#sec-Type-System.Directives.Custom-Directives"
+                  "url": "#sec-Type-System.Directives.Custom-Directives",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8883,7 +8893,8 @@
                   "value": "IDL"
                 }
               ],
-              "url": "https://en.wikipedia.org/wiki/Interface_description_language"
+              "url": "https://en.wikipedia.org/wiki/Interface_description_language",
+              "title": null
             },
             {
               "type": "Text",
@@ -9045,7 +9056,8 @@
                       "value": "CommonMark"
                     }
                   ],
-                  "url": "https://commonmark.org/"
+                  "url": "https://commonmark.org/",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -10735,7 +10747,8 @@
                           "value": "Serialization Format"
                         }
                       ],
-                      "url": "#sec-Serialization-Format"
+                      "url": "#sec-Serialization-Format",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -11033,7 +11046,8 @@
                           "value": "IEEE 754"
                         }
                       ],
-                      "url": "https://en.wikipedia.org/wiki/IEEE_floating_point"
+                      "url": "https://en.wikipedia.org/wiki/IEEE_floating_point",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -11442,7 +11456,8 @@
                               "value": "GUID"
                             }
                           ],
-                          "url": "https://en.wikipedia.org/wiki/Globally_unique_identifier"
+                          "url": "https://en.wikipedia.org/wiki/Globally_unique_identifier",
+                          "title": null
                         },
                         {
                           "type": "Text",
@@ -15657,7 +15672,8 @@
                           "value": "EDN"
                         }
                       ],
-                      "url": "https://github.com/edn-format/edn"
+                      "url": "https://github.com/edn-format/edn",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -18700,7 +18716,8 @@
                           "value": "RFC process"
                         }
                       ],
-                      "url": "https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md"
+                      "url": "https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -19282,7 +19299,8 @@
                           "value": "CommonMark"
                         }
                       ],
-                      "url": "https://commonmark.org/"
+                      "url": "https://commonmark.org/",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -19483,7 +19501,8 @@
                       "value": "CommonMark"
                     }
                   ],
-                  "url": "https://commonmark.org/"
+                  "url": "https://commonmark.org/",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -33463,7 +33482,8 @@
                           "value": "Errors and Non-Nullability"
                         }
                       ],
-                      "url": "#sec-Errors-and-Non-Nullability"
+                      "url": "#sec-Errors-and-Non-Nullability",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -38908,7 +38928,8 @@
                           "value": "unordered collection of key-value pairs"
                         }
                       ],
-                      "url": "https://tools.ietf.org/html/rfc7159#section-4"
+                      "url": "https://tools.ietf.org/html/rfc7159#section-4",
+                      "title": null
                     },
                     {
                       "type": "Text",

--- a/test/links/ast.json
+++ b/test/links/ast.json
@@ -1,0 +1,502 @@
+{
+  "type": "Document",
+  "title": {
+    "type": "DocumentTitle",
+    "value": "Links"
+  },
+  "contents": [
+    {
+      "type": "Section",
+      "header": {
+        "type": "Header",
+        "level": 1,
+        "secID": null,
+        "title": "Links"
+      },
+      "contents": [
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "Simple link"
+                }
+              ],
+              "url": "url",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With encoded char"
+                }
+              ],
+              "url": "url path",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With encodeable char"
+                }
+              ],
+              "url": "url<path",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With not-always-encoded char"
+                }
+              ],
+              "url": "url(path",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With balanced parens"
+                }
+              ],
+              "url": "url(p(a())th)",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With escaped parens"
+                }
+              ],
+              "url": "url(path",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With pointy url"
+                }
+              ],
+              "url": "url ) path",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With pointy escaped url"
+                }
+              ],
+              "url": "url>path",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With spaces"
+                }
+              ],
+              "url": "url",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With breaks"
+                }
+              ],
+              "url": "url",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With spaces "
+                }
+              ],
+              "url": "url",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "With breaks"
+                }
+              ],
+              "url": "url",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [],
+              "url": "invisible-url",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "no url"
+                }
+              ],
+              "url": "",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "no pointy url"
+                }
+              ],
+              "url": "",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with title"
+                }
+              ],
+              "url": "url",
+              "title": "ti’tle"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with escaped title"
+                }
+              ],
+              "url": "url",
+              "title": "ti\"tle"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with line break"
+                }
+              ],
+              "url": "url",
+              "title": "title break"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with single title"
+                }
+              ],
+              "url": "url",
+              "title": "ti“tle"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with escaped single title"
+                }
+              ],
+              "url": "url",
+              "title": "ti'tle"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with single line break"
+                }
+              ],
+              "url": "url",
+              "title": "title break"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with paren title"
+                }
+              ],
+              "url": "url",
+              "title": "title"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with escaped paren title"
+                }
+              ],
+              "url": "url",
+              "title": "ti(t)le"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "with paren line break"
+                }
+              ],
+              "url": "url",
+              "title": "title break"
+            }
+          ]
+        },
+        {
+          "type": "Paragraph",
+          "contents": [
+            {
+              "type": "Link",
+              "contents": [
+                {
+                  "type": "Image",
+                  "alt": "linked image",
+                  "url": "moon.jpg",
+                  "title": null
+                }
+              ],
+              "url": "/uri",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "Section",
+          "header": {
+            "type": "Header",
+            "level": 2,
+            "secID": null,
+            "title": "Not Links"
+          },
+          "contents": [
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "[Space after title] (url)"
+                }
+              ]
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "[Url with unencoded space](url path)"
+                }
+              ]
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Link",
+                  "contents": [
+                    {
+                      "type": "Text",
+                      "value": "No nested [link"
+                    }
+                  ],
+                  "url": "url",
+                  "title": null
+                },
+                {
+                  "type": "Text",
+                  "value": "](url)"
+                }
+              ]
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "[Unclosed quote title](url “title)"
+                }
+              ]
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "[Interior quote title](url “tit“le”)"
+                }
+              ]
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "[Too many line breaks in title](url “title\\ too many”)"
+                }
+              ]
+            },
+            {
+              "type": "Paragraph",
+              "contents": [
+                {
+                  "type": "Text",
+                  "value": "[with nested paren title](url (ti(t)le)) "
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/links/input.md
+++ b/test/links/input.md
@@ -1,0 +1,79 @@
+# Links
+
+
+# Links
+
+[Simple link](url)
+
+[With encoded char](url%20path)
+
+[With encodeable char](url<path)
+
+[With not-always-encoded char](url%28path)
+
+[With balanced parens](url(p(a())th))
+
+[With escaped parens](url\(path)
+
+[With pointy url](<url ) path>)
+
+[With pointy escaped url](<url\>path>)
+
+[With spaces]( url )
+
+[With breaks](
+  url
+)
+
+[ With spaces ](url)
+
+[
+  With breaks
+](url)
+
+[](invisible-url)
+
+[no url]()
+
+[no pointy url](<>)
+
+[with title](url "ti'tle")
+
+[with escaped title](url "ti\"tle")
+
+[with line break](url "title
+break")
+
+[with single title](url 'ti"tle')
+
+[with escaped single title](url 'ti\'tle')
+
+[with single line break](url 'title
+break')
+
+[with paren title](url (title))
+
+[with escaped paren title](url (ti\(t\)le))
+
+[with paren line break](url (title
+break))
+
+[![linked image](moon.jpg)](/uri)
+
+## Not Links
+
+[Space after title] (url)
+
+[Url with unencoded space](url path)
+
+[No nested [link](url)](url)
+
+[Unclosed quote title](url "title)
+
+[Interior quote title](url "tit"le")
+
+[Too many line breaks in title](url "title\
+
+too many")
+
+[with nested paren title](url (ti(t)le))

--- a/test/links/output.html
+++ b/test/links/output.html
@@ -2,7 +2,7 @@
 <!-- Built with spec-md https://spec-md.com -->
 <html>
 <head><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1"><title>Task lists</title>
+<meta name="viewport" content="width=device-width, initial-scale=1"><title>Links</title>
 <style>
 :root {
   color: #333333;
@@ -1044,60 +1044,69 @@ pre[class*="language-"] {
 </head>
 <body><article>
 <header>
-<h1>Task lists</h1>
-<section id="intro">
-<p>Unordered</p>
-<ul>
-<li class="task">
-<input type="checkbox" disabled>This</li>
-<li class="task">
-<input type="checkbox" disabled checked>task</li>
-<li class="task">
-<input type="checkbox" disabled checked>list</li>
-<li>can have regular bullets</li>
-</ul>
-<p>Ordered</p>
-<ol>
-<li>numbers</li>
-<li class="task">
-<input type="checkbox" disabled checked>can have</li>
-<li>bullets</li>
-</ol>
-<p>Nested</p>
-<ul>
-<li class="task">
-<input type="checkbox" disabled>tasks<ul>
-<li class="task">
-<input type="checkbox" disabled>can be nested<ul>
-<li class="task">
-<input type="checkbox" disabled checked>deeply</li>
-</ul>
-</li>
-</ul>
-</li>
-</ul>
-<p>Requires a space</p>
-<ul>
-<li class="task">
-<input type="checkbox" disabled checked>(task)</li>
-<li><a href="link">x</a></li>
-<li>[x]neither </li>
-</ul>
-</section>
+<h1>Links</h1>
 <nav class="spec-toc">
 <div class="title">Contents</div>
 <ol>
+<li><a href="#sec-Links"><span class="spec-secid">1</span>Links</a><ol>
+<li><a href="#sec-Not-Links"><span class="spec-secid">1.1</span>Not Links</a></li>
+</ol>
+</li>
 </ol>
 </nav>
 </header>
+<section id="sec-Links" secid="1">
+<h1><span class="spec-secid" title="link to this section"><a href="#sec-Links">1</a></span>Links</h1>
+<p><a href="url">Simple link</a></p>
+<p><a href="url%20path">With encoded char</a></p>
+<p><a href="url%3Cpath">With encodeable char</a></p>
+<p><a href="url(path">With not-always-encoded char</a></p>
+<p><a href="url(p(a())th)">With balanced parens</a></p>
+<p><a href="url(path">With escaped parens</a></p>
+<p><a href="url%20)%20path">With pointy url</a></p>
+<p><a href="url%3Epath">With pointy escaped url</a></p>
+<p><a href="url">With spaces</a></p>
+<p><a href="url">With breaks</a></p>
+<p><a href="url">With spaces </a></p>
+<p><a href="url">With breaks</a></p>
+<p><a href="invisible-url"></a></p>
+<p><a href="">no url</a></p>
+<p><a href="">no pointy url</a></p>
+<p><a href="url" title="ti&rsquo;tle">with title</a></p>
+<p><a href="url" title="ti&quot;tle">with escaped title</a></p>
+<p><a href="url" title="title break">with line break</a></p>
+<p><a href="url" title="ti&ldquo;tle">with single title</a></p>
+<p><a href="url" title="ti'tle">with escaped single title</a></p>
+<p><a href="url" title="title break">with single line break</a></p>
+<p><a href="url" title="title">with paren title</a></p>
+<p><a href="url" title="ti(t)le">with escaped paren title</a></p>
+<p><a href="url" title="title break">with paren line break</a></p>
+<p><a href="/uri"><img src="moon.jpg" alt="linked image"/></a></p>
+<section id="sec-Not-Links" secid="1.1">
+<h2><span class="spec-secid" title="link to this section"><a href="#sec-Not-Links">1.1</a></span>Not Links</h2>
+<p>[Space after title] (url)</p>
+<p>[Url with unencoded space](url path)</p>
+<p><a href="url">No nested [link</a>](url)</p>
+<p>[Unclosed quote title](url &ldquo;title)</p>
+<p>[Interior quote title](url &ldquo;tit&ldquo;le&rdquo;)</p>
+<p>[Too many line breaks in title](url &ldquo;title\ too many&rdquo;)</p>
+<p>[with nested paren title](url (ti(t)le)) </p>
+</section>
+</section>
 </article>
 <footer>
 Written in <a href="https://spec-md.com" target="_blank">Spec Markdown</a>.</footer>
 <input hidden class="spec-sidebar-toggle" type="checkbox" id="spec-sidebar-toggle" aria-hidden /><label for="spec-sidebar-toggle" aria-hidden><div class="spec-sidebar-button">&#x2630;</div></label>
 <div class="spec-sidebar" aria-hidden>
 <div class="spec-toc">
-<div class="title"><a href="#">Task lists</a></div>
-<ol></ol>
+<div class="title"><a href="#">Links</a></div>
+<ol><li id="_sidebar_1"><a href="#sec-Links"><span class="spec-secid">1</span>Links</a>
+<input hidden class="toggle" type="checkbox" id="_toggle_1" /><label for="_toggle_1"></label>
+<ol>
+<li id="_sidebar_1.1"><a href="#sec-Not-Links"><span class="spec-secid">1.1</span>Not Links</a></li>
+</ol>
+</li>
+</ol>
 </div>
 <script>(function(){var e,t=[],n=document.querySelector('label[for="spec-sidebar-toggle"]');function o(e){e.preventDefault()}n.addEventListener("scroll",o),n.addEventListener("touchmove",o);for(var i=document.getElementsByTagName("section"),r=0;r<i.length;r++)i[r].getAttribute("secid")&&t.push(i[r]);var c=window.scrollY,l=!1;function d(n){for(var o,i=n+document.documentElement.clientHeight/4,r=t.length-1;r>=0;r--)if(t[r].offsetTop<i){o=t[r];break}var c=o&&o.getAttribute("secid");c!==e&&(e&&a(e,!1),c&&a(c,!0),e=c)}function a(e,t){document.getElementById("_sidebar_"+e).className=t?"viewing":"";for(var n=e.split(".");n.length;){var o=document.getElementById("_toggle_"+n.join("."));o&&(o.checked=t),n.pop()}}window.addEventListener("scroll",(function(e){c=window.scrollY,l||(l=!0,window.requestAnimationFrame((function(){d(c),l=!1})))})),d(window.scrollY);})()</script>
 </div>

--- a/test/readme-gh/ast.json
+++ b/test/readme-gh/ast.json
@@ -83,7 +83,8 @@
                   "value": "Spec additions"
                 }
               ],
-              "url": "./spec/Spec%20Additions.md#Spec-Additions"
+              "url": "./spec/Spec Additions.md#Spec-Additions",
+              "title": null
             },
             {
               "type": "Text",
@@ -164,7 +165,8 @@
                   "value": "Using Spec Markdown"
                 }
               ],
-              "url": "./spec/Usage.md#Using-Spec-Markdown"
+              "url": "./spec/Usage.md#Using-Spec-Markdown",
+              "title": null
             },
             {
               "type": "Text",
@@ -198,7 +200,8 @@
                   "value": "Markdown"
                 }
               ],
-              "url": "http://daringfireball.net/projects/markdown/syntax"
+              "url": "http://daringfireball.net/projects/markdown/syntax",
+              "title": null
             },
             {
               "type": "Text",
@@ -212,7 +215,8 @@
                   "value": "Github-flavored Markdown"
                 }
               ],
-              "url": "https://help.github.com/articles/github-flavored-markdown/"
+              "url": "https://help.github.com/articles/github-flavored-markdown/",
+              "title": null
             },
             {
               "type": "Text",
@@ -576,7 +580,8 @@
                           "value": "←"
                         }
                       ],
-                      "url": "https://www.facebook.com"
+                      "url": "https://www.facebook.com",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -590,15 +595,6 @@
                     {
                       "type": "Text",
                       "value": "Links do not yet support a reference style short-form."
-                    }
-                  ]
-                },
-                {
-                  "type": "Todo",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "Links do not yet support a title attribute."
                     }
                   ]
                 }
@@ -929,52 +925,8 @@
                     {
                       "type": "Image",
                       "alt": "Specs",
-                      "url": "http://i.imgur.com/aV8o3rE.png"
-                    }
-                  ]
-                },
-                {
-                  "type": "Paragraph",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "Also, consider using images for support of more complex features like graph diagrams. For example, with Graviso:"
-                    }
-                  ]
-                },
-                {
-                  "type": "Code",
-                  "raw": false,
-                  "lang": null,
-                  "example": false,
-                  "counter": false,
-                  "code": "![How spec-md works](http://g.gravizo.com/svg?\n  digraph specmd {\n    markdown [shape=box];\n    ast [shape=box];\n    html [shape=box];\n    markdown -> parse [weight=8];\n    parse -> ast;\n    ast -> print;\n    edge [color=red];\n    print -> html;\n  }\n)\n"
-                },
-                {
-                  "type": "Paragraph",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "Produces the following:"
-                    }
-                  ]
-                },
-                {
-                  "type": "Paragraph",
-                  "contents": [
-                    {
-                      "type": "Image",
-                      "alt": "How spec-md works",
-                      "url": "http://g.gravizo.com/svg?\n  digraph specmd {\n    markdown [shape=box];\n    ast [shape=box];\n    html [shape=box];\n    markdown -> parse [weight=8];\n    parse -> ast;\n    ast -> print;\n    edge [color=red];\n    print -> html;\n  }\n"
-                    }
-                  ]
-                },
-                {
-                  "type": "Todo",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "the title attribute is not yet supported"
+                      "url": "http://i.imgur.com/aV8o3rE.png",
+                      "title": null
                     }
                   ]
                 }
@@ -1426,7 +1378,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": " is"
+                              "value": "is"
                             }
                           ]
                         },
@@ -1436,7 +1388,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": " a"
+                              "value": "a"
                             },
                             {
                               "type": "List",
@@ -1448,7 +1400,7 @@
                                   "contents": [
                                     {
                                       "type": "Text",
-                                      "value": " nested"
+                                      "value": "nested"
                                     }
                                   ]
                                 }
@@ -1659,7 +1611,8 @@
                       "value": "Algorithms"
                     }
                   ],
-                  "url": "#sec-Algorithms"
+                  "url": "#sec-Algorithms",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -1673,7 +1626,8 @@
                       "value": "Grammar"
                     }
                   ],
-                  "url": "#sec-Grammar"
+                  "url": "#sec-Grammar",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -1687,7 +1641,8 @@
                       "value": "Notes"
                     }
                   ],
-                  "url": "#sec-Note"
+                  "url": "#sec-Note",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -1701,7 +1656,8 @@
                       "value": "Examples"
                     }
                   ],
-                  "url": "#sec-Examples"
+                  "url": "#sec-Examples",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -2892,7 +2848,8 @@
                       "value": "CriticMarkup"
                     }
                   ],
-                  "url": "http://criticmarkup.com/"
+                  "url": "http://criticmarkup.com/",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -7661,7 +7618,8 @@
                   "value": "node script"
                 }
               ],
-              "url": "https://docs.npmjs.com/cli/run-script"
+              "url": "https://docs.npmjs.com/cli/run-script",
+              "title": null
             },
             {
               "type": "Text",
@@ -8047,7 +8005,8 @@
                       "value": "Unix Philosophy"
                     }
                   ],
-                  "url": "http://www.faqs.org/docs/artu/ch01s06.html"
+                  "url": "http://www.faqs.org/docs/artu/ch01s06.html",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8099,7 +8058,8 @@
                   "value": "Issue"
                 }
               ],
-              "url": "https://github.com/leebyron/spec-md/issues"
+              "url": "https://github.com/leebyron/spec-md/issues",
+              "title": null
             },
             {
               "type": "Text",
@@ -8131,7 +8091,8 @@
                       "value": "pull requests"
                     }
                   ],
-                  "url": "https://help.github.com/articles/creating-a-pull-request"
+                  "url": "https://help.github.com/articles/creating-a-pull-request",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8154,7 +8115,8 @@
                           "value": "Fork the repo"
                         }
                       ],
-                      "url": "https://github.com/leebyron/spec-md/"
+                      "url": "https://github.com/leebyron/spec-md/",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -8258,7 +8220,8 @@
                       "value": "version"
                     }
                   ],
-                  "url": "http://semver.org/"
+                  "url": "http://semver.org/",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8272,7 +8235,8 @@
                       "value": "npm"
                     }
                   ],
-                  "url": "https://www.npmjs.org/package/spec-md"
+                  "url": "https://www.npmjs.org/package/spec-md",
+                  "title": null
                 },
                 {
                   "type": "Text",

--- a/test/readme-gh/output.html
+++ b/test/readme-gh/output.html
@@ -1216,69 +1216,49 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <p data-source="spec/Markdown.md#L68">This is an <a href="https://www.facebook.com">&rarr;<em>example</em>&larr;</a> of a link.</p>
 <div class="spec-todo" data-source="spec/Markdown.md#L71">
 Links do not yet support a reference style short-form.</div>
-<div class="spec-todo" data-source="spec/Markdown.md#L73">
-Links do not yet support a title attribute.</div>
 </section>
 <section id="sec-Emphasis" secid="2.2.3">
-<h3 data-source="spec/Markdown.md#L76"><span class="spec-secid" title="link to this section"><a href="#sec-Emphasis">2.2.3</a></span>Emphasis</h3>
-<p data-source="spec/Markdown.md#L78">Wrapping asterisks <em>(*)</em> indicate emphasis.</p>
-<pre data-source="spec/Markdown.md#L80-L82"><code>Example of **bold** and *italic* and ***bold italic***.
+<h3 data-source="spec/Markdown.md#L74"><span class="spec-secid" title="link to this section"><a href="#sec-Emphasis">2.2.3</a></span>Emphasis</h3>
+<p data-source="spec/Markdown.md#L76">Wrapping asterisks <em>(*)</em> indicate emphasis.</p>
+<pre data-source="spec/Markdown.md#L78-L80"><code>Example of **bold** and *italic* and ***bold italic***.
 </code></pre>
-<p data-source="spec/Markdown.md#L84">Produces the following:</p>
-<p data-source="spec/Markdown.md#L86">Example of <strong>bold</strong> and <em>italic</em> and <strong><em>bold italic</em></strong>.</p>
-<p data-source="spec/Markdown.md#L88">Alternatively, use underscore <em>(_)</em> for italic emphasis.</p>
-<pre data-source="spec/Markdown.md#L90-L92"><code>Example of _italic_ and **_bold italic_** or _**bold italic**_.
+<p data-source="spec/Markdown.md#L82">Produces the following:</p>
+<p data-source="spec/Markdown.md#L84">Example of <strong>bold</strong> and <em>italic</em> and <strong><em>bold italic</em></strong>.</p>
+<p data-source="spec/Markdown.md#L86">Alternatively, use underscore <em>(_)</em> for italic emphasis.</p>
+<pre data-source="spec/Markdown.md#L88-L90"><code>Example of _italic_ and **_bold italic_** or _**bold italic**_.
 </code></pre>
-<p data-source="spec/Markdown.md#L94">Produces the following:</p>
-<p data-source="spec/Markdown.md#L96">Example of <em>italic</em> and <strong><em>bold italic</em></strong> or <em><strong>bold italic</strong></em>.</p>
+<p data-source="spec/Markdown.md#L92">Produces the following:</p>
+<p data-source="spec/Markdown.md#L94">Example of <em>italic</em> and <strong><em>bold italic</em></strong> or <em><strong>bold italic</strong></em>.</p>
 </section>
 <section id="sec-Inline-Code" secid="2.2.4">
-<h3 data-source="spec/Markdown.md#L99"><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Code">2.2.4</a></span>Inline Code</h3>
-<p data-source="spec/Markdown.md#L101-L103">Wrapping back-ticks <em>(`)</em> indicate inline code, text inside back-ticks is not formatted, allowing for special characters to be used in inline code without escapes.</p>
-<pre data-source="spec/Markdown.md#L105-L107"><code>This is an `example` of some inline code.
+<h3 data-source="spec/Markdown.md#L97"><span class="spec-secid" title="link to this section"><a href="#sec-Inline-Code">2.2.4</a></span>Inline Code</h3>
+<p data-source="spec/Markdown.md#L99-L101">Wrapping back-ticks <em>(`)</em> indicate inline code, text inside back-ticks is not formatted, allowing for special characters to be used in inline code without escapes.</p>
+<pre data-source="spec/Markdown.md#L103-L105"><code>This is an `example` of some inline code.
 </code></pre>
-<p data-source="spec/Markdown.md#L109">Produces</p>
-<p data-source="spec/Markdown.md#L111">This is an <code>example</code> of some inline code.</p>
-<p data-source="spec/Markdown.md#L114">Inline code can also use double- or triple-backticks. Wrapping spaces are removed.</p>
-<p data-source="spec/Markdown.md#L116"><code>`` ` ``</code> Produces <code>`</code></p>
+<p data-source="spec/Markdown.md#L107">Produces</p>
+<p data-source="spec/Markdown.md#L109">This is an <code>example</code> of some inline code.</p>
+<p data-source="spec/Markdown.md#L112">Inline code can also use double- or triple-backticks. Wrapping spaces are removed.</p>
+<p data-source="spec/Markdown.md#L114"><code>`` ` ``</code> Produces <code>`</code></p>
 </section>
 <section id="sec-Images" secid="2.2.5">
-<h3 data-source="spec/Markdown.md#L119"><span class="spec-secid" title="link to this section"><a href="#sec-Images">2.2.5</a></span>Images</h3>
-<pre data-source="spec/Markdown.md#L121-L123"><code>![Specs](http://i.imgur.com/aV8o3rE.png)
+<h3 data-source="spec/Markdown.md#L117"><span class="spec-secid" title="link to this section"><a href="#sec-Images">2.2.5</a></span>Images</h3>
+<pre data-source="spec/Markdown.md#L119-L121"><code>![Specs](http://i.imgur.com/aV8o3rE.png)
 </code></pre>
-<p data-source="spec/Markdown.md#L125">Produces the following:</p>
-<p data-source="spec/Markdown.md#L127"><img src="http://i.imgur.com/aV8o3rE.png" alt="Specs"/></p>
-<p data-source="spec/Markdown.md#L129-L130">Also, consider using images for support of more complex features like graph diagrams. For example, with Graviso:</p>
-<pre data-source="spec/Markdown.md#L132-L145"><code>![How spec-md works](http://g.gravizo.com/svg?
-  digraph specmd {
-    markdown [shape=box];
-    ast [shape=box];
-    html [shape=box];
-    markdown -&gt; parse [weight=8];
-    parse -&gt; ast;
-    ast -&gt; print;
-    edge [color=red];
-    print -&gt; html;
-  }
-)
-</code></pre>
-<p data-source="spec/Markdown.md#L147">Produces the following:</p>
-<p data-source="spec/Markdown.md#L149-L160"><img src="http://g.gravizo.com/svg?%0A%20%20digraph%20specmd%20%7B%0A%20%20%20%20markdown%20%5Bshape=box%5D;%0A%20%20%20%20ast%20%5Bshape=box%5D;%0A%20%20%20%20html%20%5Bshape=box%5D;%0A%20%20%20%20markdown%20-%3E%20parse%20%5Bweight=8%5D;%0A%20%20%20%20parse%20-%3E%20ast;%0A%20%20%20%20ast%20-%3E%20print;%0A%20%20%20%20edge%20%5Bcolor=red%5D;%0A%20%20%20%20print%20-%3E%20html;%0A%20%20%7D%0A" alt="How spec-md works"/></p>
-<div class="spec-todo" data-source="spec/Markdown.md#L162">
-the title attribute is not yet supported</div>
+<p data-source="spec/Markdown.md#L123">Produces the following:</p>
+<p data-source="spec/Markdown.md#L125"><img src="http://i.imgur.com/aV8o3rE.png" alt="Specs"/></p>
 </section>
 </section>
 <section id="sec-Blocks" secid="2.3">
-<h2 data-source="spec/Markdown.md#L166"><span class="spec-secid" title="link to this section"><a href="#sec-Blocks">2.3</a></span>Blocks</h2>
-<p data-source="spec/Markdown.md#L168-L170">Markdown allows for block-level structual formatting. Every block is seperated by at least two new lines. Spec Markdown makes use of Markdown&rsquo;s blocks to produce more specific structural formatting.</p>
+<h2 data-source="spec/Markdown.md#L128"><span class="spec-secid" title="link to this section"><a href="#sec-Blocks">2.3</a></span>Blocks</h2>
+<p data-source="spec/Markdown.md#L130-L132">Markdown allows for block-level structual formatting. Every block is seperated by at least two new lines. Spec Markdown makes use of Markdown&rsquo;s blocks to produce more specific structural formatting.</p>
 <section id="sec-Block-HTML" secid="2.3.1">
-<h3 data-source="spec/Markdown.md#L173"><span class="spec-secid" title="link to this section"><a href="#sec-Block-HTML">2.3.1</a></span>Block HTML</h3>
-<p data-source="spec/Markdown.md#L175-L177">Markdown is not a replacement for HTML and instead leverages HTML by allowing its use as complete blocks when separated from surrounding content by blank lines.</p>
-<div id="note-5b9d8" class="spec-note" data-source="spec/Markdown.md#L179">
+<h3 data-source="spec/Markdown.md#L135"><span class="spec-secid" title="link to this section"><a href="#sec-Block-HTML">2.3.1</a></span>Block HTML</h3>
+<p data-source="spec/Markdown.md#L137-L139">Markdown is not a replacement for HTML and instead leverages HTML by allowing its use as complete blocks when separated from surrounding content by blank lines.</p>
+<div id="note-5b9d8" class="spec-note" data-source="spec/Markdown.md#L141">
 <a href="#note-5b9d8">Note</a>
 Markdown formatting syntax is not processed within block-level HTML tags.</div>
-<p data-source="spec/Markdown.md#L181">For example, to add an HTML table to a Markdown article:</p>
-<pre data-source="spec/Markdown.md#L183-L200"><code>Unrelated previous paragraph followed by a blank line
+<p data-source="spec/Markdown.md#L143">For example, to add an HTML table to a Markdown article:</p>
+<pre data-source="spec/Markdown.md#L145-L162"><code>Unrelated previous paragraph followed by a blank line
 
 &lt;table&gt;
 &lt;tr&gt;
@@ -1295,8 +1275,8 @@ Markdown formatting syntax is not processed within block-level HTML tags.</div>
 &lt;/tr&gt;
 &lt;/table&gt;
 </code></pre>
-<p data-source="spec/Markdown.md#L202">Produces the following:</p>
-<p data-source="spec/Markdown.md#L204">Unrelated previous paragraph followed by a blank line</p>
+<p data-source="spec/Markdown.md#L164">Produces the following:</p>
+<p data-source="spec/Markdown.md#L166">Unrelated previous paragraph followed by a blank line</p>
 <table>
 <tr>
 <td>Table cell</td>
@@ -1310,8 +1290,8 @@ Markdown formatting syntax is not processed within block-level HTML tags.</div>
 
 </td>
 </tr>
-</table><p data-source="spec/Markdown.md#L221">And using <code>&lt;pre&gt;</code> produces a simple code block:</p>
-<pre data-source="spec/Markdown.md#L223-L237"><code>&lt;pre&gt;
+</table><p data-source="spec/Markdown.md#L183">And using <code>&lt;pre&gt;</code> produces a simple code block:</p>
+<pre data-source="spec/Markdown.md#L185-L199"><code>&lt;pre&gt;
 Buffalo Bill ’s
 defunct
        who used to
@@ -1325,7 +1305,7 @@ how do you like your blueeyed boy
 Mister Death
 &lt;/pre&gt;
 </code></pre>
-<p data-source="spec/Markdown.md#L239">Produces the following:</p>
+<p data-source="spec/Markdown.md#L201">Produces the following:</p>
 <pre>
 Buffalo Bill ’s
 defunct
@@ -1340,91 +1320,88 @@ how do you like your blueeyed boy
 Mister Death
 </pre></section>
 <section id="sec-Blocks.Section-Headers" secid="2.3.2">
-<h3 data-source="spec/Markdown.md#L256"><span class="spec-secid" title="link to this section"><a href="#sec-Blocks.Section-Headers">2.3.2</a></span>Section Headers</h3>
-<p data-source="spec/Markdown.md#L258-L259">Regular Markdown supports two styles of headers, Setext and atx, however Spec Markdown generally only supports atx style headers.</p>
-<pre id="example-d82de" class="spec-example" data-source="spec/Markdown.md#L261-L263"><a href="#example-d82de">Example № 1</a><code># Header
+<h3 data-source="spec/Markdown.md#L218"><span class="spec-secid" title="link to this section"><a href="#sec-Blocks.Section-Headers">2.3.2</a></span>Section Headers</h3>
+<p data-source="spec/Markdown.md#L220-L221">Regular Markdown supports two styles of headers, Setext and atx, however Spec Markdown generally only supports atx style headers.</p>
+<pre id="example-d82de" class="spec-example" data-source="spec/Markdown.md#L223-L225"><a href="#example-d82de">Example № 1</a><code># Header
 </code></pre>
-<p data-source="spec/Markdown.md#L265">Setext headers are not supported by Spec Markdown.</p>
-<pre id="example-7c917" class="spec-counter-example" data-source="spec/Markdown.md#L267-L270"><a href="#example-7c917">Counter Example № 2</a><code>Header
+<p data-source="spec/Markdown.md#L227">Setext headers are not supported by Spec Markdown.</p>
+<pre id="example-7c917" class="spec-counter-example" data-source="spec/Markdown.md#L229-L232"><a href="#example-7c917">Counter Example № 2</a><code>Header
 ------
 </code></pre>
-<p data-source="spec/Markdown.md#L272-L274">The number of <code>#</code> characters refers to the depth of the section. To produce an, <code>&lt;h3&gt;</code>, type <code>###</code>. Optionally, a header may be &ldquo;closed&rdquo; by any number of <code>#</code> characters.</p>
-<div id="note-e6510" class="spec-note" data-source="spec/Markdown.md#L276">
+<p data-source="spec/Markdown.md#L234-L236">The number of <code>#</code> characters refers to the depth of the section. To produce an, <code>&lt;h3&gt;</code>, type <code>###</code>. Optionally, a header may be &ldquo;closed&rdquo; by any number of <code>#</code> characters.</p>
+<div id="note-e6510" class="spec-note" data-source="spec/Markdown.md#L238">
 <a href="#note-e6510">Note</a>
 Spec Markdown requires that documents start with a header.</div>
 </section>
 <section id="sec-Paragraphs" secid="2.3.3">
-<h3 data-source="spec/Markdown.md#L279"><span class="spec-secid" title="link to this section"><a href="#sec-Paragraphs">2.3.3</a></span>Paragraphs</h3>
-<p data-source="spec/Markdown.md#L281-L282">Paragraphs are the most simple Markdown blocks. Lines are appended together to form a single &lt;p&gt; tag. Any inline syntax is allowed within a paragraph.</p>
+<h3 data-source="spec/Markdown.md#L241"><span class="spec-secid" title="link to this section"><a href="#sec-Paragraphs">2.3.3</a></span>Paragraphs</h3>
+<p data-source="spec/Markdown.md#L243-L244">Paragraphs are the most simple Markdown blocks. Lines are appended together to form a single &lt;p&gt; tag. Any inline syntax is allowed within a paragraph.</p>
 </section>
 <section id="sec-Lists" secid="2.3.4">
-<h3 data-source="spec/Markdown.md#L285"><span class="spec-secid" title="link to this section"><a href="#sec-Lists">2.3.4</a></span>Lists</h3>
-<p data-source="spec/Markdown.md#L287-L288">Markdown lists are lines which each start with either a ordered bullet <code>1.</code> or unordered bullet, <code>*</code>, <code>-</code>, or <code>+</code>. Lists are optionally indented by two spaces.</p>
-<p data-source="spec/Markdown.md#L290">Lists can be nested within other lists by indenting by at least two spaces.</p>
-<pre id="example-4d8ec" class="spec-example" data-source="spec/Markdown.md#L292-L298"><a href="#example-4d8ec">Example № 3</a><code>  1. this
+<h3 data-source="spec/Markdown.md#L247"><span class="spec-secid" title="link to this section"><a href="#sec-Lists">2.3.4</a></span>Lists</h3>
+<p data-source="spec/Markdown.md#L249-L250">Markdown lists are lines which each start with either a ordered bullet <code>1.</code> or unordered bullet, <code>*</code>, <code>-</code>, or <code>+</code>. Lists are optionally indented by two spaces.</p>
+<p data-source="spec/Markdown.md#L252">Lists can be nested within other lists by indenting by at least two spaces.</p>
+<pre id="example-4d8ec" class="spec-example" data-source="spec/Markdown.md#L254-L260"><a href="#example-4d8ec">Example № 3</a><code>  1. this
   2. is
   3. a
     - nested
   4. list
 </code></pre>
-<p data-source="spec/Markdown.md#L300">Produces the following:</p>
+<p data-source="spec/Markdown.md#L262">Produces the following:</p>
 <ol>
-<li data-source="spec/Markdown.md#L302">this</li>
-<li data-source="spec/Markdown.md#L303">is</li>
-<li data-source="spec/Markdown.md#L304-L305">a<ul>
-<li data-source="spec/Markdown.md#L305">nested</li>
+<li data-source="spec/Markdown.md#L264">this</li>
+<li data-source="spec/Markdown.md#L265">is</li>
+<li data-source="spec/Markdown.md#L266-L267">a<ul>
+<li data-source="spec/Markdown.md#L267">nested</li>
 </ul>
 </li>
-<li data-source="spec/Markdown.md#L306">list</li>
+<li data-source="spec/Markdown.md#L268">list</li>
 </ol>
 <section id="sec-Task-Lists" secid="2.3.4.1">
-<h4 data-source="spec/Markdown.md#L308"><span class="spec-secid" title="link to this section"><a href="#sec-Task-Lists">2.3.4.1</a></span>Task Lists</h4>
-<p data-source="spec/Markdown.md#L310-L312">Spec Markdown also supports task lists. Start a list item with <code>[ ]</code> or <code>[x]</code> to render a checkbox. This can be useful for keeping your tasks inline with in-progress draft specifications.</p>
-<pre id="example-f34a9" class="spec-example" data-source="spec/Markdown.md#L314-L320"><a href="#example-f34a9">Example № 4</a><code>  1. this
+<h4 data-source="spec/Markdown.md#L270"><span class="spec-secid" title="link to this section"><a href="#sec-Task-Lists">2.3.4.1</a></span>Task Lists</h4>
+<p data-source="spec/Markdown.md#L272-L274">Spec Markdown also supports task lists. Start a list item with <code>[ ]</code> or <code>[x]</code> to render a checkbox. This can be useful for keeping your tasks inline with in-progress draft specifications.</p>
+<pre id="example-f34a9" class="spec-example" data-source="spec/Markdown.md#L276-L282"><a href="#example-f34a9">Example № 4</a><code>  1. this
   2. [ ] is
   3. [x] a
     - [X] nested
   4. todo list
 </code></pre>
-<p data-source="spec/Markdown.md#L322">Produces the following:</p>
+<p data-source="spec/Markdown.md#L284">Produces the following:</p>
 <ol>
-<li data-source="spec/Markdown.md#L324">this</li>
-<li class="task" data-source="spec/Markdown.md#L325">
-<input type="checkbox" disabled>
- is</li>
-<li class="task" data-source="spec/Markdown.md#L326-L327">
-<input type="checkbox" disabled checked>
- a<ul>
-<li class="task" data-source="spec/Markdown.md#L327">
-<input type="checkbox" disabled checked>
- nested</li>
+<li data-source="spec/Markdown.md#L286">this</li>
+<li class="task" data-source="spec/Markdown.md#L287">
+<input type="checkbox" disabled>is</li>
+<li class="task" data-source="spec/Markdown.md#L288-L289">
+<input type="checkbox" disabled checked>a<ul>
+<li class="task" data-source="spec/Markdown.md#L289">
+<input type="checkbox" disabled checked>nested</li>
 </ul>
 </li>
-<li data-source="spec/Markdown.md#L328">todo list</li>
+<li data-source="spec/Markdown.md#L290">todo list</li>
 </ol>
 </section>
 </section>
 <section id="sec-Code-Block" secid="2.3.5">
-<h3 data-source="spec/Markdown.md#L331"><span class="spec-secid" title="link to this section"><a href="#sec-Code-Block">2.3.5</a></span>Code Block</h3>
-<p data-source="spec/Markdown.md#L333-L334">A block of code is formed by either indenting by 4 spaces, or wrapping with <code>```</code> on their own lines.</p>
-<pre data-source="spec/Markdown.md#L336-L338"><code>```
+<h3 data-source="spec/Markdown.md#L293"><span class="spec-secid" title="link to this section"><a href="#sec-Code-Block">2.3.5</a></span>Code Block</h3>
+<p data-source="spec/Markdown.md#L295-L296">A block of code is formed by either indenting by 4 spaces, or wrapping with <code>```</code> on their own lines.</p>
+<pre data-source="spec/Markdown.md#L298-L300"><code>```
 const code = sample();
 ```</code></pre>
-<p data-source="spec/Markdown.md#L340">Produces the following:</p>
-<pre data-source="spec/Markdown.md#L342-L344"><code>const code = sample();
+<p data-source="spec/Markdown.md#L302">Produces the following:</p>
+<pre data-source="spec/Markdown.md#L304-L306"><code>const code = sample();
 </code></pre>
 </section>
 <section id="sec-Block-Quotes" secid="2.3.6">
-<h3 data-source="spec/Markdown.md#L347"><span class="spec-secid" title="link to this section"><a href="#sec-Block-Quotes">2.3.6</a></span>Block Quotes</h3>
-<p data-source="spec/Markdown.md#L349">Spec markdown does not yet support Markdown&rsquo;s <code>&gt;</code> style block quotes.</p>
+<h3 data-source="spec/Markdown.md#L309"><span class="spec-secid" title="link to this section"><a href="#sec-Block-Quotes">2.3.6</a></span>Block Quotes</h3>
+<p data-source="spec/Markdown.md#L311">Spec markdown does not yet support Markdown&rsquo;s <code>&gt;</code> style block quotes.</p>
 </section>
 <section id="sec-Horizontal-Rules" secid="2.3.7">
-<h3 data-source="spec/Markdown.md#L352"><span class="spec-secid" title="link to this section"><a href="#sec-Horizontal-Rules">2.3.7</a></span>Horizontal Rules</h3>
-<p data-source="spec/Markdown.md#L354">Spec Markdown does not yet support Markdown&rsquo;s <code>---</code> style &lt;hr&gt;.</p>
+<h3 data-source="spec/Markdown.md#L314"><span class="spec-secid" title="link to this section"><a href="#sec-Horizontal-Rules">2.3.7</a></span>Horizontal Rules</h3>
+<p data-source="spec/Markdown.md#L316">Spec Markdown does not yet support Markdown&rsquo;s <code>---</code> style &lt;hr&gt;.</p>
 </section>
 <section id="sec-Automatic-Links" secid="2.3.8">
-<h3 data-source="spec/Markdown.md#L357"><span class="spec-secid" title="link to this section"><a href="#sec-Automatic-Links">2.3.8</a></span>Automatic Links</h3>
-<p data-source="spec/Markdown.md#L359-L360">Spec Markdown does not yet automatically link urls. </p>
+<h3 data-source="spec/Markdown.md#L319"><span class="spec-secid" title="link to this section"><a href="#sec-Automatic-Links">2.3.8</a></span>Automatic Links</h3>
+<p data-source="spec/Markdown.md#L321-L322">Spec Markdown does not yet automatically link urls. </p>
 </section>
 </section>
 </section>

--- a/test/readme/ast.json
+++ b/test/readme/ast.json
@@ -83,7 +83,8 @@
                   "value": "Spec additions"
                 }
               ],
-              "url": "./spec/Spec%20Additions.md#Spec-Additions"
+              "url": "./spec/Spec Additions.md#Spec-Additions",
+              "title": null
             },
             {
               "type": "Text",
@@ -164,7 +165,8 @@
                   "value": "Using Spec Markdown"
                 }
               ],
-              "url": "./spec/Usage.md#Using-Spec-Markdown"
+              "url": "./spec/Usage.md#Using-Spec-Markdown",
+              "title": null
             },
             {
               "type": "Text",
@@ -198,7 +200,8 @@
                   "value": "Markdown"
                 }
               ],
-              "url": "http://daringfireball.net/projects/markdown/syntax"
+              "url": "http://daringfireball.net/projects/markdown/syntax",
+              "title": null
             },
             {
               "type": "Text",
@@ -212,7 +215,8 @@
                   "value": "Github-flavored Markdown"
                 }
               ],
-              "url": "https://help.github.com/articles/github-flavored-markdown/"
+              "url": "https://help.github.com/articles/github-flavored-markdown/",
+              "title": null
             },
             {
               "type": "Text",
@@ -576,7 +580,8 @@
                           "value": "←"
                         }
                       ],
-                      "url": "https://www.facebook.com"
+                      "url": "https://www.facebook.com",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -590,15 +595,6 @@
                     {
                       "type": "Text",
                       "value": "Links do not yet support a reference style short-form."
-                    }
-                  ]
-                },
-                {
-                  "type": "Todo",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "Links do not yet support a title attribute."
                     }
                   ]
                 }
@@ -929,52 +925,8 @@
                     {
                       "type": "Image",
                       "alt": "Specs",
-                      "url": "http://i.imgur.com/aV8o3rE.png"
-                    }
-                  ]
-                },
-                {
-                  "type": "Paragraph",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "Also, consider using images for support of more complex features like graph diagrams. For example, with Graviso:"
-                    }
-                  ]
-                },
-                {
-                  "type": "Code",
-                  "raw": false,
-                  "lang": null,
-                  "example": false,
-                  "counter": false,
-                  "code": "![How spec-md works](http://g.gravizo.com/svg?\n  digraph specmd {\n    markdown [shape=box];\n    ast [shape=box];\n    html [shape=box];\n    markdown -> parse [weight=8];\n    parse -> ast;\n    ast -> print;\n    edge [color=red];\n    print -> html;\n  }\n)\n"
-                },
-                {
-                  "type": "Paragraph",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "Produces the following:"
-                    }
-                  ]
-                },
-                {
-                  "type": "Paragraph",
-                  "contents": [
-                    {
-                      "type": "Image",
-                      "alt": "How spec-md works",
-                      "url": "http://g.gravizo.com/svg?\n  digraph specmd {\n    markdown [shape=box];\n    ast [shape=box];\n    html [shape=box];\n    markdown -> parse [weight=8];\n    parse -> ast;\n    ast -> print;\n    edge [color=red];\n    print -> html;\n  }\n"
-                    }
-                  ]
-                },
-                {
-                  "type": "Todo",
-                  "contents": [
-                    {
-                      "type": "Text",
-                      "value": "the title attribute is not yet supported"
+                      "url": "http://i.imgur.com/aV8o3rE.png",
+                      "title": null
                     }
                   ]
                 }
@@ -1426,7 +1378,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": " is"
+                              "value": "is"
                             }
                           ]
                         },
@@ -1436,7 +1388,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": " a"
+                              "value": "a"
                             },
                             {
                               "type": "List",
@@ -1448,7 +1400,7 @@
                                   "contents": [
                                     {
                                       "type": "Text",
-                                      "value": " nested"
+                                      "value": "nested"
                                     }
                                   ]
                                 }
@@ -1659,7 +1611,8 @@
                       "value": "Algorithms"
                     }
                   ],
-                  "url": "#sec-Algorithms"
+                  "url": "#sec-Algorithms",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -1673,7 +1626,8 @@
                       "value": "Grammar"
                     }
                   ],
-                  "url": "#sec-Grammar"
+                  "url": "#sec-Grammar",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -1687,7 +1641,8 @@
                       "value": "Notes"
                     }
                   ],
-                  "url": "#sec-Note"
+                  "url": "#sec-Note",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -1701,7 +1656,8 @@
                       "value": "Examples"
                     }
                   ],
-                  "url": "#sec-Examples"
+                  "url": "#sec-Examples",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -2892,7 +2848,8 @@
                       "value": "CriticMarkup"
                     }
                   ],
-                  "url": "http://criticmarkup.com/"
+                  "url": "http://criticmarkup.com/",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -7661,7 +7618,8 @@
                   "value": "node script"
                 }
               ],
-              "url": "https://docs.npmjs.com/cli/run-script"
+              "url": "https://docs.npmjs.com/cli/run-script",
+              "title": null
             },
             {
               "type": "Text",
@@ -8047,7 +8005,8 @@
                       "value": "Unix Philosophy"
                     }
                   ],
-                  "url": "http://www.faqs.org/docs/artu/ch01s06.html"
+                  "url": "http://www.faqs.org/docs/artu/ch01s06.html",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8099,7 +8058,8 @@
                   "value": "Issue"
                 }
               ],
-              "url": "https://github.com/leebyron/spec-md/issues"
+              "url": "https://github.com/leebyron/spec-md/issues",
+              "title": null
             },
             {
               "type": "Text",
@@ -8131,7 +8091,8 @@
                       "value": "pull requests"
                     }
                   ],
-                  "url": "https://help.github.com/articles/creating-a-pull-request"
+                  "url": "https://help.github.com/articles/creating-a-pull-request",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8154,7 +8115,8 @@
                           "value": "Fork the repo"
                         }
                       ],
-                      "url": "https://github.com/leebyron/spec-md/"
+                      "url": "https://github.com/leebyron/spec-md/",
+                      "title": null
                     },
                     {
                       "type": "Text",
@@ -8258,7 +8220,8 @@
                       "value": "version"
                     }
                   ],
-                  "url": "http://semver.org/"
+                  "url": "http://semver.org/",
+                  "title": null
                 },
                 {
                   "type": "Text",
@@ -8272,7 +8235,8 @@
                       "value": "npm"
                     }
                   ],
-                  "url": "https://www.npmjs.org/package/spec-md"
+                  "url": "https://www.npmjs.org/package/spec-md",
+                  "title": null
                 },
                 {
                   "type": "Text",

--- a/test/readme/output.html
+++ b/test/readme/output.html
@@ -1215,8 +1215,6 @@ specMarkdown<span class="token punctuation">.</span><span class="token method fu
 <p>This is an <a href="https://www.facebook.com">&rarr;<em>example</em>&larr;</a> of a link.</p>
 <div class="spec-todo">
 Links do not yet support a reference style short-form.</div>
-<div class="spec-todo">
-Links do not yet support a title attribute.</div>
 </section>
 <section id="sec-Emphasis" secid="2.2.3">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-Emphasis">2.2.3</a></span>Emphasis</h3>
@@ -1247,24 +1245,6 @@ Links do not yet support a title attribute.</div>
 </code></pre>
 <p>Produces the following:</p>
 <p><img src="http://i.imgur.com/aV8o3rE.png" alt="Specs"/></p>
-<p>Also, consider using images for support of more complex features like graph diagrams. For example, with Graviso:</p>
-<pre><code>![How spec-md works](http://g.gravizo.com/svg?
-  digraph specmd {
-    markdown [shape=box];
-    ast [shape=box];
-    html [shape=box];
-    markdown -&gt; parse [weight=8];
-    parse -&gt; ast;
-    ast -&gt; print;
-    edge [color=red];
-    print -&gt; html;
-  }
-)
-</code></pre>
-<p>Produces the following:</p>
-<p><img src="http://g.gravizo.com/svg?%0A%20%20digraph%20specmd%20%7B%0A%20%20%20%20markdown%20%5Bshape=box%5D;%0A%20%20%20%20ast%20%5Bshape=box%5D;%0A%20%20%20%20html%20%5Bshape=box%5D;%0A%20%20%20%20markdown%20-%3E%20parse%20%5Bweight=8%5D;%0A%20%20%20%20parse%20-%3E%20ast;%0A%20%20%20%20ast%20-%3E%20print;%0A%20%20%20%20edge%20%5Bcolor=red%5D;%0A%20%20%20%20print%20-%3E%20html;%0A%20%20%7D%0A" alt="How spec-md works"/></p>
-<div class="spec-todo">
-the title attribute is not yet supported</div>
 </section>
 </section>
 <section id="sec-Blocks" secid="2.3">
@@ -1389,14 +1369,11 @@ Spec Markdown requires that documents start with a header.</div>
 <ol>
 <li>this</li>
 <li class="task">
-<input type="checkbox" disabled>
- is</li>
+<input type="checkbox" disabled>is</li>
 <li class="task">
-<input type="checkbox" disabled checked>
- a<ul>
+<input type="checkbox" disabled checked>a<ul>
 <li class="task">
-<input type="checkbox" disabled checked>
- nested</li>
+<input type="checkbox" disabled checked>nested</li>
 </ul>
 </li>
 <li>todo list</li>

--- a/test/sections/ast.json
+++ b/test/sections/ast.json
@@ -141,7 +141,8 @@
                                           "value": "Level 2"
                                         }
                                       ],
-                                      "url": "#Level-2"
+                                      "url": "#Level-2",
+                                      "title": null
                                     },
                                     {
                                       "type": "Text",
@@ -164,7 +165,8 @@
                                           "value": "Imported level 2"
                                         }
                                       ],
-                                      "url": "./imported.md#Imported-level-2"
+                                      "url": "./imported.md#Imported-level-2",
+                                      "title": null
                                     },
                                     {
                                       "type": "Text",

--- a/test/smart-quotes/ast.json
+++ b/test/smart-quotes/ast.json
@@ -56,7 +56,8 @@
                   "value": "link"
                 }
               ],
-              "url": "https://spec-md.com"
+              "url": "https://spec-md.com",
+              "title": null
             },
             {
               "type": "Text",

--- a/test/task-lists/ast.json
+++ b/test/task-lists/ast.json
@@ -24,7 +24,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": " This"
+              "value": "This"
             }
           ]
         },
@@ -34,7 +34,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": " task"
+              "value": "task"
             }
           ]
         },
@@ -44,7 +44,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": " list"
+              "value": "list"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": " can have"
+              "value": "can have"
             }
           ]
         },
@@ -121,7 +121,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": " tasks"
+              "value": "tasks"
             },
             {
               "type": "List",
@@ -133,7 +133,7 @@
                   "contents": [
                     {
                       "type": "Text",
-                      "value": " can be nested"
+                      "value": "can be nested"
                     },
                     {
                       "type": "List",
@@ -145,7 +145,7 @@
                           "contents": [
                             {
                               "type": "Text",
-                              "value": " deeply"
+                              "value": "deeply"
                             }
                           ]
                         }
@@ -164,7 +164,7 @@
       "contents": [
         {
           "type": "Text",
-          "value": "Conflict with links"
+          "value": "Requires a space"
         }
       ]
     },
@@ -178,7 +178,7 @@
           "contents": [
             {
               "type": "Text",
-              "value": " (this is a task)"
+              "value": "(task)"
             }
           ]
         },
@@ -193,11 +193,17 @@
                   "value": "x"
                 }
               ],
-              "url": "this is a link"
-            },
+              "url": "link",
+              "title": null
+            }
+          ]
+        },
+        {
+          "type": "ListItem",
+          "contents": [
             {
               "type": "Text",
-              "value": " "
+              "value": "[x]neither "
             }
           ]
         }

--- a/test/task-lists/input.md
+++ b/test/task-lists/input.md
@@ -20,7 +20,8 @@ Nested
   * [ ] can be nested
     * [x] deeply
 
-Conflict with links
+Requires a space
 
-* [x] \(this is a task)
-* [x] (this is a link)
+* [x] (task)
+* [x](link)
+* [x]neither


### PR DESCRIPTION
Fix: Allows link urls to include encoded chars without double-encoding and supports markdown's balanced parens in urls.

Also restricts spaces in urls, adjust spacing rules around link parsing, and adds title support to links and images as per [commonmark](https://spec.commonmark.org/0.29/#links)

Fixes a small bug related to link restrictions in task lists