### PR TITLE
Fix faulty key check in flattenDocuments

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -72,7 +72,8 @@ function flattenDocuments(ast, asts) {
   let needToFlatten;
   return visit(ast, {
     leave: function (node, key, parent, keyPath) {
-      if (needToFlatten !== undefined && keyPath.join('.') === needToFlatten) {
+      let keyPathStr = keyPath.join(".") + (key !== undefined ? "." + key : "");
+      if (needToFlatten !== undefined && keyPathStr === needToFlatten) {
         node.contents = node.contents.reduce(flattener, []);
         needToFlatten = needToFlattenStack.pop();
       }

--- a/src/parse.js
+++ b/src/parse.js
@@ -72,8 +72,9 @@ function flattenDocuments(ast, asts) {
   let needToFlatten;
   return visit(ast, {
     leave: function (node, key, parent, keyPath) {
-      let keyPathStr = keyPath.join(".") + (key !== undefined ? "." + key : "");
-      if (needToFlatten !== undefined && keyPathStr === needToFlatten) {
+      const keyString =
+        keyPath.join('.') + (key !== undefined ? '.' + key : '');
+      if (needToFlatten !== undefined && keyString === needToFlatten) {
         node.contents = node.contents.reduce(flattener, []);
         needToFlatten = needToFlattenStack.pop();
       }

--- a/test/sections/ast.json
+++ b/test/sections/ast.json
@@ -41,39 +41,37 @@
                 "title": "Level #3"
               },
               "contents": [
-                [
-                  {
-                    "type": "Section",
-                    "header": {
-                      "type": "Header",
-                      "level": 1,
-                      "secID": null,
-                      "title": "Imported level 1"
-                    },
-                    "contents": [
-                      {
-                        "type": "Section",
-                        "header": {
-                          "type": "Header",
-                          "level": 2,
-                          "secID": null,
-                          "title": "Imported level 2"
-                        },
-                        "contents": [
-                          {
-                            "type": "Paragraph",
-                            "contents": [
-                              {
-                                "type": "Text",
-                                "value": "This has been imported "
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ],
+                {
+                  "type": "Section",
+                  "header": {
+                    "type": "Header",
+                    "level": 1,
+                    "secID": null,
+                    "title": "Imported level 1"
+                  },
+                  "contents": [
+                    {
+                      "type": "Section",
+                      "header": {
+                        "type": "Header",
+                        "level": 2,
+                        "secID": null,
+                        "title": "Imported level 2"
+                      },
+                      "contents": [
+                        {
+                          "type": "Paragraph",
+                          "contents": [
+                            {
+                              "type": "Text",
+                              "value": "This has been imported "
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
                 {
                   "type": "Section",
                   "header": {


### PR DESCRIPTION
Or at least, I _think_ this check is faulty.

This fix arose from debugging what was happening on a document with this structure:

```
# Title

Introduction

# Section 1

# [Section 2, imported](sec2.md)

# Section 3

## [Section 3.1, imported](sec3-1.md)
```

The output with this document was that the entire `sec2.md` AST was being inserted into the introduction.  This seemed to be because the root document's content array was never actually being flattened, so the array representing the `sec2.md` AST wasn't filtered out in the `content.type !== "Section"` check in `printIntro`.

I believe this also fixes #82.  I was able to reproduce the extraneous commas by importing a file that didn't start with a header.  In that case, the commas were the result of an array being stringified, which was only occurring because the array was never flattened.